### PR TITLE
Add versions of TableQuery.First* that take predicate

### DIFF
--- a/src/SQLite.cs
+++ b/src/SQLite.cs
@@ -2902,6 +2902,16 @@ namespace SQLite
 			var query = Take (1);
 			return query.ToList<T>().FirstOrDefault ();
 		}
+
+		public T First (Expression<Func<T, bool>> predExpr)
+		{
+			return Where (predExpr).First ();
+		}
+
+		public T FirstOrDefault (Expression<Func<T, bool>> predExpr)
+		{
+			return Where (predExpr).FirstOrDefault ();
+		}
     }
 
 	public static class SQLite3


### PR DESCRIPTION
It's entirely too easy to accidentally use the extension methods that
already exist, but they generate horrible queries that potentially
build enormous in-memory lists just to grab one element.