### PR TITLE
In-memory capability for NETFX_CORE

### DIFF
--- a/src/SQLite.cs
+++ b/src/SQLite.cs
@@ -1657,17 +1657,32 @@ namespace SQLite
 
 #if NETFX_CORE
 		static readonly string MetroStyleDataPath = Windows.Storage.ApplicationData.Current.LocalFolder.Path;
+
+        public static readonly string[] InMemoryDbPaths = new[]
+        {
+            ":memory:",
+            "file::memory:"
+        };
+
+        public static bool IsInMemoryPath(string databasePath)
+        {
+            return InMemoryDbPaths.Any(i => i.Equals(databasePath, StringComparison.OrdinalIgnoreCase));
+        }
+
 #endif
 
-		public SQLiteConnectionString (string databasePath, bool storeDateTimeAsTicks)
+        public SQLiteConnectionString (string databasePath, bool storeDateTimeAsTicks)
 		{
 			ConnectionString = databasePath;
 			StoreDateTimeAsTicks = storeDateTimeAsTicks;
 
 #if NETFX_CORE
-			DatabasePath = System.IO.Path.Combine (MetroStyleDataPath, databasePath);
+			DatabasePath = IsInMemoryPath(databasePath)
+                ? databasePath
+                : System.IO.Path.Combine(MetroStyleDataPath, databasePath);
+
 #else
-			DatabasePath = databasePath;
+            DatabasePath = databasePath;
 #endif
 		}
 	}


### PR DESCRIPTION
On other platforms I have been able to use sqlite as an in-memory database, which is very handy for integration testing.

With sqlite-net this is not possible out-of-the-box on the  NETFX_CORE-platform, as it is hard-wired to Windows.Storage.ApplicationData.Current.LocalFolder.Path.

This pull request enables the in-memory capability by creating a connection like this: 

`var connection = new SQLiteAsyncConnection(":memory:");`

(based on [https://www.sqlite.org/inmemorydb.html](https://www.sqlite.org/inmemorydb.html))

Best regards
Tommy Wendelborg