### PR TITLE
When we use an SQLite.Ignore decorated property inside an expression.

### DIFF
--- a/src/SQLite.cs
+++ b/src/SQLite.cs
@@ -2380,7 +2380,13 @@ namespace SQLite
 					// This is a column of our table, output just the column name
 					// Need to translate it if that column name is mapped
 					//
-					var columnName = Table.FindColumnWithPropertyName (mem.Member.Name).Name;
+
+					var column = Table.FindColumnWithPropertyName (mem.Member.Name);
+
+					if(column==null)
+						throw new Exception(string.Format("Column {0} not found in database table. Maybe you are referencing a 'SQLite.Ignore' decorated property",mem.Member.Name));
+
+					var columnName =column.Name;
 					return new CompileResult { CommandText = "\"" + columnName + "\"" };
 				} else {
 					object obj = null;


### PR DESCRIPTION
Minor change. More descriptive error (it thows now 'Null reference exception') ... When we use an SQLite.Ignore decorated property inside an expression.

To Test: 
Just decorate a property in your class with [SQLite.Ignore] and try to use that property inside an expresion like:
db.Table<Example>().OrderBy(ex=>ex.SQLiteIgnoredProperty)
