### PR TITLE
Added optional Create flags allowing easier use with POCO objects, "AutoInc" guids

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,22 @@
+# Auto detect text files and perform LF normalization
+* text=auto
+
+# Custom for Visual Studio
+*.cs     diff=csharp
+*.sln    merge=union
+*.csproj merge=union
+*.vbproj merge=union
+*.fsproj merge=union
+*.dbproj merge=union
+
+# Standard to msysgit
+*.doc	 diff=astextplain
+*.DOC	 diff=astextplain
+*.docx diff=astextplain
+*.DOCX diff=astextplain
+*.dot  diff=astextplain
+*.DOT  diff=astextplain
+*.pdf  diff=astextplain
+*.PDF	 diff=astextplain
+*.rtf	 diff=astextplain
+*.RTF	 diff=astextplain

--- a/ImplicitChanges.txt
+++ b/ImplicitChanges.txt
@@ -1,0 +1,80 @@
+76
+    [Flags]
+    public enum CreateFlags
+    {
+        None = 0,
+        ImplicitPK = 1,    // create a primary key for field called 'Id'
+        ImplicitIndex = 2, // create an index for fields ending in 'Id'
+        AllImplicit = 3,   // do both above
+
+        AutoIncPK = 4      // force PK field to be auto inc
+    }
+
+
+233
+        public TableMapping GetMapping (Type type, CreateFlags createFlags = CreateFlags.None)
+        {
+            if (_mappings == null) {
+                _mappings = new Dictionary<string, TableMapping> ();
+            }
+            TableMapping map;
+            if (!_mappings.TryGetValue (type.FullName, out map)) {
+                map = new TableMapping (type, createFlags);
+                _mappings [type.FullName] = map;
+            }
+            return map;
+        }
+
+293
+        public int CreateTable<T>(CreateFlags createFlags = CreateFlags.None)
+        {
+            return CreateTable(typeof (T), createFlags);
+        }
+
+308
+        public int CreateTable(Type ty, CreateFlags createFlags = CreateFlags.None)
+        {
+            if (_tables == null) {
+                _tables = new Dictionary<string, TableMapping> ();
+            }
+            TableMapping map;
+            if (!_tables.TryGetValue (ty.FullName, out map)) {
+                map = GetMapping(ty, createFlags);
+
+
+1436
+        public TableMapping (Type type, CreateFlags createFlags = CreateFlags.None)
+
+1464
+                    cols.Add (new Column (p, createFlags));
+
+1603
+            public Column (PropertyInfo prop, CreateFlags createFlags = CreateFlags.None)
+            {
+                var colAttr = (ColumnAttribute)prop.GetCustomAttributes (typeof(ColumnAttribute), true).FirstOrDefault ();
+
+                _prop = prop;
+                Name = colAttr == null ? prop.Name : colAttr.Name;
+                //If this type is Nullable<T> then Nullable.GetUnderlyingType returns the T, otherwise it returns null, so get the actual type instead
+                ColumnType = Nullable.GetUnderlyingType(prop.PropertyType) ?? prop.PropertyType;
+                Collation = Orm.Collation (prop);
+                IsAutoInc = Orm.IsAutoInc (prop);
+                IsPK = Orm.IsPK (prop) || (((createFlags & CreateFlags.ImplicitPK) == CreateFlags.ImplicitPK) && prop.Name == Orm.ImplicitPkName);
+
+                IsAutoInc = Orm.IsAutoInc(prop) || (IsPK && ((createFlags & CreateFlags.AutoIncPK) == CreateFlags.AutoIncPK));
+                Indices = Orm.GetIndices(prop);
+                if (!Indices.Any()
+                    && !IsPK
+                    && ((createFlags & CreateFlags.ImplicitIndex) == CreateFlags.ImplicitIndex)
+                    && Name.EndsWith(Orm.ImplicitIndexSuffix)
+                    )
+                {
+                    Indices = new IndexedAttribute[] {new IndexedAttribute()};
+                }
+                IsNullable = !IsPK;
+                MaxStringLength = Orm.MaxStringLength (prop);
+            }
+
+1643
+        public const string ImplicitPkName = "Id";
+        public const string ImplicitIndexSuffix = "Id";

--- a/examples/StocksImplicit/AssemblyInfo.cs
+++ b/examples/StocksImplicit/AssemblyInfo.cs
@@ -1,0 +1,26 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+
+// Information about this assembly is defined by the following attributes. 
+// Change them to the values specific to your project.
+
+[assembly: AssemblyTitle("Stocks")]
+[assembly: AssemblyDescription("An example of using sqlite-net")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("")]
+[assembly: AssemblyCopyright("")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// The assembly version has the format "{Major}.{Minor}.{Build}.{Revision}".
+// The form "{Major}.{Minor}.*" will automatically update the build and revision,
+// and "{Major}.{Minor}.{Build}.*" will update just the revision.
+
+[assembly: AssemblyVersion("1.0.*")]
+
+// The following attributes are used to specify the signing key for the assembly, 
+// if desired. See the Mono documentation for more information about signing.
+
+//[assembly: AssemblyDelaySign(false)]
+//[assembly: AssemblyKeyFile("")]

--- a/examples/StocksImplicit/Main.cs
+++ b/examples/StocksImplicit/Main.cs
@@ -1,0 +1,138 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Path = System.IO.Path;
+
+using SQLite;
+
+namespace Stocks.CommandLine
+{
+	class Program
+	{
+		public static void Main (string[] args)
+		{
+			new Program ().Run ();
+		}
+
+		Database _db;
+
+		void Initialize ()
+		{
+			var dbPath = Path.Combine (Environment.GetFolderPath (Environment.SpecialFolder.MyDocuments), "StocksImplicit.db");
+			_db = new Database (dbPath);
+		}
+
+		void DisplayStock (string stockSymbol)
+		{
+			var stock = _db.QueryStock (stockSymbol);
+			
+			if (stock == null) {
+				Console.WriteLine ("I don't know about {0}", stockSymbol);
+				Console.WriteLine ("Run \"up {0}\" to update the stock", stockSymbol);
+			} else {
+				
+				//
+				// Display the last 1 week
+				//				
+				foreach (var v in _db.QueryValuations (stock)) {
+					Console.WriteLine ("  {0}", v);
+				}
+				
+			}
+		}
+
+		void UpdateStock (string stockSymbol)
+		{
+			_db.UpdateStock(stockSymbol);
+		}
+
+		void ListStocks ()
+		{
+			foreach (var stock in _db.QueryAllStocks ()) {
+				Console.WriteLine (stock);
+			}
+		}
+
+		void DisplayBanner ()
+		{
+			Console.WriteLine ("Stocks - a demo of sqlite-net");
+			Console.WriteLine ("Using " + _db.DatabaseName);
+			Console.WriteLine ();
+		}
+
+		void DisplayHelp (string cmd)
+		{
+			Action<string, string> display = (c, h) => { Console.WriteLine ("{0} {1}", c, h); };
+			var cmds = new SortedDictionary<string, string> {
+				{
+					"ls",
+					"\t List all known stocks"
+				},
+				{
+					"exit",
+					"\t Exit stocks"
+				},
+				{
+					"up stock",
+					"Updates stock"
+				},
+				{
+					"help",
+					"\t Displays help"
+				},
+				{
+					"stock",
+					"\t Displays latest valuations for stock"
+				}
+			};
+			if (cmds.ContainsKey (cmd)) {
+				display (cmd, cmds[cmd]);
+			} else {
+				foreach (var ch in cmds) {
+					display (ch.Key, ch.Value);
+				}
+			}
+		}
+
+		void Run ()
+		{
+			var WS = new char[] {
+				' ',
+				'\t',
+				'\r',
+				'\n'
+			};
+			
+			Initialize ();
+			
+			DisplayBanner ();
+			DisplayHelp ("");
+			
+			for (;;) {
+				Console.Write ("$ ");
+				var cmdline = Console.ReadLine ();
+				
+				var args = cmdline.Split (WS, StringSplitOptions.RemoveEmptyEntries);
+				if (args.Length < 1)
+					continue;
+				var cmd = args[0].ToLowerInvariant ();
+				
+				if (cmd == "?" || cmd == "help") {
+					DisplayHelp ("");
+				} else if (cmd == "exit") {
+					break;
+				} else if (cmd == "ls") {
+					ListStocks ();
+				} else if (cmd == "up") {
+					if (args.Length == 2) {
+						UpdateStock (args[1].ToUpperInvariant ());
+					} else {
+						DisplayHelp ("up stock");
+					}
+				} else {
+					DisplayStock (cmd.ToUpperInvariant ());
+				}
+			}
+		}
+	}
+}

--- a/examples/StocksImplicit/Stocks.cs
+++ b/examples/StocksImplicit/Stocks.cs
@@ -1,0 +1,130 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Path = System.IO.Path;
+
+using SQLite;
+using System.Globalization;
+
+namespace Stocks
+{
+    public class Stock
+    {
+        public Guid Id { get; set; }
+        public string Symbol { get; set; }
+
+        public override string ToString ()
+        {
+            return Symbol;
+        }
+    }
+
+    public class Valuation
+    {
+        public Guid Id { get; set; }
+        public Guid StockId { get; set; }
+        public DateTime Time { get; set; }
+        public decimal Price { get; set; }
+
+        public override string ToString ()
+        {
+            return string.Format ("{0:MMM dd yy}    {1:C}", Time, Price);
+        }
+    }
+
+    public class Database : SQLiteConnection
+    {
+        public Database (string path) : base(path)
+        {
+            CreateTable<Stock>(CreateFlags.AllImplicit | CreateFlags.AutoIncPK);
+            CreateTable<Valuation>(CreateFlags.AllImplicit | CreateFlags.AutoIncPK);
+            _DatabaseName = path;
+        }
+
+        private string _DatabaseName;
+        public string DatabaseName
+        {
+            get { return _DatabaseName; }
+        }
+        
+        public IEnumerable<Valuation> QueryValuations (Stock stock)
+        {
+            return Table<Valuation> ().Where(x => x.StockId == stock.Id);
+        }
+
+        public Valuation QueryLatestValuation (Stock stock)
+        {
+            return Table<Valuation> ().Where(x => x.StockId == stock.Id).OrderByDescending(x => x.Time).Take(1).FirstOrDefault();
+        }
+        public Stock QueryStock (string stockSymbol)
+        {
+            return	(from s in Table<Stock> ()
+                    where s.Symbol == stockSymbol
+                    select s).FirstOrDefault ();
+        }
+        public IEnumerable<Stock> QueryAllStocks ()
+        {
+            return	from s in Table<Stock> ()
+                    orderby s.Symbol
+                    select s;
+        }
+
+        public void UpdateStock (string stockSymbol)
+        {
+            //
+            // Ensure that there is a valid Stock in the DB
+            //
+            var stock = QueryStock (stockSymbol);
+            if (stock == null) {
+                stock = new Stock { Symbol = stockSymbol };
+                Insert (stock);
+            }
+            
+            //
+            // When was it last valued?
+            //
+            var latest = QueryLatestValuation (stock);
+            var latestDate = latest != null ? latest.Time : new DateTime (1950, 1, 1);
+            
+            //
+            // Get the latest valuations
+            //
+            try {
+                var newVals = new YahooScraper ().GetValuations (stock, latestDate + TimeSpan.FromHours (23), DateTime.Now);
+                InsertAll (newVals);
+            } catch (System.Net.WebException ex) {
+                Console.WriteLine (ex);
+            }
+        }
+    }
+
+    public class YahooScraper
+    {
+        public IEnumerable<Valuation> GetValuations (Stock stock, DateTime start, DateTime end)
+        {
+            var t = "http://ichart.finance.yahoo.com/table.csv?s={0}&d={1}&e={2}&f={3}&g=d&a={4}&b={5}&c={6}&ignore=.csv";
+            var url = string.Format (t, stock.Symbol, end.Month - 1, end.Day, end.Year, start.Month - 1, start.Day, start.Year);
+            Console.WriteLine ("GET {0}", url);
+            var req = System.Net.WebRequest.Create (url);
+            using (var resp = new System.IO.StreamReader (req.GetResponse ().GetResponseStream ())) {
+                var first = true;
+                var dateCol = 0;
+                var priceCol = 6;
+                for (var line = resp.ReadLine (); line != null; line = resp.ReadLine ()) {
+                    var parts = line.Split (',');
+                    if (first) {
+                        dateCol = Array.IndexOf (parts, "Date");
+                        priceCol = Array.IndexOf (parts, "Adj Close");
+                        first = false;
+                    } else {
+                        yield return new Valuation {
+                            StockId = stock.Id,
+                            Price = decimal.Parse (parts[priceCol], CultureInfo.InvariantCulture),
+                            Time = DateTime.Parse (parts[dateCol])
+                        };
+                    }
+                }
+            }
+        }
+    }
+}

--- a/examples/StocksImplicit/StocksImplicit.csproj
+++ b/examples/StocksImplicit/StocksImplicit.csproj
@@ -1,0 +1,77 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProductVersion>9.0.21022</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{9E5D6B89-B69B-486B-9F7B-406BE8690589}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>Stocks</RootNamespace>
+    <AssemblyName>Stocks</AssemblyName>
+    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <FileUpgradeFlags>
+    </FileUpgradeFlags>
+    <UpgradeBackupLocation>
+    </UpgradeBackupLocation>
+    <OldToolsVersion>3.5</OldToolsVersion>
+    <PublishUrl>publish\</PublishUrl>
+    <Install>true</Install>
+    <InstallFrom>Disk</InstallFrom>
+    <UpdateEnabled>false</UpdateEnabled>
+    <UpdateMode>Foreground</UpdateMode>
+    <UpdateInterval>7</UpdateInterval>
+    <UpdateIntervalUnits>Days</UpdateIntervalUnits>
+    <UpdatePeriodically>false</UpdatePeriodically>
+    <UpdateRequired>false</UpdateRequired>
+    <MapFileExtensions>true</MapFileExtensions>
+    <ApplicationRevision>0</ApplicationRevision>
+    <ApplicationVersion>1.0.0.%2a</ApplicationVersion>
+    <IsWebBootstrapper>false</IsWebBootstrapper>
+    <UseApplicationTrust>false</UseApplicationTrust>
+    <BootstrapperEnabled>true</BootstrapperEnabled>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug</OutputPath>
+    <DefineConstants>DEBUG</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <PlatformTarget>x86</PlatformTarget>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>none</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Release</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core">
+      <RequiredTargetFramework>3.5</RequiredTargetFramework>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Main.cs" />
+    <Compile Include="AssemblyInfo.cs" />
+    <Compile Include="..\..\src\SQLite.cs" />
+    <Compile Include="Stocks.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <BootstrapperPackage Include="Microsoft.Net.Client.3.5">
+      <Visible>False</Visible>
+      <ProductName>.NET Framework 3.5 SP1 Client Profile</ProductName>
+      <Install>false</Install>
+    </BootstrapperPackage>
+    <BootstrapperPackage Include="Microsoft.Net.Framework.3.5.SP1">
+      <Visible>False</Visible>
+      <ProductName>.NET Framework 3.5 SP1</ProductName>
+      <Install>true</Install>
+    </BootstrapperPackage>
+  </ItemGroup>
+  <ItemGroup />
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/examples/StocksImplicit/StocksImplicit.sln
+++ b/examples/StocksImplicit/StocksImplicit.sln
@@ -1,0 +1,23 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 2012
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "StocksImplicit", "StocksImplicit.csproj", "{9E5D6B89-B69B-486B-9F7B-406BE8690589}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{9E5D6B89-B69B-486B-9F7B-406BE8690589}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9E5D6B89-B69B-486B-9F7B-406BE8690589}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9E5D6B89-B69B-486B-9F7B-406BE8690589}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9E5D6B89-B69B-486B-9F7B-406BE8690589}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(MonoDevelopProperties) = preSolution
+		StartupItem = Stocks.csproj
+	EndGlobalSection
+EndGlobal

--- a/tests/CreateTableImplicitTest.cs
+++ b/tests/CreateTableImplicitTest.cs
@@ -1,0 +1,173 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+
+#if NETFX_CORE
+using Microsoft.VisualStudio.TestPlatform.UnitTestFramework;
+using SetUp = Microsoft.VisualStudio.TestPlatform.UnitTestFramework.TestInitializeAttribute;
+using TestFixture = Microsoft.VisualStudio.TestPlatform.UnitTestFramework.TestClassAttribute;
+using Test = Microsoft.VisualStudio.TestPlatform.UnitTestFramework.TestMethodAttribute;
+#else
+using NUnit.Framework;
+#endif
+
+namespace SQLite.Tests
+{
+    [TestFixture]
+    public class CreateTableImplicitTest
+    {
+
+        class NoAttributes
+        {
+            public int Id { get; set; }
+            public string AColumn { get; set; }
+            public int IndexedId { get; set; }
+        }
+
+        class PkAttribute
+        {
+            [PrimaryKey]
+            public int Id { get; set; }
+            public string AColumn { get; set; }
+            public int IndexedId { get; set; }
+        }
+
+        private void CheckPK(TestDb db)
+        {
+            for (int i = 1; i <= 10; i++)
+            {
+                var na = new NoAttributes { Id = i, AColumn = i.ToString(), IndexedId = 0 };
+                db.Insert(na);
+            }
+            var item = db.Get<NoAttributes>(2);
+            Assert.IsNotNull(item);
+            Assert.AreEqual(2, item.Id);
+        }
+
+        [Test]
+        public void WithoutImplicitMapping ()
+        {
+            var db = new TestDb ();
+
+            db.CreateTable<NoAttributes>();
+
+            var mapping = db.GetMapping<NoAttributes>();
+
+            Assert.IsNull (mapping.PK);
+
+            var column = mapping.Columns[2];
+            Assert.AreEqual("IndexedId", column.Name);
+            Assert.IsFalse(column.Indices.Any());
+
+            Assert.Throws(typeof(AssertionException), () => CheckPK(db));
+        }
+
+        [Test]
+        public void ImplicitPK()
+        {
+            var db = new TestDb();
+
+            db.CreateTable<NoAttributes>(CreateFlags.ImplicitPK);
+
+            var mapping = db.GetMapping<NoAttributes>();
+
+            Assert.IsNotNull(mapping.PK);
+            Assert.AreEqual("Id", mapping.PK.Name);
+            Assert.IsTrue(mapping.PK.IsPK);
+            Assert.IsFalse(mapping.PK.IsAutoInc);
+
+            CheckPK(db);
+        }
+
+
+        [Test]
+        public void ImplicitAutoInc()
+        {
+            var db = new TestDb();
+
+            db.CreateTable<PkAttribute>(CreateFlags.AutoIncPK);
+
+            var mapping = db.GetMapping<PkAttribute>();
+
+            Assert.IsNotNull(mapping.PK);
+            Assert.AreEqual("Id", mapping.PK.Name);
+            Assert.IsTrue(mapping.PK.IsPK);
+            Assert.IsTrue(mapping.PK.IsAutoInc);
+        }
+
+        [Test]
+        public void ImplicitIndex()
+        {
+            var db = new TestDb();
+
+            db.CreateTable<NoAttributes>(CreateFlags.ImplicitIndex);
+
+            var mapping = db.GetMapping<NoAttributes>();
+            var column = mapping.Columns[2];
+            Assert.AreEqual("IndexedId", column.Name);
+            Assert.IsTrue(column.Indices.Any());
+        }
+
+        [Test]
+        public void ImplicitPKAutoInc()
+        {
+            var db = new TestDb();
+
+            db.CreateTable(typeof(NoAttributes), CreateFlags.ImplicitPK | CreateFlags.AutoIncPK);
+
+            var mapping = db.GetMapping<NoAttributes>();
+
+            Assert.IsNotNull(mapping.PK);
+            Assert.AreEqual("Id", mapping.PK.Name);
+            Assert.IsTrue(mapping.PK.IsPK);
+            Assert.IsTrue(mapping.PK.IsAutoInc);
+        }
+
+        [Test]
+        public void ImplicitAutoIncAsPassedInTypes()
+        {
+            var db = new TestDb();
+
+            db.CreateTable(typeof(PkAttribute), CreateFlags.AutoIncPK);
+
+            var mapping = db.GetMapping<PkAttribute>();
+
+            Assert.IsNotNull(mapping.PK);
+            Assert.AreEqual("Id", mapping.PK.Name);
+            Assert.IsTrue(mapping.PK.IsPK);
+            Assert.IsTrue(mapping.PK.IsAutoInc);
+        }
+
+        [Test]
+        public void ImplicitPkAsPassedInTypes()
+        {
+            var db = new TestDb();
+
+            db.CreateTable(typeof(NoAttributes), CreateFlags.ImplicitPK);
+
+            var mapping = db.GetMapping<NoAttributes>();
+
+            Assert.IsNotNull(mapping.PK);
+            Assert.AreEqual("Id", mapping.PK.Name);
+            Assert.IsTrue(mapping.PK.IsPK);
+            Assert.IsFalse(mapping.PK.IsAutoInc);
+        }
+
+        [Test]
+        public void ImplicitPKAutoIncAsPassedInTypes()
+        {
+            var db = new TestDb();
+
+            db.CreateTable(typeof(NoAttributes), CreateFlags.ImplicitPK | CreateFlags.AutoIncPK);
+
+            var mapping = db.GetMapping<NoAttributes>();
+
+            Assert.IsNotNull(mapping.PK);
+            Assert.AreEqual("Id", mapping.PK.Name);
+            Assert.IsTrue(mapping.PK.IsPK);
+            Assert.IsTrue(mapping.PK.IsAutoInc);
+        }
+    }
+}
+

--- a/tests/GuidTests.cs
+++ b/tests/GuidTests.cs
@@ -57,5 +57,49 @@ namespace SQLite.Tests {
 
             db.Close();
         }
+
+        [Test]
+        public void AutoGuid_HasGuid()
+        {
+            var db = new SQLiteConnection(TestPath.GetTempFileName());
+            db.CreateTable<TestObj>(CreateFlags.AutoIncPK);
+
+            var guid1 = new Guid("36473164-C9E4-4CDF-B266-A0B287C85623");
+            var guid2 = new Guid("BC5C4C4A-CA57-4B61-8B53-9FD4673528B6");
+
+            var obj1 = new TestObj() { Id = guid1, Text = "First Guid Object" };
+            var obj2 = new TestObj() { Id = guid2, Text = "Second Guid Object" };
+
+            var numIn1 = db.Insert(obj1);
+            var numIn2 = db.Insert(obj2);
+            Assert.AreEqual(guid1, obj1.Id);
+            Assert.AreEqual(guid2, obj2.Id);
+
+            db.Close();
+        }
+
+        [Test]
+        public void AutoGuid_EmptyGuid()
+        {
+            var db = new SQLiteConnection(TestPath.GetTempFileName());
+            db.CreateTable<TestObj>(CreateFlags.AutoIncPK);
+
+            var guid1 = new Guid("36473164-C9E4-4CDF-B266-A0B287C85623");
+            var guid2 = new Guid("BC5C4C4A-CA57-4B61-8B53-9FD4673528B6");
+
+            var obj1 = new TestObj() { Text = "First Guid Object" };
+            var obj2 = new TestObj() { Text = "Second Guid Object" };
+
+            Assert.AreEqual(Guid.Empty, obj1.Id);
+            Assert.AreEqual(Guid.Empty, obj2.Id);
+
+            var numIn1 = db.Insert(obj1);
+            var numIn2 = db.Insert(obj2);
+            Assert.AreNotEqual(Guid.Empty, obj1.Id);
+            Assert.AreNotEqual(Guid.Empty, obj2.Id);
+            Assert.AreNotEqual(obj1.Id, obj2.Id);
+
+            db.Close();
+        }
     }
 }

--- a/tests/SQLite.Tests.csproj
+++ b/tests/SQLite.Tests.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -29,8 +29,8 @@
     <ConsolePause>False</ConsolePause>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="nunit.framework, Version=2.6.2.12296, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL" />
     <Reference Include="System" />
-    <Reference Include="nunit.framework, Version=2.4.8.0, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77" />
     <Reference Include="System.Core" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
@@ -42,6 +42,7 @@
     <Compile Include="InsertTest.cs" />
     <Compile Include="CreateTableTest.cs" />
     <Compile Include="GuidTests.cs" />
+    <Compile Include="CreateTableImplicitTest.cs" />
     <Compile Include="SkipTest.cs" />
     <Compile Include="CollateTest.cs" />
     <Compile Include="ContainsTest.cs" />


### PR DESCRIPTION
Added optional Create flags allowing easier use with POCO objects

E.g. 
CreateTable<Stock>(CreateFlags.ImplicitPK | CreateFlags.ImplicitIndex | CreateFlags.AutoIncPK);

Will create a primary key on the Field Id, indexes on fields ending in Id and make the PK an autoinc.

Note.  I have created tests for this in the CreateTableImplicitTest.cs.  This will need to be manually added into your test project.

I have also added "autoinc" guids.  If a guid PK is marked as AutoInc then Guid.Empty will be replaced by a new Guid before inserting.

Additional tests have been placed in GuidTests.cs
