### PR TITLE
Added CreateIndex methods to SQLiteConnection

### DIFF
--- a/src/SQLite.cs
+++ b/src/SQLite.cs
@@ -409,7 +409,16 @@ namespace SQLite
         /// <param name="unique">Whether the index should be unique</param>
         public void CreateIndex<T>(Expression<Func<T, object>> property, bool unique = false)
         {
-            var propertyInfo = (property.Body as MemberExpression).Member as PropertyInfo;
+            MemberExpression mx;
+            if (property.Body.NodeType == ExpressionType.Convert)
+            {
+                mx = ((UnaryExpression)property.Body).Operand as MemberExpression;
+            }
+            else
+            {
+                mx= (property.Body as MemberExpression);
+            }
+            var propertyInfo = mx.Member as PropertyInfo;
             if (propertyInfo == null)
             {
                 throw new ArgumentException("The lambda expression 'property' should point to a valid Property");


### PR DESCRIPTION
Added CreateIndex methods to SQLiteConnection to make using POCO objects easier.

Usage is:
_Connection.CreateTable<MyTable>(CreateFlags.AllImplicit);
_Connection.CreateIndex<MyTable>(c => c.MyProperty);

or _Connection.CreateIndex("MyTable", "MyProperty");
or _Connection.CreateIndex("Idx_Name", "MyTable", "MyProperty");
