### PR TITLE
Add ability to Delete records using a predicate.

### DIFF
--- a/src/SQLite.cs
+++ b/src/SQLite.cs
@@ -2426,6 +2426,24 @@ namespace SQLite
 			}
 		}
 
+		public int Delete(Expression<Func<T, bool>> predExpr)
+		{
+			if (predExpr.NodeType == ExpressionType.Lambda) {
+				var lambda = (LambdaExpression)predExpr;
+				var pred = lambda.Body;
+				var args = new List<object> ();
+				var w = CompileExpr (pred, args);
+				var cmdText = "delete from \"" + Table.TableName + "\"";
+				cmdText += " where " + w.CommandText;
+				var command = Connection.CreateCommand (cmdText, args.ToArray ());
+
+				int result = command.ExecuteNonQuery();
+				return result;
+			} else {
+				throw new NotSupportedException ("Must be a predicate");
+			}
+		}
+
 		public TableQuery<T> Take (int n)
 		{
 			var q = Clone<T> ();

--- a/tests/DeleteTest.cs
+++ b/tests/DeleteTest.cs
@@ -20,6 +20,7 @@ namespace SQLite.Tests
 			[PrimaryKey, AutoIncrement]
 			public int Id { get; set; }
 			public int Datum { get; set; }
+			public string Test { get; set;}
 		}
 
 		const int Count = 100;
@@ -29,7 +30,7 @@ namespace SQLite.Tests
 			var db = new TestDb ();
 			db.CreateTable<TestTable> ();
 			var items = from i in Enumerable.Range (0, Count)
-				select new TestTable { Datum = 1000+i };
+			            select new TestTable { Datum = 1000+i, Test = "Hello World" };
 			db.InsertAll (items);
 			Assert.AreEqual (Count, db.Table<TestTable> ().Count ());
 			return db;
@@ -77,6 +78,29 @@ namespace SQLite.Tests
 
 			Assert.AreEqual (Count, r);
 			Assert.AreEqual (0, db.Table<TestTable> ().Count ());
+		}
+
+		[Test]
+		public void DeleteAllWithPredicate()
+		{
+			var db = CreateDb();
+
+			var r = db.Table<TestTable>().Delete(p => p.Test == "Hello World");
+
+			Assert.AreEqual (Count, r);
+			Assert.AreEqual (0, db.Table<TestTable> ().Count ());
+		}
+
+		[Test]
+		public void DeleteAllWithPredicateHalf()
+		{
+			var db = CreateDb();
+			db.Insert(new TestTable() { Datum = 1, Test = "Hello World 2" }); 
+
+			var r = db.Table<TestTable>().Delete(p => p.Test == "Hello World");
+
+			Assert.AreEqual (Count, r);
+			Assert.AreEqual (1, db.Table<TestTable> ().Count ());
 		}
 	}
 }

--- a/tests/SQLite.Tests.csproj
+++ b/tests/SQLite.Tests.csproj
@@ -71,6 +71,5 @@
     <Compile Include="MigrationTest.cs" />
     <Compile Include="EqualsTest.cs" />
     <Compile Include="DateTimeOffsetTest.cs" />
-    <Compile Include="DeleteExtensions.cs" />
   </ItemGroup>
 </Project>

--- a/tests/SQLite.Tests.csproj
+++ b/tests/SQLite.Tests.csproj
@@ -71,5 +71,6 @@
     <Compile Include="MigrationTest.cs" />
     <Compile Include="EqualsTest.cs" />
     <Compile Include="DateTimeOffsetTest.cs" />
+    <Compile Include="DeleteExtensions.cs" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Added a Delete function which allows records to be deleted using a predicate.

See StackOverflow question for details:
http://stackoverflow.com/questions/21123170/is-there-a-way-to-delete-in-sqlite-net-by-using-a-predicate/22055268#22055268

Can delete using:

    conn.Table<MyEntity>().Delete(t => t.someProperty == someValue);