### PR TITLE
Treat uint32 and int64 as SQLite integers

### DIFF
--- a/src/SQLite.cs
+++ b/src/SQLite.cs
@@ -2001,10 +2001,9 @@ namespace SQLite
 		public static string SqlType (TableMapping.Column p, bool storeDateTimeAsTicks)
 		{
 			var clrType = p.ColumnType;
-			if (clrType == typeof(Boolean) || clrType == typeof(Byte) || clrType == typeof(UInt16) || clrType == typeof(SByte) || clrType == typeof(Int16) || clrType == typeof(Int32)) {
+            if (clrType == typeof(Boolean) || clrType == typeof(Byte) || clrType == typeof(UInt16) || clrType == typeof(SByte) || clrType == typeof(Int16) || clrType == typeof(Int32) || clrType == typeof(UInt32) || clrType == typeof(Int64))
+            {
 				return "integer";
-			} else if (clrType == typeof(UInt32) || clrType == typeof(Int64)) {
-				return "bigint";
 			} else if (clrType == typeof(Single) || clrType == typeof(Double) || clrType == typeof(Decimal)) {
 				return "float";
 			} else if (clrType == typeof(String)) {


### PR DESCRIPTION
SQLite doesn't distinguish between int types,
it gladly stores between 1 and 64 bits of data
in an integer column without much fuss.

https://www.sqlite.org/datatype3.html

However, when setting an auto-incrementing PK,
the column must be explicitly typed as "integer"
within the SQL itself.

This fix passes the test suite on Win32/sqlite.dll
and when using CSharp-SQLite when specifying
USE_CSHARP_SQLITE as a build argument.