### PR TITLE
Boxing required in EnumCacheInfo to avoid invalid cast exception

### DIFF
--- a/src/SQLite.cs
+++ b/src/SQLite.cs
@@ -2028,9 +2028,9 @@ namespace SQLite
 
             if (IsEnum)
             {
-                // This is a big assumption, but for now support ints only as key, otherwise we still
-                // have to pay the price for boxing
-                EnumValues = Enum.GetValues(type).Cast<int>().ToDictionary(x => x, x => x.ToString());
+                // Boxing required to avoid invalid cast exception
+                EnumValues = Enum.GetValues(type).Cast<object>().ToDictionary(Convert.ToInt32, x => Convert.ToInt32(x).ToString());
+
 
 #if !USE_NEW_REFLECTION_API
                 StoreAsText = type.GetCustomAttribute(typeof(StoreAsTextAttribute), false) != null;

--- a/tests/EnumCacheTest.cs
+++ b/tests/EnumCacheTest.cs
@@ -37,6 +37,16 @@ namespace SQLite.Tests
             Value3
         }
 
+        public enum TestByteEnumStoreAsInt : byte
+        {
+            Value1,
+
+            Value2,
+
+            Value3
+        }
+
+
         public class TestClassThusNotEnum
         {
 
@@ -69,6 +79,23 @@ namespace SQLite.Tests
             Assert.IsNotNull(info.EnumValues);
 
             var values = Enum.GetValues(typeof(TestEnumStoreAsInt)).Cast<int>().ToList();
+
+            for (int i = 0; i < values.Count; i++)
+            {
+                Assert.AreEqual(values[i].ToString(), info.EnumValues[i]);
+            }
+        }
+
+        [Test]
+        public void ShouldReturnTrueForByteEnumStoreAsInt()
+        {
+            var info = EnumCache.GetInfo<TestByteEnumStoreAsInt>();
+
+            Assert.IsTrue(info.IsEnum);
+            Assert.IsFalse(info.StoreAsText);
+            Assert.IsNotNull(info.EnumValues);
+
+            var values = Enum.GetValues(typeof(TestByteEnumStoreAsInt)).Cast<object>().Select(x=>Convert.ToInt32(x)).ToList();
 
             for (int i = 0; i < values.Count; i++)
             {


### PR DESCRIPTION
I created a test to expose the InvalidCastException issue ( #531 ) and created a patch. However I have not investigated the performance implications.