### PR TITLE
Allow expression-tree-compiler to read VB string comparisons

### DIFF
--- a/src/SQLite.cs
+++ b/src/SQLite.cs
@@ -2735,8 +2735,18 @@ namespace SQLite
 				throw new NotSupportedException ("Expression is NULL");
 			} else if (expr is BinaryExpression) {
 				var bin = (BinaryExpression)expr;
-				
-				var leftr = CompileExpr (bin.Left, queryArgs);
+
+                // VB turns 'x=="foo"' into 'CompareString(x,"foo",true/false)==0', so we need to unwrap it
+                // http://blogs.msdn.com/b/vbteam/archive/2007/09/18/vb-expression-trees-string-comparisons.aspx
+                if (bin.Left.NodeType == ExpressionType.Call) { 
+                    var call = (MethodCallExpression)bin.Left;
+                    if (call.Method.DeclaringType.FullName == "Microsoft.VisualBasic.CompilerServices.Operators"
+                        && call.Method.Name == "CompareString")
+                        bin = Expression.MakeBinary(bin.NodeType, call.Arguments[0], call.Arguments[1]);
+                }
+
+
+                var leftr = CompileExpr (bin.Left, queryArgs);
 				var rightr = CompileExpr (bin.Right, queryArgs);
 
 				//If either side is a parameter and is null, then handle the other side specially (for "is null"/"is not null")

--- a/src/SQLite.cs
+++ b/src/SQLite.cs
@@ -2736,17 +2736,17 @@ namespace SQLite
 			} else if (expr is BinaryExpression) {
 				var bin = (BinaryExpression)expr;
 
-                // VB turns 'x=="foo"' into 'CompareString(x,"foo",true/false)==0', so we need to unwrap it
-                // http://blogs.msdn.com/b/vbteam/archive/2007/09/18/vb-expression-trees-string-comparisons.aspx
-                if (bin.Left.NodeType == ExpressionType.Call) { 
-                    var call = (MethodCallExpression)bin.Left;
-                    if (call.Method.DeclaringType.FullName == "Microsoft.VisualBasic.CompilerServices.Operators"
-                        && call.Method.Name == "CompareString")
-                        bin = Expression.MakeBinary(bin.NodeType, call.Arguments[0], call.Arguments[1]);
-                }
+				// VB turns 'x=="foo"' into 'CompareString(x,"foo",true/false)==0', so we need to unwrap it
+				// http://blogs.msdn.com/b/vbteam/archive/2007/09/18/vb-expression-trees-string-comparisons.aspx
+				if (bin.Left.NodeType == ExpressionType.Call) { 
+					var call = (MethodCallExpression)bin.Left;
+					if (call.Method.DeclaringType.FullName == "Microsoft.VisualBasic.CompilerServices.Operators"
+						&& call.Method.Name == "CompareString")
+						bin = Expression.MakeBinary(bin.NodeType, call.Arguments[0], call.Arguments[1]);
+				}
 
 
-                var leftr = CompileExpr (bin.Left, queryArgs);
+				var leftr = CompileExpr (bin.Left, queryArgs);
 				var rightr = CompileExpr (bin.Right, queryArgs);
 
 				//If either side is a parameter and is null, then handle the other side specially (for "is null"/"is not null")

--- a/tests/SQLite.Tests.csproj
+++ b/tests/SQLite.Tests.csproj
@@ -31,6 +31,7 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="Microsoft.VisualBasic" />
     <Reference Include="nunit.framework, Version=2.4.8.0, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />

--- a/tests/StringQueryTest.cs
+++ b/tests/StringQueryTest.cs
@@ -33,29 +33,29 @@ namespace SQLite.Tests
 			db.InsertAll (prods);
 		}
 		
-        [Test]
-        public void StringEquals ()
-        {
-            // C#: x => x.Name == "Foo"
-            var fs = db.Table<Product>().Where(x => x.Name == "Foo").ToList();
-            Assert.AreEqual(1, fs.Count);
+		[Test]
+		public void StringEquals ()
+		{
+			// C#: x => x.Name == "Foo"
+			var fs = db.Table<Product>().Where(x => x.Name == "Foo").ToList();
+			Assert.AreEqual(1, fs.Count);
+			
+			// VB: Function(x) x.Name = "Foo"
+			var param = System.Linq.Expressions.Expression.Parameter(typeof(Product), "x");
+			var expr = System.Linq.Expressions.Expression.Lambda<Func<Product, bool>>(
+				System.Linq.Expressions.Expression.Equal(
+					System.Linq.Expressions.Expression.Call(
+						typeof(Microsoft.VisualBasic.CompilerServices.Operators).GetMethod("CompareString"),
+						System.Linq.Expressions.Expression.MakeMemberAccess(param, typeof(Product).GetMember("Name").First()),
+						System.Linq.Expressions.Expression.Constant("Foo"),
+						System.Linq.Expressions.Expression.Constant(false)), // Option Compare Binary (false) or Text (true)
+					System.Linq.Expressions.Expression.Constant(0)),
+				param);
+			var bs = db.Table<Product>().Where(expr).ToList();
+			Assert.AreEqual(1, bs.Count);
+		}
 
-            // VB: Function(x) x.Name = "Foo"
-            var param = System.Linq.Expressions.Expression.Parameter(typeof(Product), "x");
-            var expr = System.Linq.Expressions.Expression.Lambda<Func<Product, bool>>(
-                System.Linq.Expressions.Expression.Equal(
-                    System.Linq.Expressions.Expression.Call(
-                        typeof(Microsoft.VisualBasic.CompilerServices.Operators).GetMethod("CompareString"),
-                        System.Linq.Expressions.Expression.MakeMemberAccess(param, typeof(Product).GetMember("Name").First()),
-                        System.Linq.Expressions.Expression.Constant("Foo"),
-                        System.Linq.Expressions.Expression.Constant(false)), // Option Compare Binary (false) or Text (true)
-                    System.Linq.Expressions.Expression.Constant(0)),
-                param);
-            var bs = db.Table<Product>().Where(expr).ToList();
-            Assert.AreEqual(1, bs.Count);
-        }
-
-        [Test]
+		[Test]
 		public void StartsWith ()
 		{
 			var fs = db.Table<Product> ().Where (x => x.Name.StartsWith ("F")).ToList ();

--- a/tests/StringQueryTest.cs
+++ b/tests/StringQueryTest.cs
@@ -33,7 +33,29 @@ namespace SQLite.Tests
 			db.InsertAll (prods);
 		}
 		
-		[Test]
+        [Test]
+        public void StringEquals ()
+        {
+            // C#: x => x.Name == "Foo"
+            var fs = db.Table<Product>().Where(x => x.Name == "Foo").ToList();
+            Assert.AreEqual(1, fs.Count);
+
+            // VB: Function(x) x.Name = "Foo"
+            var param = System.Linq.Expressions.Expression.Parameter(typeof(Product), "x");
+            var expr = System.Linq.Expressions.Expression.Lambda<Func<Product, bool>>(
+                System.Linq.Expressions.Expression.Equal(
+                    System.Linq.Expressions.Expression.Call(
+                        typeof(Microsoft.VisualBasic.CompilerServices.Operators).GetMethod("CompareString"),
+                        System.Linq.Expressions.Expression.MakeMemberAccess(param, typeof(Product).GetMember("Name").First()),
+                        System.Linq.Expressions.Expression.Constant("Foo"),
+                        System.Linq.Expressions.Expression.Constant(false)), // Option Compare Binary (false) or Text (true)
+                    System.Linq.Expressions.Expression.Constant(0)),
+                param);
+            var bs = db.Table<Product>().Where(expr).ToList();
+            Assert.AreEqual(1, bs.Count);
+        }
+
+        [Test]
 		public void StartsWith ()
 		{
 			var fs = db.Table<Product> ().Where (x => x.Name.StartsWith ("F")).ToList ();


### PR DESCRIPTION
Fix for issue #121 

The C# compiler turns `x => x == "Foo"` into a simple expression tree
```cs
Equals(Parameter "x", Constant "Foo")`
```

But the VB compiler turns `Function(x) x = "Foo"` into a call to a helper method as below. It passes either `true` or `false` to the helper method depending on whether the user wrote `Option Compare Binary` (case-sensitive) or `Option Compare Text` (case insensitive).
```cs
Equals(Call[CompareString](Parameter "x", Constant "Foo", true/false), Constant 0)
```

That's why SQLite gives an error message "method CompareString not recognized".

The solution is explained by formed VB compiler team lead Timothy Ng:
http://blogs.msdn.com/b/vbteam/archive/2007/09/18/vb-expression-trees-string-comparisons.aspx

He writes, "if your provider doesn't care about string comparison semantics (LINQ to SQL, for example, doesn't care), then you can use the following code to transform the binary operator for the method call to a binary operator for the method call arguments, ignoring the string comparison semantics."

Note: I added a reference to Microsoft.VisualBasic.dll in the test project, so as to be able to write the unit-test. If this isn't wanted, I could instead define the Microsoft.VisualBasic.CompilerServices.Operators.CompareString method right in the unit-tests.