### PR TITLE
Fixed compat with older index table names & added [Unique]

### DIFF
--- a/src/SQLite.cs
+++ b/src/SQLite.cs
@@ -808,6 +808,10 @@ namespace SQLite
 	{
 	}
 
+	public class UniqueAttribute : Attribute
+	{
+	}
+
 	public class MaxLengthAttribute : Attribute
 	{
 		public int Value { get; private set; }
@@ -950,6 +954,8 @@ namespace SQLite
 
 			public bool IsAutoInc { get; protected set; }
 
+			public bool IsUnique { get; protected set; }
+
 			public bool IsPK { get; protected set; }
 
 			public IEnumerable<IndexedAttribute> Indices { get; set; }
@@ -975,6 +981,7 @@ namespace SQLite
 				ColumnType = Nullable.GetUnderlyingType(prop.PropertyType) ?? prop.PropertyType;
 				Collation = Orm.Collation (prop);
 				IsAutoInc = Orm.IsAutoInc (prop);
+				IsUnique = Orm.IsUnique (prop);
 				IsPK = Orm.IsPK (prop);
 				Indices = Orm.GetIndices(prop);
 				IsNullable = !IsPK;
@@ -1006,6 +1013,8 @@ namespace SQLite
 			}
 			if (p.IsAutoInc) {
 				decl += "autoincrement ";
+			} else if (p.IsUnique) {
+				decl += "unique ";
 			}
 			if (!p.IsNullable) {
 				decl += "not null ";
@@ -1072,6 +1081,16 @@ namespace SQLite
 		public static bool IsAutoInc (MemberInfo p)
 		{
 			var attrs = p.GetCustomAttributes (typeof(AutoIncrementAttribute), true);
+#if !NETFX_CORE
+			return attrs.Length > 0;
+#else
+			return attrs.Count() > 0;
+#endif
+		}
+
+		public static bool IsUnique (MemberInfo p)
+		{
+			var attrs = p.GetCustomAttributes (typeof(UniqueAttribute), true);
 #if !NETFX_CORE
 			return attrs.Length > 0;
 #else


### PR DESCRIPTION
Before IndexedAttribute allowed custom naming, the index names
were created by combining TableName + "_" + ColumnName.

This fix unfortunately breaks the more recent assumption that index
names will automatically be prefixed with "IX_", but that's easier
to work around in code by just adding the "IX_" prefix to the name
provided in the IndexedAttribute.
