### PR TITLE
If a column is PRIMARY KEY AUTOINCREMENT, then no need to add NOT NULL w...

### DIFF
--- a/src/SQLite.cs
+++ b/src/SQLite.cs
@@ -1761,7 +1761,7 @@ namespace SQLite
 			if (p.IsAutoInc) {
 				decl += "autoincrement ";
 			}
-			if (!p.IsNullable) {
+			if (!p.IsNullable && !(p.IsPK && p.IsAutoInc)) {
 				decl += "not null ";
 			}
 			if (!string.IsNullOrEmpty (p.Collation)) {


### PR DESCRIPTION
If a column is PRIMARY KEY AUTOINCREMENT, then no need to add NOT NULL when creating it
