### PR TITLE
Add support for custom serializers

### DIFF
--- a/tests/TestDb.cs
+++ b/tests/TestDb.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 
 #if NETFX_CORE
@@ -53,7 +54,7 @@ namespace SQLite.Tests
 
 	public class TestDb : SQLiteConnection
 	{
-		public TestDb (bool storeDateTimeAsTicks = true) : base (TestPath.GetTempFileName (), storeDateTimeAsTicks)
+		public TestDb (bool storeDateTimeAsTicks = true, IReadOnlyList<SQLSerializer> serializers = null) : base (TestPath.GetTempFileName (), storeDateTimeAsTicks, serializers)
 		{
 			Trace = true;
 		}


### PR DESCRIPTION
With this change, people can introduce custom serializers for custom types which allows support for more complex types without creating intermediate objects.

``` C#
class Address
{
	public string FullAddress { get; set; }
}

class Person
{
	public Guid Id { get; set; }
	public Address Address { get; set; }
}

// Then we could just create a db with serializer
var db = new SqliteConnection(serializers: new[] { AddressSerializer, CustomGuidSerializer });
db.CreateTable<Person>();
db.Insert(new Person
{
	Id = Guid.NewGuid(),
	Address = new Address { FullAddress = "Some Place" },
});

// Assuming these are the serializers
static readonly SQLSerializer AddressSerializer = SQLSerializer.Create<Address, string>(
	toSQL: address => address.FullAddress,
	fromSQL: s => new Address { FullAddress = s });

static readonly SQLSerializer CustomGuidSerializer = SQLSerializer.Create<Guid, string>(
	toSQL: guid => guid.ToString(),
	fromSQL: s => Guid.Parse(s));
```
I also fixed some of the warnings in the xml documentation