### PR TITLE
Fixed issue #303: added support for NOT

### DIFF
--- a/src/SQLite.cs
+++ b/src/SQLite.cs
@@ -2653,7 +2653,18 @@ namespace SQLite
 				else
 					text = "(" + leftr.CommandText + " " + GetSqlName(bin) + " " + rightr.CommandText + ")";
 				return new CompileResult { CommandText = text };
-			} else if (expr.NodeType == ExpressionType.Call) {
+			} else if (expr.NodeType == ExpressionType.Not) {
+                var operandExpr = ((UnaryExpression)expr).Operand;
+                var opr = CompileExpr(operandExpr, queryArgs);
+                object val = opr.Value;
+                if (val is bool)
+                    val = !((bool) val);
+                return new CompileResult
+                {
+                    CommandText = "NOT(" + opr.CommandText + ")",
+                    Value = val
+                };
+            } else if (expr.NodeType == ExpressionType.Call) {
 				
 				var call = (MethodCallExpression)expr;
 				var args = new CompileResult[call.Arguments.Count];

--- a/tests/LinqTest.cs
+++ b/tests/LinqTest.cs
@@ -183,5 +183,55 @@ namespace SQLite.Tests
 			Assert.AreEqual (1, db.Table<Issue96_A>().Where(p => p.ClassB == id).Count ());
 			Assert.AreEqual (3, db.Table<Issue96_A>().Where(p => p.ClassB == null).Count ());
 		}
+
+        public class Issue303_A
+        {
+            [PrimaryKey, NotNull]
+            public int Id { get; set; }
+            public string Name { get; set; }
+        }
+
+        public class Issue303_B
+        {
+            [PrimaryKey, NotNull]
+            public int Id { get; set; }
+            public bool Flag { get; set; }
+        }
+
+        [Test]
+        public void Issue303_WhereNot_A()
+        {
+            using (var db = new TestDb())
+            {
+                db.CreateTable<Issue303_A>();
+                db.Insert(new Issue303_A { Id = 1, Name = "aa" });
+                db.Insert(new Issue303_A { Id = 2, Name = null });
+                db.Insert(new Issue303_A { Id = 3, Name = "test" });
+                db.Insert(new Issue303_A { Id = 4, Name = null });
+
+                var r = (from p in db.Table<Issue303_A>() where !(p.Name == null) select p).ToList();
+                Assert.AreEqual(2, r.Count);
+                Assert.AreEqual(1, r[0].Id);
+                Assert.AreEqual(3, r[1].Id);
+            }
+        }
+
+        [Test]
+        public void Issue303_WhereNot_B()
+        {
+            using (var db = new TestDb())
+            {
+                db.CreateTable<Issue303_B>();
+                db.Insert(new Issue303_B { Id = 1, Flag = true });
+                db.Insert(new Issue303_B { Id = 2, Flag = false });
+                db.Insert(new Issue303_B { Id = 3, Flag = true });
+                db.Insert(new Issue303_B { Id = 4, Flag = false });
+
+                var r = (from p in db.Table<Issue303_B>() where !p.Flag select p).ToList();
+                Assert.AreEqual(2, r.Count);
+                Assert.AreEqual(2, r[0].Id);
+                Assert.AreEqual(4, r[1].Id);
+            }
+        }
 	}
 }


### PR DESCRIPTION
Just added a case for `ExpressionType.Not` in `CompileExpr`