### PR TITLE
Fixed some broken indenting

### DIFF
--- a/src/SQLite.cs
+++ b/src/SQLite.cs
@@ -1249,8 +1249,7 @@ namespace SQLite
 				} else {
 					b.Index = nextIdx++;
 				}
-			}
-			foreach (var b in _bindings) {
+				
 				BindParameter (stmt, b.Index, b.Value);
 			}
 		}


### PR DESCRIPTION
This patch just fixes some indenting that seemed to have gone astray. Makes the code a lot easier to read.
