### PR TITLE
Comparing the column name in LowerCase.

### DIFF
--- a/src/SQLite.cs
+++ b/src/SQLite.cs
@@ -1887,7 +1887,7 @@ namespace SQLite
 
 		public Column FindColumn (string columnName)
 		{
-			var exact = Columns.FirstOrDefault (c => c.Name == columnName);
+			var exact = Columns.FirstOrDefault (c => c.Name.ToLower() == columnName.ToLower());
 			return exact;
 		}
 


### PR DESCRIPTION
The FindColumn used by the ExecuteDeferredQuery will now compare the columns in lower case, because if the Property or MappedColumnName is different of the Table column name, the value of that column will be null.