### PR TITLE
Added Fluent API

### DIFF
--- a/src/SQLite.cs
+++ b/src/SQLite.cs
@@ -2292,7 +2292,7 @@ namespace SQLite
 		/// <returns>
 		/// The number of entries added to the database schema.
 		/// </returns>
-		public int CreateTable()
+		public int CreateTable(CreateFlags createFlags = CreateFlags.None)
 		{
 			var tableMapping = new TableMapping(MappedType, _tableName ?? MappedType.Name);
 
@@ -2359,7 +2359,7 @@ namespace SQLite
 
 			_sqlite.AddMapping(tableMapping);
 
-			return _sqlite.CreateTable(tableMapping.MappedType);
+			return _sqlite.CreateTable(tableMapping.MappedType, createFlags);
 		}
 	}
 

--- a/src/SQLite.cs
+++ b/src/SQLite.cs
@@ -2064,6 +2064,48 @@ namespace SQLite
 		}
 	}
 
+	public static class TableMappingFluentExtensions
+	{
+		public static PropertyInfo AsPropertyInfo<TEntity>(this Expression<Func<TEntity, object>> property)
+		{
+			Expression body = property.Body;
+			var operand = (body as UnaryExpression)?.Operand as MemberExpression;
+			if (operand != null) {
+				body = operand;
+			}
+			return (body as MemberExpression)?.Member as PropertyInfo;
+		}
+
+		public static void AddPropertyValue<T, TEntity>(this Dictionary<PropertyInfo, T> dict, Expression<Func<TEntity, object>> property, T value)
+		{
+			var prop = AsPropertyInfo(property);
+			dict[prop] = value;
+		}
+
+		public static void AddProperty<TEntity>(this List<PropertyInfo> list, Expression<Func<TEntity, object>> property)
+		{
+			var prop = AsPropertyInfo(property);
+			if (!list.Contains(prop)) {
+				list.Add(prop);
+			}
+		}
+
+		public static void AddProperties<TEntity>(this List<PropertyInfo> list, Expression<Func<TEntity, object>>[] properties)
+		{
+			foreach (var property in properties) {
+				AddProperty(list, property);
+			}
+		}
+
+		public static T GetOrDefault<T>(this Dictionary<PropertyInfo, T> dict, PropertyInfo key, T defaultValue = default(T))
+		{
+			if (dict.ContainsKey(key)) {
+				return dict[key];
+			}
+			return defaultValue;
+		}
+	}
+
     internal class EnumCacheInfo
     {
         public EnumCacheInfo(Type type)

--- a/src/SQLite.cs
+++ b/src/SQLite.cs
@@ -350,6 +350,17 @@ namespace SQLite
 			_mappings[tableMapping.MappedType.FullName] = tableMapping;
 		}
 
+		/// <summary>
+		/// Returns a TableMappingBuilder for constructing table mappings with a fluent API.
+		/// Please note: the SQLite attributes on the type's properties will be ignored if this method is used.
+		/// </summary>
+		/// <typeparam name="T">The entity type to create a table for.</typeparam>
+		/// <returns>The table mapping builder.</returns>
+		public TableMappingBuilder<T> BuildMapping<T>()
+		{
+			return new TableMappingBuilder<T>(this);
+		}
+
 		private struct IndexedColumn
 		{
 			public int Order;

--- a/src/SQLite.cs
+++ b/src/SQLite.cs
@@ -1719,8 +1719,15 @@ namespace SQLite
 	{
 	}
 
+	public interface IColumnIndex
+	{
+		string Name { get; set; }
+		int Order { get; set; }
+		bool Unique { get; set; }
+	}
+
 	[AttributeUsage (AttributeTargets.Property)]
-	public class IndexedAttribute : Attribute
+	public class IndexedAttribute : Attribute, IColumnIndex
 	{
 		public string Name { get; set; }
 		public int Order { get; set; }
@@ -1735,6 +1742,13 @@ namespace SQLite
 			Name = name;
 			Order = order;
 		}
+	}
+
+	public class ColumnIndex : IColumnIndex
+	{
+		public string Name { get; set; }
+		public int Order { get; set; }
+		public bool Unique { get; set; }
 	}
 
 	[AttributeUsage (AttributeTargets.Property)]

--- a/src/SQLite.cs
+++ b/src/SQLite.cs
@@ -338,6 +338,18 @@ namespace SQLite
 			return GetMapping (typeof (T));
 		}
 
+		/// <summary>
+		/// Adds a mapping to be used for indexes and naming for the given type.
+		/// </summary>
+		/// <param name="tableMapping">The table mapping.</param>
+		internal void AddMapping(TableMapping tableMapping)
+		{
+			if (_mappings == null) {
+				_mappings = new Dictionary<string, TableMapping>();
+			}
+			_mappings[tableMapping.MappedType.FullName] = tableMapping;
+		}
+
 		private struct IndexedColumn
 		{
 			public int Order;


### PR DESCRIPTION
The changes made in this pull request allow tables to be created using a Fluent API with attribute-free objects (aka POCOs). This allows for cleaner separation of layers and aids dependency injection by not requiring references to sqlite-net to decorate model classes.

Example usage:

```
connection.BuildMapping<SampleEntity>()
		  .TableName("ExampleTable")
		  .PrimaryKey(x => x.Key)
		  .CreateTable();

connection.BuildMapping<SampleEntity2>()
		  .TableName("Users")
		  .PrimaryKey(x => x.Id)
		  .AutoIncrement(x => x.Id)
		  .ColumnName(x => x.PasswordHash, "Password")
		  .Unique(x => x.Username)
		  .CreateTable();

connection.BuildMapping<SampleEntity3>()
		  .TableName("Contacts")
		  .Index("ix_full", x => x.Name, x => x.Email, x => x.Telephone)
		  .PrimaryKey(x => x.Id, true)
		  .MaxLength(x => x.Email, 255)
		  .NotNull(x => x.Email)
		  .Ignore(x => x.SecretMessage)
		  .CreateTable();
```
Based on the following example plain model classes...

```
public class SampleEntity
{
	public string Key { get; set; }

	public string Value { get; set; }
}

public class SampleEntity2
{
	public int Id { get; set; }

	public string Username { get; set; }

	public string PasswordHash { get; set; }
}

public class SampleEntity3
{
	public int Id { get; set; }

	public string Name { get; set; }

	public string Email { get; set; }

	public string Telephone { get; set; }

	public string SecretMessage { get; set; }
}
```

Note: CreateTable() must be called to trigger the creation of the mapping and resulting table. 

The additional code recycles existing functionality for creating table mappings from attributes.