### PR TITLE
Added NotNullAttribute Fix #187

### DIFF
--- a/tests/NotNullAttributeTest.cs
+++ b/tests/NotNullAttributeTest.cs
@@ -1,0 +1,313 @@
+﻿using System;
+using System.IO;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using SQLite;
+
+#if NETFX_CORE
+using Microsoft.VisualStudio.TestPlatform.UnitTestFramework;
+using SetUp = Microsoft.VisualStudio.TestPlatform.UnitTestFramework.TestInitializeAttribute;
+using TearDown = Microsoft.VisualStudio.TestPlatform.UnitTestFramework.TestCleanupAttribute;
+using TestFixture = Microsoft.VisualStudio.TestPlatform.UnitTestFramework.TestClassAttribute;
+using Test = Microsoft.VisualStudio.TestPlatform.UnitTestFramework.TestMethodAttribute;
+#else
+using NUnit.Framework;
+#endif
+
+namespace SQLite.Tests
+{
+
+	[TestFixture]
+	public class NotNullAttributeTest
+	{
+		private class NotNullNoPK
+		{
+			[PrimaryKey, AutoIncrement]
+			public int? objectId { get; set; }
+			[NotNull]
+			public int? RequiredIntProp { get; set; }
+			public int? OptionalIntProp { get; set; }
+			[NotNull]
+			public string RequiredStringProp { get; set; }
+			public string OptionalStringProp { get; set; }
+			[NotNull]
+			public string AnotherRequiredStringProp { get; set; }
+		}
+
+		private class ClassWithPK
+		{
+			[PrimaryKey, AutoIncrement]
+			public int Id { get; set; }
+		}
+
+		private IEnumerable<SQLiteConnection.ColumnInfo> GetExpectedColumnInfos (Type type)
+		{
+#if !NETFX_CORE
+			var expectedValues = from prop in type.GetProperties (BindingFlags.Public | BindingFlags.Instance | BindingFlags.SetProperty)
+								 select new SQLiteConnection.ColumnInfo {
+									 Name = prop.Name,
+									 notnull = ((prop.GetCustomAttributes (typeof (NotNullAttribute), true).Count () == 0) && (prop.GetCustomAttributes (typeof (PrimaryKeyAttribute), true).Count () == 0)) ? 0 : 1
+								 };
+#else
+			var expectedValues = from prop in type.GetRuntimeProperties ()
+								 select new SQLiteConnection.ColumnInfo {
+									 Name = prop.Name,
+									 notnull = ((prop.GetCustomAttribute<NotNullAttribute> (true) == null) && (prop.GetCustomAttribute<PrimaryKeyAttribute> (true) == null)) ? 0 : 1
+								 };
+#endif
+
+			return expectedValues;
+		}
+
+		[Test]
+		public void PrimaryKeyHasNotNullConstraint ()
+		{
+			using (TestDb db = new TestDb ()) {
+
+				db.CreateTable<ClassWithPK> ();
+				var cols = db.GetTableInfo ("ClassWithPK");
+
+				var joined = from expected in GetExpectedColumnInfos (typeof (ClassWithPK))
+							 join actual in cols on expected.Name equals actual.Name
+							 where actual.notnull != expected.notnull
+							 select actual.Name;
+
+				Assert.AreNotEqual (0, cols.Count (), "Failed to get table info");
+				Assert.IsTrue (joined.Count () == 0, string.Format ("not null constraint was not created for the following properties: {0}"
+					, string.Join (", ", joined.ToArray ())));
+			}
+		}
+
+		[Test]
+		public void CreateTableWithNotNullConstraints ()
+		{
+			using (var db = new TestDb ()) {
+				db.CreateTable<NotNullNoPK> ();
+				var cols = db.GetTableInfo ("NotNullNoPK");
+
+				var joined = from expected in GetExpectedColumnInfos (typeof (NotNullNoPK))
+							 join actual in cols on expected.Name equals actual.Name
+							 where actual.notnull != expected.notnull
+							 select actual.Name;
+
+				Assert.AreNotEqual (0, cols.Count (), "Failed to get table info");
+				Assert.IsTrue (joined.Count () == 0, string.Format ("not null constraint was not created for the following properties: {0}"
+					, string.Join (", ", joined.ToArray ())));
+			}
+		}
+
+		[Test]
+		public void InsertWithNullsThrowsException ()
+		{
+			using (TestDb db = new TestDb ()) {
+
+				db.CreateTable<NotNullNoPK> ();
+
+				try {
+					NotNullNoPK obj = new NotNullNoPK ();
+					db.Insert (obj);
+				}
+				catch (NotNullConstraintViolationException) {
+					return;
+				}
+				catch (SQLiteException ex) {
+					if (SQLite3.LibVersionNumber () < 3007017 && ex.Result == SQLite3.Result.Constraint) {
+						Assert.Inconclusive ("Detailed constraint information is only available in SQLite3 version 3.7.17 and above.");
+					}
+				}
+			}
+			Assert.Fail ("Expected an exception of type NotNullConstraintViolationException to be thrown. No exception was thrown.");
+		}
+
+
+		[Test]
+		public void UpdateWithNullThrowsException ()
+		{
+			using (TestDb db = new TestDb ()) {
+
+				db.CreateTable<NotNullNoPK> ();
+
+				try {
+					NotNullNoPK obj = new NotNullNoPK () {
+						AnotherRequiredStringProp = "Another required string",
+						RequiredIntProp = 123,
+						RequiredStringProp = "Required string"
+					};
+					db.Insert (obj);
+					obj.RequiredStringProp = null;
+					db.Update (obj);
+				}
+				catch (NotNullConstraintViolationException) {
+					return;
+				}
+				catch (SQLiteException ex) {
+					if (SQLite3.LibVersionNumber () < 3007017 && ex.Result == SQLite3.Result.Constraint) {
+						Assert.Inconclusive ("Detailed constraint information is only available in SQLite3 version 3.7.17 and above.");
+					}
+				}
+			}
+			Assert.Fail ("Expected an exception of type NotNullConstraintViolationException to be thrown. No exception was thrown.");
+		}
+
+		[Test]
+		public void NotNullConstraintExceptionListsOffendingColumnsOnInsert ()
+		{
+			using (TestDb db = new TestDb ()) {
+
+				db.CreateTable<NotNullNoPK> ();
+
+				try {
+					NotNullNoPK obj = new NotNullNoPK () { RequiredStringProp = "Some value" };
+					db.Insert (obj);
+				}
+				catch (NotNullConstraintViolationException ex) {
+					string expected = "AnotherRequiredStringProp, RequiredIntProp";
+					string actual = string.Join (", ", ex.Columns.Where (c => !c.IsPK).OrderBy (p => p.PropertyName).Select (c => c.PropertyName));
+
+					Assert.AreEqual (expected, actual, "NotNullConstraintViolationException did not correctly list the columns that violated the constraint");
+					return;
+				}
+				catch (SQLiteException ex) {
+					if (SQLite3.LibVersionNumber () < 3007017 && ex.Result == SQLite3.Result.Constraint) {
+						Assert.Inconclusive ("Detailed constraint information is only available in SQLite3 version 3.7.17 and above.");
+					}
+				}
+				Assert.Fail ("Expected an exception of type NotNullConstraintViolationException to be thrown. No exception was thrown.");
+			}
+		}
+
+		[Test]
+		public void NotNullConstraintExceptionListsOffendingColumnsOnUpdate ()
+		{
+			// Skip this test if the Dll doesn't support the extended SQLITE_CONSTRAINT codes
+
+				using (TestDb db = new TestDb ()) {
+					db.CreateTable<NotNullNoPK> ();
+
+					try {
+						NotNullNoPK obj = new NotNullNoPK () {
+							AnotherRequiredStringProp = "Another required string",
+							RequiredIntProp = 123,
+							RequiredStringProp = "Required string"
+						};
+						db.Insert (obj);
+						obj.RequiredStringProp = null;
+						db.Update (obj);
+					}
+					catch (NotNullConstraintViolationException ex) {
+						string expected = "RequiredStringProp";
+						string actual = string.Join (", ", ex.Columns.Where (c => !c.IsPK).OrderBy (p => p.PropertyName).Select (c => c.PropertyName));
+
+						Assert.AreEqual (expected, actual, "NotNullConstraintViolationException did not correctly list the columns that violated the constraint");
+
+						return;
+					}
+					catch (SQLiteException ex) {
+						if (SQLite3.LibVersionNumber () < 3007017 && ex.Result == SQLite3.Result.Constraint) {
+							Assert.Inconclusive ("Detailed constraint information is only available in SQLite3 version 3.7.17 and above.");
+						}
+					}
+					catch (Exception ex) {
+						Assert.Fail ("Expected an exception of type NotNullConstraintViolationException to be thrown. An exception of type {0} was thrown instead.", ex.GetType ().Name);
+					}
+				Assert.Fail ("Expected an exception of type NotNullConstraintViolationException to be thrown. No exception was thrown.");
+			}
+		}
+
+		[Test]
+		public void InsertQueryWithNullThrowsException ()
+		{
+			// Skip this test if the Dll doesn't support the extended SQLITE_CONSTRAINT codes
+			if (SQLite3.LibVersionNumber () >= 3007017) {
+				using (TestDb db = new TestDb ()) {
+
+					db.CreateTable<NotNullNoPK> ();
+
+					try {
+						db.Execute ("insert into \"NotNullNoPK\" (AnotherRequiredStringProp, RequiredIntProp, RequiredStringProp) values(?, ?, ?)",
+							new object[] { "Another required string", 123, null });
+					}
+					catch (NotNullConstraintViolationException) {
+						return;
+					}
+					catch (SQLiteException ex) {
+						if (SQLite3.LibVersionNumber () < 3007017 && ex.Result == SQLite3.Result.Constraint) {
+							Assert.Inconclusive ("Detailed constraint information is only available in SQLite3 version 3.7.17 and above.");
+						}
+					}
+					catch (Exception ex) {
+						Assert.Fail ("Expected an exception of type NotNullConstraintViolationException to be thrown. An exception of type {0} was thrown instead.", ex.GetType ().Name);
+					}
+				}
+				Assert.Fail ("Expected an exception of type NotNullConstraintViolationException to be thrown. No exception was thrown.");
+			}
+		}
+
+		[Test]
+		public void UpdateQueryWithNullThrowsException ()
+		{
+			// Skip this test if the Dll doesn't support the extended SQLITE_CONSTRAINT codes
+			using (TestDb db = new TestDb ()) {
+
+				db.CreateTable<NotNullNoPK> ();
+
+				try {
+					db.Execute ("insert into \"NotNullNoPK\" (AnotherRequiredStringProp, RequiredIntProp, RequiredStringProp) values(?, ?, ?)",
+						new object[] { "Another required string", 123, "Required string" });
+
+					db.Execute ("update \"NotNullNoPK\" set AnotherRequiredStringProp=?, RequiredIntProp=?, RequiredStringProp=? where ObjectId=?",
+						new object[] { "Another required string", 123, null, 1 });
+				}
+				catch (NotNullConstraintViolationException) {
+					return;
+				}
+				catch (SQLiteException ex) {
+					if (SQLite3.LibVersionNumber () < 3007017 && ex.Result == SQLite3.Result.Constraint) {
+						Assert.Inconclusive ("Detailed constraint information is only available in SQLite3 version 3.7.17 and above.");
+					}
+				}
+				catch (Exception ex) {
+					Assert.Fail ("Expected an exception of type NotNullConstraintViolationException to be thrown. An exception of type {0} was thrown instead.", ex.GetType ().Name);
+				}
+				Assert.Fail ("Expected an exception of type NotNullConstraintViolationException to be thrown. No exception was thrown.");
+			}
+		}
+
+		[Test]
+		public void ExecuteNonQueryWithNullThrowsException ()
+		{
+			using (TestDb db = new TestDb ()) {
+				TableMapping map;
+
+				db.CreateTable<NotNullNoPK> ();
+
+				try {
+					NotNullNoPK obj = new NotNullNoPK () {
+						AnotherRequiredStringProp = "Another required prop",
+						RequiredIntProp = 123,
+						RequiredStringProp = "Required string prop"
+					};
+					db.Insert (obj);
+
+					map = db.GetMapping<NotNullNoPK> ();
+					map.GetInsertCommand (db, "OR REPLACE").ExecuteNonQuery (new object[] { 1, null, 123, null, null, null });
+				}
+				catch (NotNullConstraintViolationException) {
+					return;
+				}
+				catch (SQLiteException ex) {
+					if (SQLite3.LibVersionNumber () < 3007017 && ex.Result == SQLite3.Result.Constraint) {
+						Assert.Inconclusive ("Detailed constraint information is only available in SQLite3 version 3.7.17 and above.");
+					}
+				}
+				catch (Exception ex) {
+					Assert.Fail ("Expected an exception of type NotNullConstraintViolationException to be thrown. An exception of type {0} was thrown instead.", ex.GetType ().Name);
+				}
+			}
+			Assert.Fail ("Expected an exception of type NotNullConstraintViolationException to be thrown. No exception was thrown.");
+		}
+
+	}
+}

--- a/tests/SQLite.Tests.csproj
+++ b/tests/SQLite.Tests.csproj
@@ -45,6 +45,7 @@
     <Compile Include="CreateTableTest.cs" />
     <Compile Include="GuidTests.cs" />
     <Compile Include="CreateTableImplicitTest.cs" />
+    <Compile Include="NotNullAttributeTest.cs" />
     <Compile Include="SkipTest.cs" />
     <Compile Include="CollateTest.cs" />
     <Compile Include="ContainsTest.cs" />

--- a/tests/SQLiteMetroTests/SQLiteMetroTests.csproj
+++ b/tests/SQLiteMetroTests/SQLiteMetroTests.csproj
@@ -160,6 +160,9 @@
     <Compile Include="..\MappingTest.cs">
       <Link>MappingTest.cs</Link>
     </Compile>
+    <Compile Include="..\NotNullAttributeTest.cs">
+      <Link>NotNullAttributeTest.cs</Link>
+    </Compile>
     <Compile Include="..\NullableTest.cs">
       <Link>NullableTest.cs</Link>
     </Compile>


### PR DESCRIPTION
Added NotNullAttribute.
Added support for extended error codes.

Usage:

public Class TestObj
{
    [PrimaryKey, autoincrement]
    public int? PatientId { get; set; }
    [NotNull]
    public string FirstName { get; set; }
    [NotNull]
    public string LastName { get; set; }
}

A database column created from a property decorated with this attribute will be created with a not null constraint. Violations of not null constraints from Insert, Update, and ExecuteNonQuery methods results in a NotNullConstraintViolationException being thrown. NotNullConstraintViolationException contains an IEnumerable<TableMapping.Columns> property listing all the columns that violated the constraint.
