### PR TITLE
Throw exception if a new table would have no columns

### DIFF
--- a/src/SQLite.cs
+++ b/src/SQLite.cs
@@ -380,6 +380,10 @@ namespace SQLite
 				map = GetMapping (ty, createFlags);
 				_tables.Add (ty.FullName, map);
 			}
+			
+			if (map.Columns.Length == 0) {
+				throw new Exception(string.Format("Cannot create a table with zero columns (does '{0}' have public properties?)", ty.FullName));
+			}
 			var query = "create table if not exists \"" + map.TableName + "\"(\n";
 			
 			var decls = map.Columns.Select (p => Orm.SqlDecl (p, StoreDateTimeAsTicks));


### PR DESCRIPTION
I didn't realize that stored objects needed to have public properties and that fields wouldn't be used. What happens when a table mapping has no qualifying columns is that bad sql is generated and an obscure error is thrown when it's executed.

This PR adds an exception if the SQL will be malformed in this case.