### PR TITLE
Add Xamarin.mac support, bump to SQLitePCLRaw 1.1.1

### DIFF
--- a/nuget/SQLite-net/packages.config
+++ b/nuget/SQLite-net/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="SQLitePCLRaw.bundle_green" version="1.1.0" targetFramework="portable45-net45+win8+wp8+wpa81" />
-  <package id="SQLitePCLRaw.core" version="1.1.0" targetFramework="portable45-net45+win8+wp8+wpa81" />
+  <package id="SQLitePCLRaw.bundle_green" version="1.1.1" targetFramework="portable45-net45+win8+wp8+wpa81" />
+  <package id="SQLitePCLRaw.core" version="1.1.1" targetFramework="portable45-net45+win8+wp8+wpa81" />
 </packages>

--- a/sqlite-net-pcl.nuspec
+++ b/sqlite-net-pcl.nuspec
@@ -19,12 +19,12 @@
     ]]>
     </releaseNotes>
     <dependencies>
-      <dependency id="SQLitePCLRaw.bundle_green" version="1.1.0" />
+      <dependency id="SQLitePCLRaw.bundle_green" version="1.1.1" />
     </dependencies>
   </metadata>
   <files>
-    <file src="nuget/SQLite-net/bin/Release/SQLite-net.dll" target="lib/portable-net45+wp8+wpa81+win8+MonoAndroid10+MonoTouch10+Xamarin.iOS10" />
-    <file src="nuget/SQLite-net/bin/Release/SQLite-net.dll.mdb" target="lib/portable-net45+wp8+wpa81+win8+MonoAndroid10+MonoTouch10+Xamarin.iOS10" />
-    <file src="nuget/SQLite-net/bin/Release/SQLite-net.xml" target="lib/portable-net45+wp8+wpa81+win8+MonoAndroid10+MonoTouch10+Xamarin.iOS10" />
+    <file src="nuget/SQLite-net/bin/Release/SQLite-net.dll" target="lib/portable-net45+wp8+wpa81+win8+MonoAndroid10+MonoTouch10+Xamarin.iOS10+xamarinmac20" />
+    <file src="nuget/SQLite-net/bin/Release/SQLite-net.dll.mdb" target="lib/portable-net45+wp8+wpa81+win8+MonoAndroid10+MonoTouch10+Xamarin.iOS10+xamarinmac20" />
+    <file src="nuget/SQLite-net/bin/Release/SQLite-net.xml" target="lib/portable-net45+wp8+wpa81+win8+MonoAndroid10+MonoTouch10+Xamarin.iOS10+xamarinmac20" />
   </files>
 </package>

--- a/src/SQLite.cs
+++ b/src/SQLite.cs
@@ -238,8 +238,8 @@ namespace SQLite
 			
 			BusyTimeout = TimeSpan.FromSeconds (0.1);
 		}
-		
-#if __IOS__
+
+#if __IOS__ || __UNIFIED__
 		static SQLiteConnection ()
 		{
 			if (_preserveDuringLinkMagic) {


### PR DESCRIPTION
This pr's adds support to install the package on Xamarin.Mac unified application.

Also bumps support on SQLitePCLRaw since on 1.1.1 they are also now supporting Mac OSX. 

Fixes #483 