### PR TITLE
fix for bundle_green ByteArray Empty vs null test

### DIFF
--- a/src/SQLite.cs
+++ b/src/SQLite.cs
@@ -3575,7 +3575,12 @@ namespace SQLite
 
 		public static byte[] ColumnByteArray(Sqlite3Statement stmt, int index)
 		{
-			return ColumnBlob(stmt, index);
+			int length = ColumnBytes(stmt, index);
+			if (length > 0)
+			{
+				return ColumnBlob(stmt, index);
+			}
+			return new byte[0];
 		}
 
 #if !USE_SQLITEPCL_RAW


### PR DESCRIPTION
for issue #488 

ColumnBlob returns null, but in this case we want to return an empty byte[]