### PR TITLE
Implement SQLiteAsyncConnection.ResetPool()

### DIFF
--- a/src/SQLiteAsync.cs
+++ b/src/SQLiteAsync.cs
@@ -46,6 +46,11 @@ namespace SQLite
             _connectionString = new SQLiteConnectionString(databasePath, storeDateTimeAsTicks);
         }
 
+		public static void ResetPool()
+		{
+			SQLiteConnectionPool.Shared.Reset();
+		}
+
 		SQLiteConnectionWithLock GetConnection ()
 		{
 			return SQLiteConnectionPool.Shared.GetConnection (_connectionString, _openFlags);


### PR DESCRIPTION
Hi Frank,

I would like to support deleting my database file and creating it again, but the connection pooling is causing sqlite-net to keep a reference to the deleted file, which is leading to read only errors later on.

It seems I need to use the SQLiteConnectionPool.Shared.Reset() method after I Delete the file, but the SQLiteConnectionPool class has been made internal in the sqlite-net implementation, preventing use.

I have been unable to find any other way to clear the connection pool that references the old DB file.

I noticed the following patch was submitted, but there were concerns with the implementation there:
https://github.com/praeclarum/sqlite-net/pull/320

I am hoping that my pull request may be easier to accept, as it contains far less significant changes.

Thanks,
Ryan