### PR TITLE
Fix build break caused by pull request #178 (breaks csharp-sqlite and sqlite-net-wp8).

### DIFF
--- a/src/SQLite.cs
+++ b/src/SQLite.cs
@@ -3046,6 +3046,11 @@ namespace SQLite
 		{
 			return ColumnBlob(stmt, index);
 		}
+
+		public static Result EnableLoadExtension(Sqlite3DatabaseHandle db, int onoff)
+		{
+			return (Result)Sqlite3.sqlite3_enable_load_extension(db, onoff);
+		}
 #endif
 
 		public enum ColType : int


### PR DESCRIPTION
Pull request #178 defined an export in sqlite3.dll but not the corresponding wrapper method for csharp-sqlite and sqlite-net-wp8 users.
