### PR TITLE
Justify use of string storage of DateTime by using ISO 8601 standard

### DIFF
--- a/src/SQLite.cs
+++ b/src/SQLite.cs
@@ -2317,7 +2317,7 @@ namespace SQLite
 						SQLite3.BindInt64 (stmt, index, ((DateTime)value).Ticks);
 					}
 					else {
-						SQLite3.BindText (stmt, index, ((DateTime)value).ToString ("yyyy-MM-dd HH:mm:ss"), -1, NegativePointer);
+                        SQLite3.BindText(stmt, index, ((DateTime)value).ToString("yyyy-MM-ddTHH:mm:ssK"), -1, NegativePointer);
 					}
 				} else if (value is DateTimeOffset) {
 					SQLite3.BindInt64 (stmt, index, ((DateTimeOffset)value).UtcTicks);


### PR DESCRIPTION
If ticks are faster and set by default, justify use of string storage of
DateTime values by including time zone information for higher temporal
accuracy.