### PR TITLE
Support for columns participating in multiple indices (Fix #258)

### DIFF
--- a/src/SQLite.cs
+++ b/src/SQLite.cs
@@ -98,6 +98,107 @@ namespace SQLite
 		}
 	}
 
+    public class UniqueConstraintViolationException : SQLiteException
+    {
+        // This is intended for use within insert/update loops. It should let you 
+        // know which object caused the exception to be thrown.
+        public  object DataObject { get; private set; }
+
+        protected UniqueConstraintViolationException(SQLite3.Result r, string message)
+            : this (r, message, null)
+        {
+
+        }
+
+        protected UniqueConstraintViolationException(SQLite3.Result r, string message, object obj)
+            : base (r, message)
+        {
+            DataObject = obj;
+        }
+
+        public static new UniqueConstraintViolationException New(SQLite3.Result r, string message)
+        {
+            return new UniqueConstraintViolationException (r, message);
+        }
+
+        public static UniqueConstraintViolationException New(SQLiteException exception, object obj)
+        {
+            return new UniqueConstraintViolationException (exception.Result, exception.Message, obj);
+        }
+    }
+
+    public static class Pragma
+    {
+        public class IndexColumnInfo
+        {
+            [Column ("seqno")]
+            public int SeqNo { get; set; }
+            [Column ("cid")]
+            public string TableRank { get; set; }
+            [Column ("name")]
+            public string Name { get; set; }
+        }
+
+        public class IndexInfo
+        {
+            [Column ("seq")]
+            public int Seq { get; set; }
+            [Column ("name")]
+            public string Name { get; set; }
+            [Column ("unique")]
+            public bool Unique { get; set; }
+
+            public List<IndexColumnInfo> GetColumns(SQLiteConnection db)
+            {
+                return GetIndexInfo (db, Name).ToList ();
+            }
+        }
+
+        public static List<IndexInfo> GetIndexList<T>(SQLiteConnection db)
+        {
+            return GetIndexList (db, typeof (T));
+        }
+
+        public static List<IndexInfo> GetIndexList(SQLiteConnection db, Type type)
+        {
+            if (db == null) {
+                throw new ArgumentNullException ("db");
+            }
+
+            if (type == null) {
+                throw new ArgumentNullException ("type");
+            }
+
+            var map = db.GetMapping (type);
+            var query = string.Format ("pragma index_list (\"{0}\")", map.TableName);
+            return db.Query<IndexInfo> (query).OrderBy (i => i.Seq).ToList();
+        }
+
+        public static List<IndexColumnInfo> GetIndexInfo(SQLiteConnection db, IndexInfo index)
+        {
+            if (index == null) {
+                throw new ArgumentNullException ("listInfo");
+            }
+            return GetIndexInfo (db, index.Name).ToList();
+        }
+
+
+        public static List<IndexColumnInfo> GetIndexInfo(SQLiteConnection db, string indexName)
+        {
+            if (db == null) {
+                throw new ArgumentNullException ("db");
+            }
+
+            if (indexName == null) {
+                throw new ArgumentNullException ("indexName");
+            }
+
+            var query = string.Format ("pragma index_info(\"{0}\")", indexName);
+            IEnumerable<IndexColumnInfo> retVal = db.Query<IndexColumnInfo> (query).OrderBy (c => c.SeqNo);
+            return retVal.ToList();
+        }
+    }
+
 	[Flags]
 	public enum SQLiteOpenFlags {
 		ReadOnly = 1, ReadWrite = 2, Create = 4,
@@ -1281,11 +1382,14 @@ namespace SQLite
 				count = insertCmd.ExecuteNonQuery (vals);
 			}
 			catch (SQLiteException ex) {
-
-				if (SQLite3.ExtendedErrCode (this.Handle) == SQLite3.ExtendedResult.ConstraintNotNull) {
-					throw NotNullConstraintViolationException.New (ex.Result, ex.Message, map, obj);
-				}
-				throw;
+                switch (SQLite3.ExtendedErrCode (this.Handle)) {
+                case SQLite3.ExtendedResult.ConstraintNotNull:
+                    throw NotNullConstraintViolationException.New (ex, map, obj);
+                case SQLite3.ExtendedResult.ConstraintUnique:
+                    throw UniqueConstraintViolationException.New (ex, obj);
+                default:
+                    throw;
+                }
 			}
 
             if (map.HasAutoIncPK)
@@ -1362,12 +1466,14 @@ namespace SQLite
 				rowsAffected = Execute (q, ps.ToArray ());
 			}
 			catch (SQLiteException ex) {
-
-				if (ex.Result == SQLite3.Result.Constraint && SQLite3.ExtendedErrCode (this.Handle) == SQLite3.ExtendedResult.ConstraintNotNull) {
-					throw NotNullConstraintViolationException.New (ex, map, obj);
-				}
-
-				throw ex;
+                switch (SQLite3.ExtendedErrCode (this.Handle)) {
+                case SQLite3.ExtendedResult.ConstraintNotNull:
+                    throw NotNullConstraintViolationException.New (ex, map, obj);
+                case SQLite3.ExtendedResult.ConstraintUnique:
+                    throw UniqueConstraintViolationException.New (ex, obj);
+                default:
+                    throw;
+                }
 			}
 
 			if (rowsAffected > 0)
@@ -1465,6 +1571,64 @@ namespace SQLite
 				OnTableChanged (map, NotifyTableChangedAction.Delete);
 			return count;
 		}
+
+        public class ConstraintValidationInfo
+        {
+            public string ConstraintName { get; private set; }
+            public TableMapping.Column[] Columns { get; private set; }
+
+            public ConstraintValidationInfo(string name, IEnumerable<TableMapping.Column> columns)
+            {
+                ConstraintName = name;
+
+                if (columns == null) {
+                    Columns =   new TableMapping.Column[0];
+                } else {
+                    Columns = columns.ToArray ();
+                }
+            }
+        }
+
+        public List<ConstraintValidationInfo> ValidateUniqueConstraints(object obj)
+        {
+            if (obj == null) {
+                return ValidateUniqueConstraints(null, null);
+            }
+            return ValidateUniqueConstraints (obj, obj.GetType ());
+        }
+
+        public List<ConstraintValidationInfo> ValidateUniqueConstraints(object obj, Type objType)
+        {
+            var constraints = new List<ConstraintValidationInfo> ();
+            var map = GetMapping(objType);
+            var pk = map.PK;
+
+            if (obj == null) {
+                return constraints;
+            }
+
+            if (objType == null) {
+                objType = obj.GetType ();
+            }
+
+            var indices = Pragma.GetIndexList (this, objType).Where(i => i.Unique);
+            foreach (Pragma.IndexInfo index in indices) {
+                var columns = Pragma.GetIndexInfo (this, index);
+                var query = string.Format ("select count(*) from \"{0}\" where {1} {2}"
+                                            , map.TableName
+                                            , string.Join (" and ", columns.Select (c => string.Format ("\"{0}\" = ?", c.Name)))
+                                            , string.Format(" and \"{0}\" <> ?", pk.Name));
+                var mappingColumns = columns.Select(c => map.FindColumn(c.Name));
+                var values = new List<object> (mappingColumns.Select(c => c.GetValue (obj)));
+                values.Add (pk.GetValue (obj));
+                var numRows = this.ExecuteScalar<int> (query, values.ToArray());
+                if (numRows > 0) {
+                    constraints.Add (new ConstraintValidationInfo(index.Name, mappingColumns));
+                }
+            }
+
+            return constraints;
+        }
 
 		~SQLiteConnection ()
 		{
@@ -1591,7 +1755,7 @@ namespace SQLite
 	{
 	}
 
-	[AttributeUsage (AttributeTargets.Property)]
+    [AttributeUsage (AttributeTargets.Property, AllowMultiple = true)]
 	public class IndexedAttribute : Attribute
 	{
 		public string Name { get; set; }
@@ -1614,7 +1778,7 @@ namespace SQLite
 	{
 	}
 
-	[AttributeUsage (AttributeTargets.Property)]
+    [AttributeUsage (AttributeTargets.Property, AllowMultiple = true)]
 	public class UniqueAttribute : IndexedAttribute
 	{
 		public override bool Unique {
@@ -2038,9 +2202,16 @@ namespace SQLite
 				throw SQLiteException.New (r, msg);
 			}
 			else if (r == SQLite3.Result.Constraint) {
-				if (SQLite3.ExtendedErrCode (_conn.Handle) == SQLite3.ExtendedResult.ConstraintNotNull) {
-					throw NotNullConstraintViolationException.New (r, SQLite3.GetErrmsg (_conn.Handle));
-				}
+                SQLite3.ExtendedResult err = SQLite3.ExtendedErrCode (_conn.Handle); // MUST do this before calling GetErrMsg
+                string msg = SQLite3.GetErrmsg (_conn.Handle);
+                switch (err) {
+                case SQLite3.ExtendedResult.ConstraintNotNull:
+                    throw NotNullConstraintViolationException.New (r, msg);
+                case SQLite3.ExtendedResult.ConstraintUnique:
+                    throw UniqueConstraintViolationException.New (r, msg);
+                default:
+                    throw SQLiteException.New (r, msg);
+                }
 			}
 
 			throw SQLiteException.New(r, r.ToString());
@@ -2361,8 +2532,11 @@ namespace SQLite
 			} else if (r == SQLite3.Result.Constraint && SQLite3.ExtendedErrCode (Connection.Handle) == SQLite3.ExtendedResult.ConstraintNotNull) {
 				SQLite3.Reset (Statement);
 				throw NotNullConstraintViolationException.New (r, SQLite3.GetErrmsg (Connection.Handle));
-			} else {
-				SQLite3.Reset (Statement);
+            } else if (r == SQLite3.Result.Constraint && SQLite3.ExtendedErrCode (Connection.Handle) == SQLite3.ExtendedResult.ConstraintUnique) {
+                SQLite3.Reset (Statement);
+                throw UniqueConstraintViolationException.New (r, SQLite3.GetErrmsg (Connection.Handle));
+            } else {
+                SQLite3.Reset (Statement);
 				throw SQLiteException.New (r, r.ToString ());
 			}
 		}

--- a/tests/PragmaTest.cs
+++ b/tests/PragmaTest.cs
@@ -1,0 +1,151 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+#if NETFX_CORE
+using Microsoft.VisualStudio.TestPlatform.UnitTestFramework;
+using SetUp = Microsoft.VisualStudio.TestPlatform.UnitTestFramework.TestInitializeAttribute;
+using TestFixture = Microsoft.VisualStudio.TestPlatform.UnitTestFramework.TestClassAttribute;
+using Test = Microsoft.VisualStudio.TestPlatform.UnitTestFramework.TestMethodAttribute;
+#else
+using NUnit.Framework;
+#endif
+
+
+namespace SQLite.Tests
+{
+	[TestFixture]
+    public class PragmaTest
+    {
+        public class ClassWithOneIndex
+        {
+            [PrimaryKey]
+            [AutoIncrement]
+            public int Id { get; set; }
+            [Indexed("UX_Name", 1)]
+            public string LastName { get; set; }
+            [Indexed ("UX_Name", 2)]
+            public string FirstName { get; set; }
+        }
+
+        public class ClassWithTwoIndices
+        {
+            [PrimaryKey]
+            [AutoIncrement]
+            public int Id { get; set; }
+            [Indexed("UX_Name", 2)]
+            public string FirstName { get; set; }
+            [Indexed("UX_Name", 1)]
+            public string LastName { get; set; }
+            [Indexed("UX_Locale", 1)]
+            public string City { get; set; }
+            [Indexed ("UX_Locale", 2)]
+            public string State { get; set; }
+        }
+
+        public class ClassWithNoIndex
+        {
+            [PrimaryKey]
+            [AutoIncrement]
+            public int Id { get; set; }
+        }
+
+        [Test]
+        public void GetSingleIndex()
+        {
+            using (TestDb db = new TestDb ()) {
+                db.CreateTable<ClassWithOneIndex> ();
+                var info = Pragma.GetIndexList (db, typeof (ClassWithOneIndex));
+                var index = info.FirstOrDefault ();
+                var columns = Pragma.GetIndexInfo(db, "UX_Name");
+                Assert.AreEqual (1, info.Count ());
+                Assert.AreEqual ("UX_Name", index.Name);
+                Assert.AreEqual (0, index.Seq);
+                Assert.AreEqual (false, index.Unique);
+                Assert.AreEqual ("LastName", columns[0].Name);
+                Assert.AreEqual ("FirstName", columns[1].Name);
+            }
+        }
+
+        [Test]
+        public void GetMultipleIndices()
+        {
+            using (TestDb db = new TestDb ()) {
+                db.CreateTable<ClassWithTwoIndices> ();
+                var info = Pragma.GetIndexList (db, typeof (ClassWithTwoIndices));
+                List<Pragma.IndexColumnInfo> columns;
+
+                var firstIndex = info[0];
+                Assert.AreEqual ("UX_Locale", firstIndex.Name);
+                Assert.AreEqual (0, firstIndex.Seq);
+                Assert.AreEqual (false, firstIndex.Unique);
+                columns = Pragma.GetIndexInfo (db, firstIndex);
+                Assert.AreEqual ("City, State", string.Join (", ", columns.Select (c => c.Name)));
+
+                var secondIndex = info[1];
+                Assert.AreEqual ("UX_Name", secondIndex.Name);
+                Assert.AreEqual (1, secondIndex.Seq);
+                Assert.AreEqual (false, secondIndex.Unique);
+                columns = Pragma.GetIndexInfo (db, secondIndex);
+                Assert.AreEqual ("LastName, FirstName", string.Join (", ", columns.Select (c => c.Name)));
+            }
+        }
+
+        [Test]
+        public void GetNoIndex()
+        {
+            using (TestDb db = new TestDb ()) {
+                db.CreateTable<ClassWithNoIndex> ();
+                var info = Pragma.GetIndexList (db, typeof (ClassWithNoIndex));
+                var index = info.FirstOrDefault ();
+                Assert.IsNull (index);
+            }
+        }
+
+        [Test]
+        public void GetBadIndexName()
+        {
+            using (TestDb db = new TestDb ()) {
+                db.CreateTable<ClassWithOneIndex> ();
+                var columns = Pragma.GetIndexInfo (db, "UX_Nonesuch");
+                Assert.AreEqual (0, columns.Count ());
+            }
+        }
+
+        [Test]
+        public void ConvenienceMethodReturnsSameColumns()
+        {
+            using (TestDb db = new TestDb ()) {
+                db.CreateTable<ClassWithOneIndex> ();
+                var info = Pragma.GetIndexList (db, typeof (ClassWithOneIndex));
+                var index = info.FirstOrDefault ();
+                var columns = Pragma.GetIndexInfo (db, "UX_Name");
+                var convenienceColumns = index.GetColumns (db);
+
+                Assert.AreEqual (columns[0].Name, convenienceColumns[0].Name);
+                Assert.AreEqual (columns[0].SeqNo, convenienceColumns[0].SeqNo);
+                Assert.AreEqual (columns[0].TableRank, convenienceColumns[0].TableRank);
+            }
+        }
+
+        [Test]
+        public void GenericMethodReturnsSameIndices()
+        {
+            using (TestDb db = new TestDb ()) {
+                db.CreateTable<ClassWithTwoIndices> ();
+                var genericIndex = Pragma.GetIndexList<ClassWithTwoIndices> (db);
+                var index = Pragma.GetIndexList (db, typeof (ClassWithTwoIndices));
+
+                Assert.AreEqual (index.Count, genericIndex.Count);
+
+                Assert.AreEqual (index[0].Name, genericIndex[0].Name);
+                Assert.AreEqual (index[0].Seq, genericIndex[0].Seq);
+                Assert.AreEqual (index[0].Unique, genericIndex[0].Unique);
+
+                Assert.AreEqual (index[1].Name, genericIndex[1].Name);
+                Assert.AreEqual (index[1].Seq, genericIndex[1].Seq);
+                Assert.AreEqual (index[1].Unique, genericIndex[1].Unique);
+            }
+        }
+    }
+}

--- a/tests/SQLite.Tests.csproj
+++ b/tests/SQLite.Tests.csproj
@@ -48,6 +48,7 @@
     <Compile Include="CollateTest.cs" />
     <Compile Include="ContainsTest.cs" />
     <Compile Include="NullableTest.cs" />
+    <Compile Include="PragmaTest.cs" />
     <Compile Include="DropTableTest.cs" />
     <Compile Include="LinqTest.cs" />
     <Compile Include="TestDb.cs" />

--- a/tests/SQLiteMetroTests/SQLiteMetroTests.csproj
+++ b/tests/SQLiteMetroTests/SQLiteMetroTests.csproj
@@ -166,6 +166,9 @@
     <Compile Include="..\NullableTest.cs">
       <Link>NullableTest.cs</Link>
     </Compile>
+    <Compile Include="..\PragmaTest.cs">
+      <Link>PragmaTest.cs</Link>
+    </Compile>
     <Compile Include="..\SkipTest.cs">
       <Link>SkipTest.cs</Link>
     </Compile>

--- a/tests/SQLiteTouchTests/SQLiteTouchTests.csproj
+++ b/tests/SQLiteTouchTests/SQLiteTouchTests.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -140,6 +140,9 @@
     </Compile>
     <Compile Include="..\NullableTest.cs">
       <Link>NullableTest.cs</Link>
+    </Compile>
+    <Compile Include="..\PragmaTest.cs">
+      <Link>PragmaTest.cs</Link>
     </Compile>
     <Compile Include="..\ScalarTest.cs">
       <Link>ScalarTest.cs</Link>

--- a/tests/UniqueTest.cs
+++ b/tests/UniqueTest.cs
@@ -38,25 +38,67 @@ namespace SQLite.Tests
 			public int Seis { get; set;}
 		}
 
-		public class IndexColumns {
-			public int seqno { get; set;} 
-			public int cid { get; set;} 
-			public string name { get; set; } 
-		}
+        public class LosDos
+        {
+            [PrimaryKey, AutoIncrement]
+            public int ID { get; set; }
 
-		public class IndexInfo {
-			public int seq { get; set;} 
-			public string name { get; set;} 
-			public bool unique { get; set;}
-		}
+            [Unique (Name = "UX_Uno")]
+            [Unique (Name = "UX_One")]
+            public int Uno { get; set; }
+
+            [Unique (Name = "UX_Dos")]
+            [Unique (Name = "UX_Two", Order = 2)]
+            public int Dos { get; set; }
+            [Unique (Name = "UX_Dos")]
+            [Unique (Name = "UX_Two", Order = 1)]
+            public int Tres { get; set; }
+        }
+
+        public class TheThree
+        {
+            [PrimaryKey, AutoIncrement]
+            public int ID { get; set; }
+
+            [Unique (Name = "UX_One")]
+            public int One { get; set; }
+            [Unique (Name = "UX_One")]
+            [Unique (Name = "UX_Two")]
+            public int Two { get; set; }
+            [Unique (Name = "UX_Two")]
+            public int Three { get; set; }
+
+            [Indexed(Name = "IX_Uno")]
+            public string NotUnique { get; set; }
+        }
+
+        public class ClassWithBadIndex
+        {
+            [PrimaryKey, AutoIncrement]
+            public int Id { get; set; }
+            [Indexed (Name = "UX_Bad1", Unique = false)]
+            public int Column1 { get; set; }
+            [Indexed (Name = "UX_Bad1", Unique = true)]
+            public int Column2 { get; set; }
+        }
+
+        public class AnotherClassWithBadIndex
+        {
+            [PrimaryKey, AutoIncrement]
+            public int Id { get; set; }
+            [Indexed (Name = "UX_Bad1", Unique = false)]
+            public int Column1 { get; set; }
+            [Unique (Name = "UX_Bad1")]
+            public int Column2 { get; set; }
+        }
 
 		[Test]
 		public void CreateUniqueIndexes ()
 		{
 			using (var db = new TestDb ()) {
 				db.CreateTable<TheOne> ();
-				var indexes = db.Query<IndexInfo> ("PRAGMA INDEX_LIST (\"TheOne\")");
-				Assert.AreEqual (4, indexes.Count, "# of indexes");
+                var indexes = Pragma.GetIndexList (db, typeof (TheOne));
+				Assert.AreEqual (4, indexes.Count(), "# of indexes");
 				CheckIndex (db, indexes, "UX_Uno", true, "Uno");
 				CheckIndex (db, indexes, "UX_Dos", true, "Dos", "Tres");
 				CheckIndex (db, indexes, "UX_Uno_bool", true, "Cuatro");
@@ -64,18 +106,307 @@ namespace SQLite.Tests
 			}
 		}
 
-		static void CheckIndex (TestDb db, List<IndexInfo> indexes, string iname, bool unique, params string [] columns)
+        [Test]
+        public void CreateMultipleUniqueIndexesWithSharedColumns()
+        {
+            using (var db = new TestDb ()) {
+                db.CreateTable<LosDos> ();
+                var indexes = Pragma.GetIndexList (db, typeof (LosDos));
+                Assert.AreEqual (4, indexes.Count(), "# of indexes");
+                CheckIndex (db, indexes, "UX_Uno", true, "Uno");
+                CheckIndex (db, indexes, "UX_One", true, "Uno");
+                CheckIndex (db, indexes, "UX_Dos", true, "Dos", "Tres");
+                CheckIndex (db, indexes, "UX_Two", true, "Dos", "Tres");
+            }
+        }
+
+        [Test]
+        public void BadIndexThrowsException()
+        {
+            using (var db = new TestDb ()) {
+                bool exceptionCaught = false;
+                try {
+                    db.CreateTable<ClassWithBadIndex> ();
+                }
+                catch (Exception) {
+                    exceptionCaught = true;
+                }
+
+                Assert.IsTrue (exceptionCaught, "Expected an exception to be thrown. No exception was thrown.");
+            }
+        }
+
+        [Test]
+        public void BadIndexWithMixedAttributesThrowsException()
+        {
+            using (var db = new TestDb ()) {
+                bool exceptionCaught = false;
+                try {
+                    db.CreateTable<AnotherClassWithBadIndex> ();
+                }
+                catch (Exception) {
+                    exceptionCaught = true;
+                }
+
+                Assert.IsTrue (exceptionCaught, "Expected an exception to be thrown. No exception was thrown.");
+            }
+        }
+
+        [Test]
+        public void InsertThrowsSpecificException()
+        {
+            using (var db = new TestDb ()) {
+                bool exceptionCaught = false;
+
+                try {
+                    TheThree obj;
+
+                    db.CreateTable<TheThree> ();
+                    obj = new TheThree () { One = 1, Two = 2 };
+                    db.Insert (obj);
+                    db.Insert (obj);
+                }
+                catch (UniqueConstraintViolationException) {
+                    exceptionCaught = true;
+                }
+                catch (SQLiteException ex) {
+                    if (SQLite3.LibVersionNumber () < 3007017 && ex.Result == SQLite3.Result.Constraint) {
+                        Inconclusive ();
+                        return;
+                    }
+                }
+                catch (Exception ex) {
+                    Assert.Fail ("Expected an exception of type UniqueConstraintViolationException to be thrown. An exception of type {0} was thrown instead.", ex.GetType ().Name);
+                }
+
+                Assert.IsTrue (exceptionCaught, "Expected an exception of type UniqueConstraintViolationException to be thrown. No exception was thrown.");
+            }
+        }
+
+        [Test]
+        public void UpdateThrowsSpecificException()
+        {
+            using (var db = new TestDb ()) {
+                bool exceptionCaught = false;
+
+                try {
+                    TheThree obj;
+
+                    db.CreateTable<TheThree> ();
+                    obj = new TheThree () { One = 1, Two = 2 };
+                    db.Insert (obj);
+                    obj.Two = 3;
+                    db.Insert (obj);
+                    obj.Two = 2;
+                    db.Update (obj);
+                }
+                catch (UniqueConstraintViolationException) {
+                    exceptionCaught = true;
+                }
+                catch (SQLiteException ex) {
+                    if (SQLite3.LibVersionNumber () < 3007017 && ex.Result == SQLite3.Result.Constraint) {
+                        Inconclusive ();
+                        return;
+                    }
+                }
+                catch (Exception ex) {
+                    Assert.Fail ("Expected an exception of type UniqueConstraintViolationException to be thrown. An exception of type {0} was thrown instead.", ex.GetType ().Name);
+                }
+
+                Assert.IsTrue (exceptionCaught, "Expected an exception of type UniqueConstraintViolationException to be thrown. No exception was thrown.");
+            }
+        }
+
+        [Test]
+        public void InsertQueryThrowsSpecificException()
+        {
+            using (var db = new TestDb ()) {
+                bool exceptionCaught = false;
+
+                try {
+                    TheThree obj;
+
+                    db.CreateTable<TheThree> ();
+                    obj = new TheThree () { One = 1, Two = 2 };
+                    db.Insert (obj);
+                    db.Execute ("insert into \"TheThree\" (One, Two) values(?, ?)", obj.One, obj.Two);
+                }
+                catch (UniqueConstraintViolationException) {
+                    exceptionCaught = true;
+                }
+                catch (SQLiteException ex) {
+                    if (SQLite3.LibVersionNumber () < 3007017 && ex.Result == SQLite3.Result.Constraint) {
+                        Inconclusive ();
+                        return;
+                    }
+                }
+                catch (Exception ex) {
+                    Assert.Fail ("Expected an exception of type UniqueConstraintViolationException to be thrown. An exception of type {0} was thrown instead.", ex.GetType ().Name);
+                }
+
+                Assert.IsTrue (exceptionCaught, "Expected an exception of type UniqueConstraintViolationException to be thrown. No exception was thrown.");
+            }
+        }
+
+        [Test]
+        public void UpdateQueryThrowsSpecificException()
+        {
+
+            using (var db = new TestDb ()) {
+                bool exceptionCaught = false;
+
+                try {
+                    TheThree obj;
+
+                    db.CreateTable<TheThree> ();
+                    obj = new TheThree () { One = 1, Two = 2 };
+                    db.Insert (obj);
+                    obj.Two = 3;
+                    db.Insert (obj);
+                    obj.Two = 2;
+                    db.Execute ("update \"TheThree\" set One=?, Two=? where ID=?", obj.One, obj.Two, obj.ID);
+                }
+                catch (UniqueConstraintViolationException) {
+                    exceptionCaught = true;
+                }
+                catch (SQLiteException ex) {
+                    if (SQLite3.LibVersionNumber () < 3007017 && ex.Result == SQLite3.Result.Constraint) {
+                        Inconclusive ();
+                        return;
+                    }
+                }
+                catch (Exception ex) {
+                    Assert.Fail ("Expected an exception of type UniqueConstraintViolationException to be thrown. An exception of type {0} was thrown instead.", ex.GetType ().Name);
+                }
+
+                Assert.IsTrue (exceptionCaught, "Expected an exception of type UniqueConstraintViolationException to be thrown. No exception was thrown.");
+            }
+        }
+
+        [Test]
+        public void ValidateConstraintsInExceptionHandler()
+        {
+            using (var db = new TestDb ()) {
+                bool exceptionCaught = false;
+                TheThree obj = new TheThree ();
+                List<SQLiteConnection.ConstraintValidationInfo> validationIssues;
+
+                try {
+                    db.CreateTable<TheThree> ();
+                    obj.One = 1;
+                    obj.Two = 2;
+                    obj.Three = 3;
+                    db.Insert (obj);
+                    obj.ID = 0;
+                    db.Insert (obj);
+                }
+                catch (Exception ex) {
+                    if (SQLite3.LibVersionNumber () >= 3007017) {
+                        if (ex is UniqueConstraintViolationException) {
+                            exceptionCaught = true;
+                        }
+                    } else if (ex is SQLiteException && ((SQLiteException)ex).Result == SQLite3.Result.Constraint) {
+                        exceptionCaught = true;
+                    }
+
+                    validationIssues = (List<SQLiteConnection.ConstraintValidationInfo>)db.ValidateUniqueConstraints (obj);
+                    Assert.AreEqual (2, validationIssues.Count);
+                    var sorted = validationIssues.OrderBy (i => i.ConstraintName).ToArray ();
+                    Assert.AreEqual ("UX_One", sorted[0].ConstraintName);
+                    Assert.AreEqual ("UX_Two", sorted[1].ConstraintName);
+                    Assert.AreEqual ("One, Two", string.Join (", ", sorted[0].Columns.Select (c => c.Name)));
+                    Assert.AreEqual ("Two, Three", string.Join (", ", sorted[1].Columns.Select (c => c.Name)));
+                }
+
+                Assert.IsTrue (exceptionCaught, "Expected an exception of type UniqueConstraintViolationException or SQLiteException to be thrown. No exception was thrown.");
+            }
+        }
+
+        [Test]
+        public void ValidateConstraints()
+        {
+            using (var db = new TestDb ()) {
+                TheThree obj = new TheThree ();
+                List<SQLiteConnection.ConstraintValidationInfo> validationIssues;
+
+                db.CreateTable<TheThree> ();
+                obj.One = 1;
+                obj.Two = 2;
+                obj.Three = 3;
+                db.Insert (obj);
+                obj.ID = 0;
+                obj.Three = 0;
+
+                validationIssues = (List<SQLiteConnection.ConstraintValidationInfo>)db.ValidateUniqueConstraints (obj);
+                Assert.AreEqual (1, validationIssues.Count);
+                Assert.AreEqual ("UX_One", validationIssues[0].ConstraintName);
+                Assert.AreEqual ("One", validationIssues[0].Columns[0].Name);
+                Assert.AreEqual ("Two", validationIssues[0].Columns[1].Name);
+            }
+        }
+
+        [Test]
+        public void ValidateWithNoViolations()
+        {
+            using (var db = new TestDb ()) {
+                TheThree obj = new TheThree ();
+                List<SQLiteConnection.ConstraintValidationInfo> validationIssues;
+
+                db.CreateTable<TheThree> ();
+                obj.One = 1;
+                obj.Two = 2;
+                obj.Three = 3;
+                db.Insert (obj);
+                obj.ID = 0;
+                obj.One = 2;
+                obj.Three = 3;
+                obj.Three = 4;
+                validationIssues = db.ValidateUniqueConstraints (obj);
+                Assert.AreEqual (0, validationIssues.Count);
+            }
+        }
+
+        [Test]
+        public void ValidationIgnoresNonUniqueIndices()
+        {
+            using (var db = new TestDb ()) {
+                TheThree obj = new TheThree ();
+                List<SQLiteConnection.ConstraintValidationInfo> validationIssues;
+
+                db.CreateTable<TheThree> ();
+                obj.One = 1;
+                obj.Two = 2;
+                obj.NotUnique = "NotUnique";
+                db.Insert (obj);
+                obj.ID = 0;
+                obj.One = 0;
+                validationIssues = db.ValidateUniqueConstraints (obj, obj.GetType());
+                Assert.AreEqual (1, validationIssues.Count);
+                Assert.AreEqual ("UX_Two", validationIssues[0].ConstraintName);
+                Assert.AreEqual ("Two", validationIssues[0].Columns[0].Name);
+                Assert.AreEqual ("Three", validationIssues[0].Columns[1].Name);
+            }
+        }
+
+		static void CheckIndex (TestDb db, IEnumerable<Pragma.IndexInfo>indexes, string iname, bool unique, params string [] columns)
 		{
 			if (columns == null)
 				throw new Exception ("Don't!");
-			var idx = indexes.SingleOrDefault (i => i.name == iname);
+			var idx = indexes.SingleOrDefault (i => i.Name == iname);
 			Assert.IsNotNull (idx, String.Format ("Index {0} not found", iname));
-			Assert.AreEqual (idx.unique, unique, String.Format ("Index {0} unique expected {1} but got {2}", iname, unique, idx.unique));
-			var idx_columns = db.Query<IndexColumns> (String.Format ("PRAGMA INDEX_INFO (\"{0}\")", iname));
-			Assert.AreEqual (columns.Length, idx_columns.Count, String.Format ("# of columns: expected {0}, got {1}", columns.Length, idx_columns.Count));
+			Assert.AreEqual (idx.Unique, unique, String.Format ("Index {0} unique expected {1} but got {2}", iname, unique, idx.Unique));
+            var idx_columns = Pragma.GetIndexInfo (db, iname);
+			Assert.AreEqual (columns.Length, idx_columns.Count(), String.Format ("# of columns: expected {0}, got {1}", columns.Length, idx_columns.Count()));
 			foreach (var col in columns) {
-				Assert.IsNotNull (idx_columns.SingleOrDefault (c => c.name == col), String.Format ("Column {0} not in index {1}", col, idx.name));
+				Assert.IsNotNull (idx_columns.SingleOrDefault (c => c.Name == col), String.Format ("Column {0} not in index {1}", col, idx.Name));
 			}
 		}
+
+        void Inconclusive()
+        {
+#if !NETFX_CORE
+            Console.WriteLine ("Detailed constraint information is only available in SQLite3 version 3.7.17 and above.");
+#endif
+        }
 	}
 }


### PR DESCRIPTION
Set AttributeUsage.AllowMultiple to true for IndexAttribute and
UniqueAttribute.

Added UniqueConstraintViolationException (SQLite version 3.7.17 and above). 

Added methods to SQLiteConnection that can be used to figure out which
unique constraint(s) would be violated by an insert/update operation. 
This can be used either to perform data validation before saving or to
provide details for error handling.

Added a static class to encapsulate the pragma calls used to get index
metadata. This can be expanded to include other pragmas as needed.
