### PR TITLE
Add bindings for sqlite3_initialize() and sqlite3_shutdown()

### DIFF
--- a/src/SQLite.cs
+++ b/src/SQLite.cs
@@ -387,6 +387,7 @@ namespace SQLite
             const string sqlFormat = "create {2} index if not exists \"{3}\" on \"{0}\"(\"{1}\")";
             var sql = String.Format(sqlFormat, tableName, columnName, unique ? "unique" : "", indexName);
             return Execute(sql);
+        }
         
         /// <summary>
         /// Creates an index for the specified table and column.


### PR DESCRIPTION
These calls are necessary in order to be able call sqllite3_config() (for ex, to set serialized mode) on iOS5+.
