### PR TITLE
Improve .NET Standard nuget

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,22 +1,24 @@
 
-
+SRC=src/SQLite.cs src/SQLiteAsync.cs
 
 all: test nuget
 
 test: tests/bin/Debug/SQLite.Tests.dll
 	nunit-console tests/bin/Debug/SQLite.Tests.dll
 
-tests/bin/Debug/SQLite.Tests.dll: tests/SQLite.Tests.csproj src/SQLite.cs src/SQLiteAsync.cs
-	xbuild tests/SQLite.Tests.csproj
+tests/bin/Debug/SQLite.Tests.dll: tests/SQLite.Tests.csproj $(SRC)
+	msbuild tests/SQLite.Tests.csproj
 
 nuget: srcnuget pclnuget
 
-srcnuget: src/SQLite.cs src/SQLiteAsync.cs sqlite-net.nuspec
+packages: nuget/SQLite-net/packages.config
+	nuget restore SQLite.sln
+
+srcnuget: sqlite-net.nuspec $(SRC)
 	nuget pack sqlite-net.nuspec
 
-pclnuget: src/SQLite.cs src/SQLiteAsync.cs
-	nuget restore SQLite.sln
-	msbuild "/p:Configuration=Release" nuget/SQLite-net-std/SQLite-net-std.csproj 
+pclnuget: sqlite-net-pcl.nuspec packages $(SRC)
+	msbuild "/p:Configuration=Release" nuget/SQLite-net/SQLite-net.csproj
 	msbuild "/p:Configuration=Release" nuget/SQLite-net-std/SQLite-net-std.csproj 
 	nuget pack sqlite-net-pcl.nuspec -o .\
 

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ srcnuget: src/SQLite.cs src/SQLiteAsync.cs sqlite-net.nuspec
 
 pclnuget: src/SQLite.cs src/SQLiteAsync.cs
 	nuget restore SQLite.sln
-	'/Applications/Xamarin Studio.app/Contents/MacOS/mdtool' build '-c:Release|iPhone' SQLite.sln -p:SQLite-net
+	msbuild "/p:Configuration=Release" nuget/SQLite-net-std/SQLite-net-std.csproj 
+	msbuild "/p:Configuration=Release" nuget/SQLite-net-std/SQLite-net-std.csproj 
 	nuget pack sqlite-net-pcl.nuspec -o .\
 

--- a/SQLite.sln
+++ b/SQLite.sln
@@ -16,6 +16,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{FECC0E44
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SQLite.Tests.iOS", "tests\SQLite.Tests.iOS\SQLite.Tests.iOS.csproj", "{81850129-71C3-40C7-A48B-AA5D2C2E365E}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SQLite-net-std", "nuget\SQLite-net-std\SQLite-net-std.csproj", "{081D08D6-10F1-431B-88FE-469FD9FE898C}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -62,6 +64,18 @@ Global
 		{81850129-71C3-40C7-A48B-AA5D2C2E365E}.Release|iPhoneSimulator.Build.0 = Release|iPhoneSimulator
 		{81850129-71C3-40C7-A48B-AA5D2C2E365E}.Debug|iPhone.ActiveCfg = Debug|iPhone
 		{81850129-71C3-40C7-A48B-AA5D2C2E365E}.Debug|iPhone.Build.0 = Debug|iPhone
+		{081D08D6-10F1-431B-88FE-469FD9FE898C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{081D08D6-10F1-431B-88FE-469FD9FE898C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{081D08D6-10F1-431B-88FE-469FD9FE898C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{081D08D6-10F1-431B-88FE-469FD9FE898C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{081D08D6-10F1-431B-88FE-469FD9FE898C}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
+		{081D08D6-10F1-431B-88FE-469FD9FE898C}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
+		{081D08D6-10F1-431B-88FE-469FD9FE898C}.Release|iPhone.ActiveCfg = Release|Any CPU
+		{081D08D6-10F1-431B-88FE-469FD9FE898C}.Release|iPhone.Build.0 = Release|Any CPU
+		{081D08D6-10F1-431B-88FE-469FD9FE898C}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
+		{081D08D6-10F1-431B-88FE-469FD9FE898C}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
+		{081D08D6-10F1-431B-88FE-469FD9FE898C}.Debug|iPhone.ActiveCfg = Debug|Any CPU
+		{081D08D6-10F1-431B-88FE-469FD9FE898C}.Debug|iPhone.Build.0 = Debug|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{6947A8F1-99BE-4DD1-AD4D-D89425CE67A2} = {FECC0E44-E626-49CB-BD8B-0CFBD93FBEFF}

--- a/nuget/SQLite-net-std/SQLite-net-std.csproj
+++ b/nuget/SQLite-net-std/SQLite-net-std.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard1.1</TargetFramework>
+    <AssemblyName>SQLite-net</AssemblyName>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>portable</DebugType>
+    <DefineConstants>TRACE;USE_SQLITEPCL_RAW;RELEASE;NETSTANDARD1_1</DefineConstants>
+    <DocumentationFile>bin\Release\netstandard1.1\SQLite-net.xml</DocumentationFile>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DefineConstants>TRACE;USE_SQLITEPCL_RAW;DEBUG;NETSTANDARD1_1</DefineConstants>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="SQLitePCLRaw.bundle_green" Version="1.1.5" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\..\src\SQLite.cs">
+      <Link>SQLite.cs</Link>
+    </Compile>
+    <Compile Include="..\..\src\SQLiteAsync.cs">
+      <Link>SQLiteAsync.cs</Link>
+    </Compile>
+  </ItemGroup>
+</Project>

--- a/nuget/SQLite-net/SQLite-net.csproj
+++ b/nuget/SQLite-net/SQLite-net.csproj
@@ -23,7 +23,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;USE_SQLITEPCL_RAW USE_NEW_REFLECTION_API NO_CONCURRENT</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;USE_SQLITEPCL_RAW;NO_CONCURRENT</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -31,10 +31,10 @@
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
-    <DebugType></DebugType>
+    <DebugType>portable</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE;USE_SQLITEPCL_RAW USE_NEW_REFLECTION_API NO_CONCURRENT</DefineConstants>
+    <DefineConstants>TRACE;USE_SQLITEPCL_RAW;NO_CONCURRENT</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/sqlite-net-pcl.nuspec
+++ b/sqlite-net-pcl.nuspec
@@ -19,21 +19,50 @@
     ]]>
     </releaseNotes>
     <dependencies>
-      <group>
+      <group targetFramework="net">
         <dependency id="SQLitePCLRaw.bundle_green" version="1.1.5" />
       </group>
-      <group targetFramework=".NETStandard1.1">
+      <group targetFramework="win">
         <dependency id="SQLitePCLRaw.bundle_green" version="1.1.5" />
-        <dependency id="NETStandard.Library" version="1.6.0" />
+      </group>
+      <group targetFramework="wp">
+        <dependency id="SQLitePCLRaw.bundle_green" version="1.1.5" />
+      </group>
+      <group targetFramework="wpa">
+        <dependency id="SQLitePCLRaw.bundle_green" version="1.1.5" />
+      </group>
+      <group targetFramework="netstandard1.1">
+        <dependency id="SQLitePCLRaw.bundle_green" version="1.1.5" />
+        <dependency id="NETStandard.Library" version="1.6.1" />
+      </group>
+      <group targetFramework="MonoAndroid10">
+        <dependency id="SQLitePCLRaw.bundle_green" version="1.1.5" />
+      </group>
+      <group targetFramework="Xamarin.iOS10">
+        <dependency id="SQLitePCLRaw.bundle_green" version="1.1.5" />
+      </group>
+      <group targetFramework="Xamarin.Mac20">
+        <dependency id="SQLitePCLRaw.bundle_green" version="1.1.5" />
+      </group>
+      <group targetFramework="portable-net45+win+wpa81+wp80">
+        <dependency id="SQLitePCLRaw.bundle_green" version="1.1.5" />
+      </group>
+      <group targetFramework="uap">
+        <dependency id="SQLitePCLRaw.bundle_green" version="1.1.5" />
+      </group>
+      <group targetFramework="dotnet">
+        <dependency id="SQLitePCLRaw.bundle_green" version="1.1.5" />
+      </group>
+      <group targetFramework="xamarintvos">
+        <dependency id="SQLitePCLRaw.bundle_green" version="1.1.5" />
+      </group>
+      <group targetFramework="xamarinwatchos">
+        <dependency id="SQLitePCLRaw.bundle_green" version="1.1.5" />
       </group>
     </dependencies>
   </metadata>
   <files>
-    <file src="nuget/SQLite-net/bin/Release/SQLite-net.dll" target="lib/portable-net45+wp8+wpa81+win8+MonoAndroid10+MonoTouch10+Xamarin.iOS10" />
-    <file src="nuget/SQLite-net/bin/Release/SQLite-net.pdb" target="lib/portable-net45+wp8+wpa81+win8+MonoAndroid10+MonoTouch10+Xamarin.iOS10" />
-    <file src="nuget/SQLite-net/bin/Release/SQLite-net.xml" target="lib/portable-net45+wp8+wpa81+win8+MonoAndroid10+MonoTouch10+Xamarin.iOS10" />
-    <file src="nuget/SQLite-net-std/bin/Release/netstandard1.1/SQLite-net.dll" target="lib/netstandard1.1" />
-    <file src="nuget/SQLite-net-std/bin/Release/netstandard1.1/SQLite-net.pdb" target="lib/netstandard1.1" />
-    <file src="nuget/SQLite-net-std/bin/Release/netstandard1.1/SQLite-net.xml" target="lib/netstandard1.1" />
+    <file src="nuget/SQLite-net/bin/Release/SQLite-net.*" target="lib/portable-net45+wp8+wpa81+win8+MonoAndroid10+MonoTouch10+Xamarin.iOS10" />
+    <file src="nuget/SQLite-net-std/bin/Release/netstandard1.1/SQLite-net.*" target="lib/netstandard1.1" />
   </files>
 </package>

--- a/sqlite-net-pcl.nuspec
+++ b/sqlite-net-pcl.nuspec
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
-    <version>1.3.4</version>
+    <version>1.4.0</version>
     <authors>Frank A. Krueger</authors>
     <owners>Frank A. Krueger</owners>
     <licenseUrl>https://raw.githubusercontent.com/praeclarum/sqlite-net/master/LICENSE.md</licenseUrl>
@@ -15,7 +15,7 @@
     <tags>sqlite pcl database orm mobile</tags>
     <releaseNotes>
     <![CDATA[
-    v1.3.4: Fix reading and writing nullable enums
+    v1.4: Improve .NET Standard Support
     ]]>
     </releaseNotes>
     <dependencies>
@@ -32,8 +32,8 @@
     <file src="nuget/SQLite-net/bin/Release/SQLite-net.dll" target="lib/portable-net45+wp8+wpa81+win8+MonoAndroid10+MonoTouch10+Xamarin.iOS10" />
     <file src="nuget/SQLite-net/bin/Release/SQLite-net.pdb" target="lib/portable-net45+wp8+wpa81+win8+MonoAndroid10+MonoTouch10+Xamarin.iOS10" />
     <file src="nuget/SQLite-net/bin/Release/SQLite-net.xml" target="lib/portable-net45+wp8+wpa81+win8+MonoAndroid10+MonoTouch10+Xamarin.iOS10" />
-    <file src="nuget/SQLite-net/bin/Release/SQLite-net.dll" target="lib/netstandard1.1" />
-    <file src="nuget/SQLite-net/bin/Release/SQLite-net.pdb" target="lib/netstandard1.1" />
-    <file src="nuget/SQLite-net/bin/Release/SQLite-net.xml" target="lib/netstandard1.1" />
+    <file src="nuget/SQLite-net-std/bin/Release/netstandard1.1/SQLite-net.dll" target="lib/netstandard1.1" />
+    <file src="nuget/SQLite-net-std/bin/Release/netstandard1.1/SQLite-net.pdb" target="lib/netstandard1.1" />
+    <file src="nuget/SQLite-net-std/bin/Release/netstandard1.1/SQLite-net.xml" target="lib/netstandard1.1" />
   </files>
 </package>

--- a/sqlite-net.nuspec
+++ b/sqlite-net.nuspec
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
-    <version>1.3.4</version>
+    <version>1.4.0</version>
     <authors>Frank Krueger</authors>
     <owners>Frank Krueger,Tim Heuer</owners>
     <licenseUrl>https://raw.githubusercontent.com/praeclarum/sqlite-net/master/LICENSE.md</licenseUrl>

--- a/src/AssemblyInfo.cs
+++ b/src/AssemblyInfo.cs
@@ -11,7 +11,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Krueger Systems, Inc.")]
 [assembly: AssemblyProduct("SQLite-net")]
-[assembly: AssemblyCopyright("Copyright © 2009-2016 Krueger Systems, Inc.")]
+[assembly: AssemblyCopyright("Copyright © 2009-2017 Krueger Systems, Inc.")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 [assembly: NeutralResourcesLanguage("en")]
@@ -26,5 +26,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.1.0.0")]
-[assembly: AssemblyFileVersion("1.1.0.0")]
+[assembly: AssemblyVersion("1.4.0.0")]
+[assembly: AssemblyFileVersion("1.4.0.0")]


### PR DESCRIPTION
This patch:

1. Adds a .NET Standard 1.1 project to the repo that uses the new build system
2. Uses target-specific dependencies in the unspec to improve packaging

Thanks to @jamesmontemagno for PR #546 on which this was based