### PR TITLE
Added support for scalar queries.

### DIFF
--- a/src/SQLite.cs
+++ b/src/SQLite.cs
@@ -2245,11 +2245,19 @@ namespace SQLite
 
 		public IEnumerable<T> ExecuteDeferredQuery<T> ()
 		{
+			if (IsScalarType(typeof(T)))
+			{
+				return ExecuteDeferredScalarQuery<T>();
+			}
 			return ExecuteDeferredQuery<T>(_conn.GetMapping(typeof(T)));
 		}
 
 		public List<T> ExecuteQuery<T> ()
 		{
+			if (IsScalarType(typeof(T)))
+			{
+				return ExecuteDeferredScalarQuery<T>().ToList();
+			}
 			return ExecuteDeferredQuery<T>(_conn.GetMapping(typeof(T))).ToList();
 		}
 
@@ -2302,6 +2310,28 @@ namespace SQLite
  					}
 					OnInstanceCreated (obj);
 					yield return (T)obj;
+				}
+			}
+			finally
+			{
+				SQLite3.Finalize(stmt);
+			}
+		}
+
+		public IEnumerable<T> ExecuteDeferredScalarQuery<T>()
+		{
+			if (_conn.Trace)
+			{
+				Debug.WriteLine("Executing Query: " + this);
+			}
+
+			var stmt = Prepare();
+			try
+			{
+				while (SQLite3.Step(stmt) == SQLite3.Result.Row)
+				{
+					var colType = SQLite3.ColumnType(stmt, 0);
+					yield return (T)ReadCol(stmt, 0, colType, typeof(T));
 				}
 			}
 			finally
@@ -2521,6 +2551,21 @@ namespace SQLite
 					throw new NotSupportedException ("Don't know how to read " + clrType);
 				}
 			}
+		}
+
+		// Returns true if the Type can be return from a single column.
+		bool IsScalarType(Type clrType)
+		{
+			if (clrType == typeof(string) || clrType == typeof(byte[])) {
+				return true;
+#if !USE_NEW_REFLECTION_API
+			} else if (clrType.IsEnum || clrType.IsValueType) {
+#else
+			} else if (clrType.GetTypeInfo().IsEnum || clrType.GetTypeInfo().IsValueType) {
+#endif
+				return true;
+			}
+			return false;
 		}
 	}
 

--- a/src/SQLite.cs
+++ b/src/SQLite.cs
@@ -2245,8 +2245,7 @@ namespace SQLite
 
 		public IEnumerable<T> ExecuteDeferredQuery<T> ()
 		{
-			if (IsScalarType(typeof(T)))
-			{
+			if (IsScalarType(typeof(T))) {
 				return ExecuteDeferredScalarQuery<T>();
 			}
 			return ExecuteDeferredQuery<T>(_conn.GetMapping(typeof(T)));
@@ -2254,8 +2253,7 @@ namespace SQLite
 
 		public List<T> ExecuteQuery<T> ()
 		{
-			if (IsScalarType(typeof(T)))
-			{
+			if (IsScalarType(typeof(T))) {
 				return ExecuteDeferredScalarQuery<T>().ToList();
 			}
 			return ExecuteDeferredQuery<T>(_conn.GetMapping(typeof(T))).ToList();
@@ -2320,16 +2318,14 @@ namespace SQLite
 
 		public IEnumerable<T> ExecuteDeferredScalarQuery<T>()
 		{
-			if (_conn.Trace)
-			{
+			if (_conn.Trace) {
 				Debug.WriteLine("Executing Query: " + this);
 			}
 
 			var stmt = Prepare();
 			try
 			{
-				while (SQLite3.Step(stmt) == SQLite3.Result.Row)
-				{
+				while (SQLite3.Step(stmt) == SQLite3.Result.Row) {
 					var colType = SQLite3.ColumnType(stmt, 0);
 					yield return (T)ReadCol(stmt, 0, colType, typeof(T));
 				}

--- a/tests/ScalarTest.cs
+++ b/tests/ScalarTest.cs
@@ -45,6 +45,20 @@ namespace SQLite.Tests
 
 			Assert.AreEqual (Count * 2, r);
 		}
+
+		[Test]
+		public void Int32s()
+		{
+			var db = CreateDb ();
+
+			var results = db.Query<int>("SELECT Id FROM TestTable");
+
+			int id = 1;
+			foreach (var r in results)
+			{
+				Assert.AreEqual(id++, r);
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
Fix #497
For examples getting a list of integers.
Normally, it would require load a list of the table's Type then use only one property.
This allows for only one column to be loaded by itself.