### PR TITLE
prevent concurrent use of insert prepared statemnt

### DIFF
--- a/src/SQLite.cs
+++ b/src/SQLite.cs
@@ -2978,6 +2978,9 @@ namespace SQLite
 		}
 
 #if !USE_CSHARP_SQLITE && !USE_WP8_NATIVE_SQLITE && !USE_SQLITEPCL_RAW
+		[DllImport("sqlite3", EntryPoint = "sqlite3_threadsafe", CallingConvention=CallingConvention.Cdecl)]
+		public static extern int Threadsafe ();
+
 		[DllImport("sqlite3", EntryPoint = "sqlite3_open", CallingConvention=CallingConvention.Cdecl)]
 		public static extern Result Open ([MarshalAs(UnmanagedType.LPStr)] string filename, out IntPtr db);
 


### PR DESCRIPTION
Problems addressed:
1) two threads can use try to use the insert prepared statement at the same time.
2) if extra varies from call to call, a thread can end up with the wrong extra applied (race condition).
