### PR TITLE
Add support for Equals in Where()-expressions

### DIFF
--- a/src/SQLite.cs
+++ b/src/SQLite.cs
@@ -2359,6 +2359,9 @@ namespace SQLite
 				else if (call.Method.Name == "EndsWith" && args.Length == 1) {
 					sqlCall = "(" + obj.CommandText + " like ('%' || " + args [0].CommandText + "))";
 				}
+				else if (call.Method.Name == "Equals" && args.Length == 1) {
+					sqlCall = "(" + obj.CommandText + " = (" + args[0].CommandText + "))";
+				}
 				else {
 					sqlCall = call.Method.Name.ToLower () + "(" + string.Join (",", args.Select (a => a.CommandText).ToArray ()) + ")";
 				}

--- a/tests/EqualsTest.cs
+++ b/tests/EqualsTest.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Linq;
+#if NETFX_CORE
+using Microsoft.VisualStudio.TestPlatform.UnitTestFramework;
+using SetUp = Microsoft.VisualStudio.TestPlatform.UnitTestFramework.TestInitializeAttribute;
+using TestFixture = Microsoft.VisualStudio.TestPlatform.UnitTestFramework.TestClassAttribute;
+using Test = Microsoft.VisualStudio.TestPlatform.UnitTestFramework.TestMethodAttribute;
+#else
+using NUnit.Framework;
+#endif
+
+namespace SQLite.Tests
+{
+    [TestFixture]
+    class EqualsTest
+    {
+        public abstract class TestObjBase<T>
+        {
+            [AutoIncrement, PrimaryKey]
+            public int Id { get; set; }
+
+            public T Data { get; set; }
+
+            public DateTime Date { get; set; }
+        }
+
+        public class TestObjString : TestObjBase<string> { }
+
+        public class TestDb : SQLiteConnection
+        {
+            public TestDb(String path)
+                : base(path)
+            {
+                CreateTable<TestObjString>();
+            }
+        }
+
+        [Test]
+        public void CanCompareAnyField()
+        {
+            var n = 20;
+            var cq =from i in Enumerable.Range(1, n)
+					select new TestObjString {
+				Data = Convert.ToString(i),
+                Date = new DateTime(2013, 1, i)
+			};
+
+            var db = new TestDb(TestPath.GetTempFileName());
+            db.InsertAll(cq);
+
+            var results = db.Table<TestObjString>().Where(o => o.Data.Equals("10"));
+            Assert.AreEqual(results.Count(), 1);
+            Assert.AreEqual(results.FirstOrDefault().Data, "10");
+
+            results = db.Table<TestObjString>().Where(o => o.Id.Equals(10));
+            Assert.AreEqual(results.Count(), 1);
+            Assert.AreEqual(results.FirstOrDefault().Data, "10");
+
+            var date = new DateTime(2013, 1, 10);
+            results = db.Table<TestObjString>().Where(o => o.Date.Equals(date));
+            Assert.AreEqual(results.Count(), 1);
+            Assert.AreEqual(results.FirstOrDefault().Data, "10");
+        }
+    }
+}

--- a/tests/SQLite.Tests.csproj
+++ b/tests/SQLite.Tests.csproj
@@ -65,5 +65,6 @@
     <Compile Include="JoinTest.cs" />
     <Compile Include="OpenTests.cs" />
     <Compile Include="MigrationTest.cs" />
+    <Compile Include="EqualsTest.cs" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This pull request allow you to use the `Equals` method to compare items in a `Where` expression.

This allows you to pull off acrobatics with generic types in your models, and use these fields when querying.
