### PR TITLE
Concurrency Test to prove failure on iOS

### DIFF
--- a/tests/ConcurrencyTest.cs
+++ b/tests/ConcurrencyTest.cs
@@ -1,0 +1,189 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using System.IO;
+
+#if NETFX_CORE
+using Microsoft.VisualStudio.TestPlatform.UnitTestFramework;
+using SetUp = Microsoft.VisualStudio.TestPlatform.UnitTestFramework.TestInitializeAttribute;
+using TearDown = Microsoft.VisualStudio.TestPlatform.UnitTestFramework.TestCleanupAttribute;
+using TestFixture = Microsoft.VisualStudio.TestPlatform.UnitTestFramework.TestClassAttribute;
+using Test = Microsoft.VisualStudio.TestPlatform.UnitTestFramework.TestMethodAttribute;
+#else
+using NUnit.Framework;
+#endif
+
+namespace SQLite.Tests
+{
+    [TestFixture]
+    public class ConcurrencyTest
+    {
+        public class TestObj
+        {
+            [AutoIncrement, PrimaryKey]
+            public int Id { get; set; }
+
+            public override string ToString()
+            {
+                return string.Format("[TestObj: Id={0}]", Id);
+            }
+        }
+
+        public class DbReader
+        {
+            private CancellationToken cancellationToken;
+
+            public DbReader(CancellationToken cancellationToken)
+            {
+                this.cancellationToken = cancellationToken;
+            }
+
+            public Task Run()
+            {
+                var t = Task.Run(() =>
+                {
+                    try
+                    {
+                        while (true)
+                        {
+                            //
+                            // NOTE: Change this to readwrite and then it does work ???
+                            // No more IOERROR
+                            // 
+                        
+                            using (var dbConnection = new DbConnection(SQLiteOpenFlags.FullMutex | SQLiteOpenFlags.ReadOnly))
+                            {
+                                var records = dbConnection.Table<TestObj>().ToList();
+                                System.Diagnostics.Debug.WriteLine($"{Environment.CurrentManagedThreadId} Read records: {records.Count}");
+                            }
+
+                            // No await so we stay on the same thread
+                            Task.Delay(10).GetAwaiter().GetResult();
+                            cancellationToken.ThrowIfCancellationRequested();
+                        }
+                    }
+                    catch (OperationCanceledException)
+                    {
+                    }
+                });
+
+                return t;
+            }
+
+        }
+
+        public class DbWriter
+        {
+            private CancellationToken cancellationToken;
+
+            public DbWriter(CancellationToken cancellationToken)
+            {
+                this.cancellationToken = cancellationToken;
+            }
+
+            public Task Run()
+            {
+                var t = Task.Run(() =>
+                {
+                    try
+                    {
+                        while (true)
+                        {
+                            using (var dbConnection = new DbConnection(SQLiteOpenFlags.FullMutex | SQLiteOpenFlags.ReadWrite))
+                            {
+                                System.Diagnostics.Debug.WriteLine($"{Environment.CurrentManagedThreadId} Start insert");
+
+                                for (var i = 0; i < 50; i++)
+                                {
+                                    var newRecord = new TestObj()
+                                    {
+                                    };
+
+                                    dbConnection.Insert(newRecord);
+                                }
+
+                                System.Diagnostics.Debug.WriteLine($"{Environment.CurrentManagedThreadId} Inserted records");
+                            }
+
+                            // No await so we stay on the same thread
+                            Task.Delay(1).GetAwaiter().GetResult();
+                            cancellationToken.ThrowIfCancellationRequested();
+                        }
+                    }
+                    catch (OperationCanceledException)
+                    {
+                    }
+                });
+
+                return t;
+            }
+
+        }
+
+        public class DbConnection : SQLiteConnection
+        {
+            private static string DbPath = GetTempFileName();
+
+            private static string GetTempFileName()
+            {
+#if NETFX_CORE
+                var name = Guid.NewGuid() + ".sqlite";
+                return Path.Combine(Windows.Storage.ApplicationData.Current.LocalFolder.Path, name);
+#else
+                return Path.GetTempFileName();
+#endif
+            }
+
+
+            public DbConnection(SQLiteOpenFlags openflags) : base(DbPath, openflags)
+            {
+                this.BusyTimeout = TimeSpan.FromSeconds(5);
+            }
+
+            public void CreateTables()
+            {
+                CreateTable<TestObj>();
+            }
+        }
+
+        [SetUp]
+        public void Setup()
+        {
+            using (var dbConenction = new DbConnection(SQLiteOpenFlags.FullMutex | SQLiteOpenFlags.ReadWrite | SQLiteOpenFlags.Create))
+            {
+                dbConenction.CreateTables();
+            }
+        }
+
+
+        [Test]
+        public void TestLoad()
+        {
+            try
+            {
+                //var result = SQLitePCL.raw.sqlite3_threadsafe();
+                //Assert.AreEqual(2, result);
+                // Yes it's threadsafe on iOS
+
+                var tokenSource = new CancellationTokenSource();
+                var tasks = new List<Task>();
+                tasks.Add(new DbReader(tokenSource.Token).Run());
+                tasks.Add(new DbWriter(tokenSource.Token).Run());
+
+                // Wait 5sec
+                tokenSource.CancelAfter(5000);
+
+                Task.WhenAll(tasks).GetAwaiter().GetResult();
+            }
+            catch (Exception ex)
+            {
+                Assert.Fail(ex.ToString());
+            }
+        }
+
+
+    }
+}
+

--- a/tests/SQLite.Tests.csproj
+++ b/tests/SQLite.Tests.csproj
@@ -43,6 +43,7 @@
     <Compile Include="BooleanTest.cs" />
     <Compile Include="..\src\SQLite.cs" />
     <Compile Include="ByteArrayTest.cs" />
+    <Compile Include="ConcurrencyTest.cs" />
     <Compile Include="EnumCacheTest.cs" />
     <Compile Include="EnumTest.cs" />
     <Compile Include="ExceptionAssert.cs" />

--- a/tests/SQLite.Tests.iOS/SQLite.Tests.iOS.csproj
+++ b/tests/SQLite.Tests.iOS/SQLite.Tests.iOS.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -33,7 +33,8 @@
     <DeviceSpecificBuild>false</DeviceSpecificBuild>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhone' ">
-    <DebugType></DebugType>
+    <DebugType>
+    </DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\iPhone\Release</OutputPath>
     <DefineConstants>__UNIFIED__;__MOBILE__;__IOS__;NO_VB</DefineConstants>
@@ -43,14 +44,16 @@
     <MtouchUseSGen>true</MtouchUseSGen>
     <MtouchUseRefCounting>true</MtouchUseRefCounting>
     <MtouchFloat32>true</MtouchFloat32>
-    <CodesignEntitlements></CodesignEntitlements>
+    <CodesignEntitlements>
+    </CodesignEntitlements>
     <MtouchLink>SdkOnly</MtouchLink>
     <MtouchArch>ARMv7, ARM64</MtouchArch>
     <MtouchHttpClientHandler>HttpClientHandler</MtouchHttpClientHandler>
     <MtouchTlsProvider>Default</MtouchTlsProvider>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhoneSimulator' ">
-    <DebugType></DebugType>
+    <DebugType>
+    </DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\iPhoneSimulator\Release</OutputPath>
     <DefineConstants>__UNIFIED__;__MOBILE__;__IOS__;NO_VB</DefineConstants>
@@ -80,7 +83,8 @@
     <MtouchUseSGen>true</MtouchUseSGen>
     <MtouchUseRefCounting>true</MtouchUseRefCounting>
     <MtouchFloat32>true</MtouchFloat32>
-    <CodesignEntitlements></CodesignEntitlements>
+    <CodesignEntitlements>
+    </CodesignEntitlements>
     <MtouchLink>SdkOnly</MtouchLink>
     <MtouchArch>ARMv7, ARM64</MtouchArch>
     <MtouchHttpClientHandler>HttpClientHandler</MtouchHttpClientHandler>
@@ -103,7 +107,43 @@
   <ItemGroup>
     <Compile Include="Main.cs" />
     <Compile Include="UnitTestAppDelegate.cs" />
-    <Compile Include="..\*.cs" />
+    <Compile Include="..\AsyncTests.cs" />
+    <Compile Include="..\BooleanTest.cs" />
+    <Compile Include="..\ByteArrayTest.cs" />
+    <Compile Include="..\CollateTest.cs" />
+    <Compile Include="..\ContainsTest.cs" />
+    <Compile Include="..\CreateTableImplicitTest.cs" />
+    <Compile Include="..\CreateTableTest.cs" />
+    <Compile Include="..\DateTimeOffsetTest.cs" />
+    <Compile Include="..\DateTimeTest.cs" />
+    <Compile Include="..\DeleteTest.cs" />
+    <Compile Include="..\DropTableTest.cs" />
+    <Compile Include="..\EnumCacheTest.cs" />
+    <Compile Include="..\EnumTest.cs" />
+    <Compile Include="..\EqualsTest.cs" />
+    <Compile Include="..\ExceptionAssert.cs" />
+    <Compile Include="..\GuidTests.cs" />
+    <Compile Include="..\IgnoreTest.cs" />
+    <Compile Include="..\InheritanceTest.cs" />
+    <Compile Include="..\InsertTest.cs" />
+    <Compile Include="..\JoinTest.cs" />
+    <Compile Include="..\LinqTest.cs" />
+    <Compile Include="..\MappingTest.cs" />
+    <Compile Include="..\MigrationTest.cs" />
+    <Compile Include="..\NotNullAttributeTest.cs" />
+    <Compile Include="..\NullableTest.cs" />
+    <Compile Include="..\OpenTests.cs" />
+    <Compile Include="..\ScalarTest.cs" />
+    <Compile Include="..\SkipTest.cs" />
+    <Compile Include="..\StringQueryTest.cs" />
+    <Compile Include="..\TableChangedTest.cs" />
+    <Compile Include="..\TestDb.cs" />
+    <Compile Include="..\TransactionTest.cs" />
+    <Compile Include="..\UnicodeTest.cs" />
+    <Compile Include="..\UniqueTest.cs" />
+    <Compile Include="..\ConcurrencyTest.cs">
+      <Link>ConcurrencyTest.cs</Link>
+    </Compile>
     <Compile Include="..\..\src\SQLite.cs">
       <Link>SQLite.cs</Link>
     </Compile>


### PR DESCRIPTION
Hi, 
I had some multithreaded concurrency issues on iOS. I wrote and added this unittest to reproduce the issues. The unittest only fails on iOS, not on UWP, Android and MacOS.

It seems that SQLite on iOS should be thread safe (it's compiled threadsafe, I checked sqlite3_threadsafe). However if you are using SQLite multithreaded with Read and ReadWrite connections this fails. Only using ReadWrite connection then there is not problem.

Any ideas on this ?

Regards,
Jeroen