### PR TITLE
Nested transaction support for InsertAll

### DIFF
--- a/src/SQLite.cs
+++ b/src/SQLite.cs
@@ -909,18 +909,15 @@ namespace SQLite
 		/// <returns>
 		/// The number of rows added to the table.
 		/// </returns>
-		public int InsertAll (System.Collections.IEnumerable objects, bool beginTransaction = true)
+		public int InsertAll (System.Collections.IEnumerable objects)
 		{
-			if (beginTransaction) {
-				BeginTransaction ();
-			}
 			var c = 0;
-			foreach (var r in objects) {
-				c += Insert (r);
-			}
-			if (beginTransaction) {
-				Commit ();
-			}
+			RunInTransaction(() => {
+				foreach (var r in objects)
+				{
+					c += Insert(r);
+				}
+			});
 			return c;
 		}
 


### PR DESCRIPTION
The existing `InsertAll` implementation doesn't rollback the inserts that might have succeeded before the exception - you need to catch the exception and call `Rollback` yourself. Also it needs to be called with `beginTransaction: false` when inside an existing transaction.

I've rewritten the method using the new `RunInTransaction` implementation to fix both issues.
