### PR TITLE
Add support to ToLower()

### DIFF
--- a/src/SQLite.cs
+++ b/src/SQLite.cs
@@ -2393,8 +2393,9 @@ namespace SQLite
 				}
 				else if (call.Method.Name == "Equals" && args.Length == 1) {
 					sqlCall = "(" + obj.CommandText + " = (" + args[0].CommandText + "))";
-				}
-				else {
+				} else if (call.Method.Name == "ToLower") {
+					sqlCall = "(lower(" + obj.CommandText + "))"; 
+				} else {
 					sqlCall = call.Method.Name.ToLower () + "(" + string.Join (",", args.Select (a => a.CommandText).ToArray ()) + ")";
 				}
 				return new CompileResult { CommandText = sqlCall };


### PR DESCRIPTION
This makes the following kind of query valid:

```
from p in DB.Table<Person> ()
where p.Name.ToLower ().Contains (searchName.ToLower ())
select p
```
