### PR TITLE
Added reentrancy to transactions.

### DIFF
--- a/src/SQLite.cs
+++ b/src/SQLite.cs
@@ -744,17 +744,18 @@ namespace SQLite
       private void _rollbackTo(string savepoint, bool noThrow) {
          // Rolling back without a TO clause rolls backs all transactions 
          //    and leaves the transaction stack empty.   
-         if (Interlocked.Exchange(ref _trasactionDepth, 0) > 0) {
             try {
                if (String.IsNullOrEmpty(savepoint)) {
-                  Execute("rollback");
+                  if (Interlocked.Exchange(ref _trasactionDepth, 0) > 0) {
+                     Execute("rollback");
+                  }
                } else {
                   _doSavePointExecute(savepoint, "rollback to ");
                }   
             } catch (SQLiteException) {
                if (!noThrow)
                   throw;
-            }
+            
          }
          // No need to rollback if there are no transactions open.
       }
@@ -770,7 +771,6 @@ namespace SQLite
       /// <param name="savepoint">The name of the savepoint to release.  The string should be the result of a call to <see cref="SaveTransactionPoint"/></param>
       public void Release(string savepoint) {
          _doSavePointExecute(savepoint, "release ");
-
       }
 
       private void _doSavePointExecute(string savepoint, string cmd) {


### PR DESCRIPTION
I added the method SaveTransactionPoint, Release, RollbackTo, and a few helping functions to support those to SQLiteConnection.  I also modified the implementation of BeginTransaction to throw an exception immediately in situations where the sql db will throw an exception anyway.  

I intended for the code to be 99% thread safe, but there are a few places where it falls short of complete safety.  You'll notice that there is a small race condition in _doSavePointExecute.  Also in some error situations, the transaction depth can be thrown off by an indeterminate amount.  Correcting for such errors precisely would only be possibly if all SQLiteExceptions were thrown from the same method, so right now these corrections will only occur in calls to BeginTransaction and SaveTransactionPoint.

Let me know what you think of the additions.  If you like this, I hope to help out more over the next few weeks.
