### PR TITLE
Fixed csharp-sqlite support

### DIFF
--- a/src/SQLite.cs
+++ b/src/SQLite.cs
@@ -138,8 +138,8 @@ namespace SQLite
 
 			Sqlite3DatabaseHandle handle;
 
-#if SILVERLIGHT
-			var r = SQLite3.Open (databasePath, out handle, (int)openFlags, IntPtr.Zero);
+#if SILVERLIGHT || USE_CSHARP_SQLITE
+            var r = SQLite3.Open (databasePath, out handle, (int)openFlags, IntPtr.Zero);
 #else
 			// open using the byte[]
 			// in the case where the path may include Unicode


### PR DESCRIPTION
Error occurs when tried to compile sqlite-net against latest csharp-sqlite from http://code.google.com/p/csharp-sqlite/, (3.7.7.1 changeset 71 or latest change set http://code.google.com/p/csharp-sqlite/source/detail?r=23fae9fe4149aa39aa5a1a5f7414a92448f8b7f4).

To fix the compilation, I think a conditional statement should be modified. The change is attached. Please review.
