### PR TITLE
Fix SQL errors when using a blob as a search criterion (Fix #243)

### DIFF
--- a/src/SQLite.cs
+++ b/src/SQLite.cs
@@ -2574,7 +2574,7 @@ namespace SQLite
 					//
 					// Work special magic for enumerables
 					//
-					if (val != null && val is System.Collections.IEnumerable && !(val is string)) {
+					if (val != null && val is System.Collections.IEnumerable && !(val is string) && !(val is System.Collections.Generic.IEnumerable<byte>)) {
 						var sb = new System.Text.StringBuilder();
 						sb.Append("(");
 						var head = "";

--- a/tests/ByteArrayTest.cs
+++ b/tests/ByteArrayTest.cs
@@ -76,6 +76,81 @@ namespace SQLite.Tests
 			}
 		}
 
+        [Test]
+        [Description("Uses a byte array to find a record")]
+        public void ByteArrayWhere()
+        {
+            //Byte Arrays for comparisson
+            ByteArrayClass[] byteArrays = new ByteArrayClass[] {
+				new ByteArrayClass() { bytes = new byte[] { 1, 2, 3, 4, 250, 252, 253, 254, 255 } }, //Range check
+				new ByteArrayClass() { bytes = new byte[] { 0 } }, //null bytes need to be handled correctly
+				new ByteArrayClass() { bytes = new byte[] { 0, 0 } },
+				new ByteArrayClass() { bytes = new byte[] { 0, 1, 0 } },
+				new ByteArrayClass() { bytes = new byte[] { 1, 0, 1 } },
+				new ByteArrayClass() { bytes = new byte[] { } }, //Empty byte array should stay empty (and not become null)
+				new ByteArrayClass() { bytes = null } //Null should be supported
+			};
+
+            SQLiteConnection database = new SQLiteConnection(TestPath.GetTempFileName());
+            database.CreateTable<ByteArrayClass>();
+
+            byte[] criterion = new byte[] { 1, 0, 1 };
+
+            //Insert all of the ByteArrayClass
+            int id = 0;
+            foreach (ByteArrayClass b in byteArrays)
+            {
+                database.Insert(b);
+                if (b.bytes != null && criterion.SequenceEqual<byte>(b.bytes))
+                    id = b.ID;
+            }
+            Assert.AreNotEqual(0, id, "An ID wasn't set");
+
+            //Get it back out
+            ByteArrayClass fetchedByteArray = database.Table<ByteArrayClass>().Where(x => x.bytes == criterion).First();
+            Assert.IsNotNull(fetchedByteArray);
+            //Check they are the same
+            Assert.AreEqual(id, fetchedByteArray.ID);
+        }
+
+        [Test]
+        [Description("Uses a null byte array to find a record")]
+        public void ByteArrayWhereNull()
+        {
+            //Byte Arrays for comparisson
+            ByteArrayClass[] byteArrays = new ByteArrayClass[] {
+				new ByteArrayClass() { bytes = new byte[] { 1, 2, 3, 4, 250, 252, 253, 254, 255 } }, //Range check
+				new ByteArrayClass() { bytes = new byte[] { 0 } }, //null bytes need to be handled correctly
+				new ByteArrayClass() { bytes = new byte[] { 0, 0 } },
+				new ByteArrayClass() { bytes = new byte[] { 0, 1, 0 } },
+				new ByteArrayClass() { bytes = new byte[] { 1, 0, 1 } },
+				new ByteArrayClass() { bytes = new byte[] { } }, //Empty byte array should stay empty (and not become null)
+				new ByteArrayClass() { bytes = null } //Null should be supported
+			};
+
+            SQLiteConnection database = new SQLiteConnection(TestPath.GetTempFileName());
+            database.CreateTable<ByteArrayClass>();
+
+            byte[] criterion = null;
+
+            //Insert all of the ByteArrayClass
+            int id = 0;
+            foreach (ByteArrayClass b in byteArrays)
+            {
+                database.Insert(b);
+                if (b.bytes == null)
+                    id = b.ID;
+            }
+            Assert.AreNotEqual(0, id, "An ID wasn't set");
+
+            //Get it back out
+            ByteArrayClass fetchedByteArray = database.Table<ByteArrayClass>().Where(x => x.bytes == criterion).First();
+
+            Assert.IsNotNull(fetchedByteArray);
+            //Check they are the same
+            Assert.AreEqual(id, fetchedByteArray.ID);
+        }
+
 		[Test]
 		[Description("Create A large byte array and check it can be stored and retrieved correctly")]
 		public void LargeByteArray()


### PR DESCRIPTION
A byte array shouldn't have a parameter for each byte. Just treat the entire blob as a single object.
