### PR TITLE
Added the possibility to run InsertAll and UpdateAll without the transac...

### DIFF
--- a/src/SQLite.cs
+++ b/src/SQLite.cs
@@ -1084,18 +1084,27 @@ namespace SQLite
 		/// </summary>
 		/// <param name="objects">
 		/// An <see cref="IEnumerable"/> of the objects to insert.
+		/// <param name="runInTransaction"/>
+		/// A boolean indicating if the inserts should be wrapped in a transaction.
 		/// </param>
 		/// <returns>
 		/// The number of rows added to the table.
 		/// </returns>
-		public int InsertAll (System.Collections.IEnumerable objects)
+		public int InsertAll (System.Collections.IEnumerable objects, bool runInTransaction=true)
 		{
 			var c = 0;
-			RunInTransaction(() => {
+			if (runInTransaction) {
+				RunInTransaction(() => {
+					foreach (var r in objects) {
+						c += Insert (r);
+					}
+				});
+			}
+			else {
 				foreach (var r in objects) {
 					c += Insert (r);
 				}
-			});
+			}
 			return c;
 		}
 
@@ -1108,17 +1117,27 @@ namespace SQLite
 		/// <param name="extra">
 		/// Literal SQL code that gets placed into the command. INSERT {extra} INTO ...
 		/// </param>
+		/// <param name="runInTransaction"/>
+		/// A boolean indicating if the inserts should be wrapped in a transaction.
+		/// </param>
 		/// <returns>
 		/// The number of rows added to the table.
 		/// </returns>
-		public int InsertAll (System.Collections.IEnumerable objects, string extra)
+		public int InsertAll (System.Collections.IEnumerable objects, string extra, bool runInTransaction=true)
 		{
 			var c = 0;
-			RunInTransaction (() => {
+			if (runInTransaction) {
+				RunInTransaction (() => {
+					foreach (var r in objects) {
+						c += Insert (r, extra);
+					}
+				});
+			}
+			else {
 				foreach (var r in objects) {
-					c += Insert (r, extra);
+					c+= Insert (r);
 				}
-			});
+			}
 			return c;
 		}
 
@@ -1131,17 +1150,27 @@ namespace SQLite
 		/// <param name="objType">
 		/// The type of object to insert.
 		/// </param>
+		/// <param name="runInTransaction"/>
+		/// A boolean indicating if the inserts should be wrapped in a transaction.
+		/// </param>
 		/// <returns>
 		/// The number of rows added to the table.
 		/// </returns>
-		public int InsertAll (System.Collections.IEnumerable objects, Type objType)
+		public int InsertAll (System.Collections.IEnumerable objects, Type objType, bool runInTransaction=true)
 		{
 			var c = 0;
-			RunInTransaction (() => {
+			if (runInTransaction) {
+				RunInTransaction (() => {
+					foreach (var r in objects) {
+						c += Insert (r, objType);
+					}
+				});
+			}
+			else {
 				foreach (var r in objects) {
 					c += Insert (r, objType);
 				}
-			});
+			}
 			return c;
 		}
 		
@@ -1418,17 +1447,27 @@ namespace SQLite
 		/// <param name="objects">
 		/// An <see cref="IEnumerable"/> of the objects to insert.
 		/// </param>
+		/// <param name="runInTransaction"/>
+		/// A boolean indicating if the inserts should be wrapped in a transaction
+		/// </param>
 		/// <returns>
 		/// The number of rows modified.
 		/// </returns>
-		public int UpdateAll (System.Collections.IEnumerable objects)
+		public int UpdateAll (System.Collections.IEnumerable objects, bool runInTransaction=true)
 		{
 			var c = 0;
-			RunInTransaction (() => {
+			if (runInTransaction) {
+				RunInTransaction (() => {
+					foreach (var r in objects) {
+						c += Update (r);
+					}
+				});
+			}
+			else {
 				foreach (var r in objects) {
 					c += Update (r);
 				}
-			});
+			}
 			return c;
 		}
 


### PR DESCRIPTION
If you run multiple InsertAll or UpdateAll in a transaction, there should be possible to not run them in a nested transaction. Since there is a default value of true, this does not affect current users.