### PR TITLE
Moved temp store to the temp folder for Windows Store apps

### DIFF
--- a/src/SQLite.cs
+++ b/src/SQLite.cs
@@ -122,7 +122,7 @@ namespace SQLite
 			}
 			_open = true;
 #if NETFX_CORE
-            Execute("PRAGMA temp_store = memory;");
+			SQLite3.SetDirectory(/*temp directory type*/2, Windows.Storage.ApplicationData.Current.TemporaryFolder.Path);
 #endif
 
 			StoreDateTimeAsTicks = storeDateTimeAsTicks;
@@ -169,7 +169,7 @@ namespace SQLite
 			}
 			_open = true;
 #if NETFX_CORE
-            Execute("PRAGMA temp_store = memory;");
+			SQLite3.SetDirectory(/*temp directory type*/2, Windows.Storage.ApplicationData.Current.TemporaryFolder.Path);
 #endif
 
 			StoreDateTimeAsTicks = storeDateTimeAsTicks;
@@ -2423,6 +2423,9 @@ namespace SQLite
 
 		[DllImport("sqlite3", EntryPoint = "sqlite3_config", CallingConvention=CallingConvention.Cdecl)]
 		public static extern Result Config (ConfigOption option);
+
+		[DllImport("sqlite3", EntryPoint = "sqlite3_win32_set_directory", CallingConvention=CallingConvention.Cdecl, CharSet=CharSet.Unicode)]
+		public static extern int SetDirectory (uint directoryType, string directoryPath);
 
 		[DllImport("sqlite3", EntryPoint = "sqlite3_busy_timeout", CallingConvention=CallingConvention.Cdecl)]
 		public static extern Result BusyTimeout (IntPtr db, int milliseconds);


### PR DESCRIPTION
The default location for the temporary store in Windows Store apps build of sqlite seems to be in a location that cannot be opened for writing. To avoid the problem, immediately upon opening the connection the location is set to memory to avoid the issue, as suggested by Tim in #78. The temp_store_directory pragma is not used instead because it is deprecated without an alternative: http://www.sqlite.org/pragma.html#pragma_temp_store_directory.
