### PR TITLE
Added FirstOrDefault(Expression) and First(Expression) Support

### DIFF
--- a/src/SQLite.cs
+++ b/src/SQLite.cs
@@ -2989,6 +2989,16 @@ namespace SQLite
 			var query = Take (1);
 			return query.ToList<T>().FirstOrDefault ();
 		}
+		
+	        public T FirstOrDefault(Expression<Func<T, bool>> predExpr)
+	        {
+	            return Where(predExpr).FirstOrDefault();
+	        }
+	
+	        public T First(Expression<Func<T, bool>> predExpr)
+	        {
+	            return Where(predExpr).First();
+	        }
     }
 
 	public static class SQLite3


### PR DESCRIPTION
Not having this was causing memory leak issues when ReSharper suggested that this:
```csharp
            return Connection.Table<DownloadRecord>()
                .Where(x => x.Status < FinalizedTransferStatusStartValue)
                .FirstOrDefault();
```

Should be changed to:
```csharp
            return Connection.Table<DownloadRecord>()
                .FirstOrDefault(x => x.Status < FinalizedTransferStatusStartValue);
```

The current code downloads the entire database into a List<T> and then executes the query in memory.