### PR TITLE
Changed tests and solution file for NUnit 2.5+.

### DIFF
--- a/tests/MigrationTest.cs
+++ b/tests/MigrationTest.cs
@@ -9,7 +9,6 @@ using TestFixture = Microsoft.VisualStudio.TestPlatform.UnitTestFramework.TestCl
 using Test = Microsoft.VisualStudio.TestPlatform.UnitTestFramework.TestMethodAttribute;
 #else
 using NUnit.Framework;
-using NUnit.Framework.SyntaxHelpers;
 #endif
 
 using System.IO;

--- a/tests/OpenTests.cs
+++ b/tests/OpenTests.cs
@@ -9,7 +9,6 @@ using TestFixture = Microsoft.VisualStudio.TestPlatform.UnitTestFramework.TestCl
 using Test = Microsoft.VisualStudio.TestPlatform.UnitTestFramework.TestMethodAttribute;
 #else
 using NUnit.Framework;
-using NUnit.Framework.SyntaxHelpers;
 #endif
 
 using System.IO;

--- a/tests/SQLite.Tests.csproj
+++ b/tests/SQLite.Tests.csproj
@@ -30,7 +30,9 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
-    <Reference Include="nunit.framework, Version=2.4.8.0, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77" />
+    <Reference Include="nunit.framework, Version=2.4.8.0, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77">
+      <SpecificVersion>False</SpecificVersion>
+    </Reference>
     <Reference Include="System.Core" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />


### PR DESCRIPTION
Everything that was in the `NUnit.Framework.SyntaxHelpers` namespace is now simply a part of `NUnit.Framework`, as of NUnit 2.5 (see http://nunit.com/index.php?p=releaseNotes&r=2.5).

A minor change was required to the csproj were required to get the solution to build with a different version of NUnit.
