### PR TITLE
A patch to support latest csharp-sqlite

### DIFF
--- a/src/SQLite.cs
+++ b/src/SQLite.cs
@@ -1990,10 +1990,15 @@ namespace SQLite
 			return result;
 		}
 #else
-		public static Result Open(string filename, out Sqlite3.sqlite3 db)
+
+        public static Result Open(string filename, out Sqlite3.sqlite3 db)
+        {
+            return (Result) Sqlite3.sqlite3_open(filename, out db);
+        }
+
+		public static Result Open(string filename, out Sqlite3.sqlite3 db, int flags, IntPtr zVfs)
 		{
-			db = new Sqlite3.sqlite3();
-			return (Result)Sqlite3.sqlite3_open(filename, ref db);
+			return (Result)Sqlite3.sqlite3_open_v2(filename, out db, flags, null);
 		}
 
 		public static Result Close(Sqlite3.sqlite3 db)
@@ -2034,7 +2039,7 @@ namespace SQLite
 
 		public static Result Finalize(Sqlite3.Vdbe stmt)
 		{
-			return (Result)Sqlite3.sqlite3_finalize(ref stmt);
+			return (Result)Sqlite3.sqlite3_finalize(stmt);
 		}
 
 		public static long LastInsertRowid(Sqlite3.sqlite3 db)
@@ -2157,5 +2162,4 @@ namespace SQLite
 			Null = 5
 		}
 	}
-	
 }


### PR DESCRIPTION
Hi,

I found csharp-sqlite support broken. Therefore, I tried to fix it. A few lines were changed.

I tested locally with all existing unit test cases. Only one case failed,

SQLite.Tests.ByteArrayTest.ByteArrays

Empty byte array became null unexpectedly. Not sure if this is a sqlite-net issue or csharp-sqlite issue.

Regards,

Lex
