### PR TITLE
Count() with predicate

### DIFF
--- a/src/SQLite.cs
+++ b/src/SQLite.cs
@@ -2515,6 +2515,11 @@ namespace SQLite
 			return GenerateCommand("count(*)").ExecuteScalar<int> ();			
 		}
 
+		public int Count (Expression<Func<T, bool>> predExpr)
+		{
+			return Where (predExpr).Count ();
+		}
+
 		public IEnumerator<T> GetEnumerator ()
 		{
 			if (!_deferred)


### PR DESCRIPTION
Calling Count() with a predicate on a TableQuery causes all rows to be selected then counted.  This fix will correctly generate a WHERE clause.
