### PR TITLE
memory and performance enhancements

### DIFF
--- a/src/SQLite.cs
+++ b/src/SQLite.cs
@@ -32,13 +32,18 @@ using System.Runtime.InteropServices;
 using System.Collections.Generic;
 #if NO_CONCURRENT
 using ConcurrentStringDictionary = System.Collections.Generic.Dictionary<string, object>;
+using ConcurrentCommandDictionary = System.Collections.Generic.Dictionary<string, SQLite.SQLiteCommand>;
+using ConcurrentTableDictionary = System.Collections.Generic.Dictionary<System.Type, SQLite.TableMapping>;
 using SQLite.Extensions;
 #else
 using ConcurrentStringDictionary = System.Collections.Concurrent.ConcurrentDictionary<string, object>;
+using ConcurrentCommandDictionary = System.Collections.Concurrent.ConcurrentDictionary<string, SQLite.SQLiteCommand>;
+using ConcurrentTableDictionary = System.Collections.Concurrent.ConcurrentDictionary<System.Type, SQLite.TableMapping>;
 #endif
 using System.Reflection;
 using System.Linq;
 using System.Linq.Expressions;
+using System.Text;
 using System.Threading;
 
 #if USE_CSHARP_SQLITE
@@ -59,21 +64,40 @@ using Sqlite3Statement = System.IntPtr;
 #endif
 
 #pragma warning disable 1591 // XML Doc Comments
+// ReSharper disable All
 
 namespace SQLite
 {
-	public class SQLiteException : Exception
+	public class SQLiteException : Exception 
 	{
-		public SQLite3.Result Result { get; private set; }
+		public SQLite3.Result Result { get; }
+		public string SQLQuery { get; }
 
-		protected SQLiteException (SQLite3.Result r, string message) : base (message)
+		protected SQLiteException(SQLite3.Result r, string message, string sql = null) : base(message)
 		{
 			Result = r;
+			SQLQuery = sql;
 		}
 
-		public static SQLiteException New (SQLite3.Result r, string message)
+		public static SQLiteException New(SQLite3.Result r, string message = null, string sql = null)
 		{
-			return new SQLiteException (r, message);
+			if (message == null) {
+				var x = (int) r;
+				message = r.ToString();
+
+				if (x > (int) SQLite3.Result.Done)
+					message = ((SQLite3.ExtendedResult) r).ToString();
+			}
+
+			return new SQLiteException(r, message, sql);
+		}
+
+		public override string ToString()
+		{
+			if (String.IsNullOrWhiteSpace(SQLQuery) == false)
+				return $"--------------------------\n{SQLQuery}\n--------------------------\n{base.ToString()}";
+
+			return base.ToString();
 		}
 	}
 
@@ -97,7 +121,7 @@ namespace SQLite
 			}
 		}
 
-		public static new NotNullConstraintViolationException New (SQLite3.Result r, string message)
+		public static NotNullConstraintViolationException New (SQLite3.Result r, string message)
 		{
 			return new NotNullConstraintViolationException (r, message);
 		}
@@ -114,11 +138,17 @@ namespace SQLite
 	}
 
 	[Flags]
-	public enum SQLiteOpenFlags
-	{
-		ReadOnly = 1, ReadWrite = 2, Create = 4,
-		NoMutex = 0x8000, FullMutex = 0x10000,
-		SharedCache = 0x20000, PrivateCache = 0x40000,
+	public enum SQLiteOpenFlags {
+		ReadOnly = 0x1,
+		ReadWrite = 0x2,
+		Create = 0x4,
+		OpenUri = 0x40,
+		OpenMemory = 0x80,
+		NoMutex = 0x8000,
+		FullMutex = 0x10000,
+		SharedCache = 0x20000,
+		PrivateCache = 0x40000,
+		Wal = 0x80000,
 		ProtectionComplete = 0x00100000,
 		ProtectionCompleteUnlessOpen = 0x00200000,
 		ProtectionCompleteUntilFirstUserAuthentication = 0x00300000,
@@ -169,31 +199,34 @@ namespace SQLite
 	{
 		private bool _open;
 		private TimeSpan _busyTimeout;
-		private Dictionary<string, TableMapping> _mappings = null;
-		private Dictionary<string, TableMapping> _tables = null;
-		private System.Diagnostics.Stopwatch _sw;
-		private long _elapsedMilliseconds = 0;
+		private ConcurrentCommandDictionary _cachedPreparedCommands;
 
 		private int _transactionDepth = 0;
 		private Random _rand = new Random ();
 
 		public Sqlite3DatabaseHandle Handle { get; private set; }
-		internal static readonly Sqlite3DatabaseHandle NullHandle = default (Sqlite3DatabaseHandle);
+		public static readonly Sqlite3DatabaseHandle NullHandle = default(Sqlite3DatabaseHandle);
 
 		/// <summary>
 		/// Gets the database path used by this connection.
 		/// </summary>
 		public string DatabasePath { get; private set; }
 
-		/// <summary>
-		/// Gets the SQLite library version number. 3007014 would be v3.7.14
-		/// </summary>
-		public int LibVersionNumber { get; private set; }
+        /// <summary>
+        /// Gets the SQLite library version number. 3007014 would be v3.7.14
+        /// </summary>
+        [Obsolete("Use LibraryVersion instead.")]
+        public int LibVersionNumber => LibraryVersion.ToInt32();
 
-		/// <summary>
-		/// Whether Trace lines should be written that show the execution time of queries.
-		/// </summary>
-		public bool TimeExecution { get; set; }
+	    /// <summary>
+	    /// Whether Trace lines should be written that show the execution time of queries.
+	    /// </summary>
+	    [Obsolete("Use TraceTime instead.")]
+	    public bool TimeExecution
+	    {
+	        get { return TraceTime; }
+	        set { TraceTime = value; }
+	    }
 
 		/// <summary>
 		/// Whether to writer queries to <see cref="Tracer"/> during execution.
@@ -201,17 +234,32 @@ namespace SQLite
 		/// <value>The tracer.</value>
 		public bool Trace { get; set; }
 
-		/// <summary>
-		/// The delegate responsible for writing trace lines.
-		/// </summary>
-		/// <value>The tracer.</value>
-		public Action<string> Tracer { get; set; }
+	    /// <summary>
+	    /// Whether Trace lines should be written that show the execution time of queries.
+	    /// </summary>
+        public bool TraceTime { get; set; } = true;
 
+        /// <summary>
+        /// Write a log message when the time exceeds a defined threshold.
+        /// </summary>
+	    public TimeSpan TraceTimeExceeding { get; set; } = TimeSpan.FromMilliseconds(500);
+
+        /// <summary>
+        /// The delegate responsible for writing trace lines.
+        /// </summary>
+        /// <value>The tracer.</value>
+        public Action<string> Tracer { get; set; }
+		
 		/// <summary>
 		/// Whether to store DateTime properties as ticks (true) or strings (false).
 		/// </summary>
 		public bool StoreDateTimeAsTicks { get; private set; }
 
+		/// <summary>
+		/// Gets the SQLite library version number. 3007014 would be v3.7.14
+		/// </summary>
+	    public SQLiteVersion LibraryVersion { get; } = new SQLiteVersion(SQLite3.LibVersionNumber());
+		
 #if USE_SQLITEPCL_RAW && !NO_SQLITEPCL_RAW_BATTERIES
 		static SQLiteConnection ()
 		{
@@ -255,14 +303,13 @@ namespace SQLite
 		/// If you use DateTimeOffset properties, it will be always stored as ticks regardingless
 		/// the storeDateTimeAsTicks parameter.
 		/// </param>
+		/// <exception cref="ArgumentException"></exception>
 		public SQLiteConnection (string databasePath, SQLiteOpenFlags openFlags, bool storeDateTimeAsTicks = true)
 		{
 			if (string.IsNullOrEmpty (databasePath))
-				throw new ArgumentException ("Must be specified", "databasePath");
+				throw new ArgumentException("Must be specified", nameof(databasePath));
 
 			DatabasePath = databasePath;
-
-			LibVersionNumber = SQLite3.LibVersionNumber ();
 
 #if NETFX_CORE
 			SQLite3.SetDirectory(/*temp directory type*/2, Windows.Storage.ApplicationData.Current.TemporaryFolder.Path);
@@ -284,12 +331,18 @@ namespace SQLite
 			if (r != SQLite3.Result.OK) {
 				throw SQLiteException.New (r, String.Format ("Could not open database file: {0} ({1})", DatabasePath, r));
 			}
-			_open = true;
+
+#if USE_SQLITEPCL_RAW
+			// enabled extended result codes
+			SQLitePCL.raw.sqlite3_extended_result_codes(handle, 1);
+#endif
+            _open = true;
 
 			StoreDateTimeAsTicks = storeDateTimeAsTicks;
 
 			BusyTimeout = TimeSpan.FromSeconds (0.1);
 
+			_cachedPreparedCommands = new ConcurrentCommandDictionary();
 			Tracer = line => Debug.WriteLine (line);
 		}
 
@@ -316,7 +369,7 @@ namespace SQLite
 		{
 			SQLite3.Result r = SQLite3.EnableLoadExtension (Handle, enabled ? 1 : 0);
 			if (r != SQLite3.Result.OK) {
-				string msg = SQLite3.GetErrmsg (Handle);
+				string msg = SQLite3.GetErrorMessage(Handle);
 				throw SQLiteException.New (r, msg);
 			}
 		}
@@ -345,15 +398,11 @@ namespace SQLite
 			}
 		}
 
-		/// <summary>
-		/// Returns the mappings from types to tables that the connection
-		/// currently understands.
-		/// </summary>
-		public IEnumerable<TableMapping> TableMappings {
-			get {
-				return _tables != null ? _tables.Values : Enumerable.Empty<TableMapping> ();
-			}
-		}
+	    /// <summary>
+	    /// Returns the mappings from types to tables that the connection
+	    /// currently understands.
+	    /// </summary>
+	    public IEnumerable<TableMapping> TableMappings => TableMapping.TableMappings;
 
 		/// <summary>
 		/// Retrieves the mapping that is automatically generated for the given type.
@@ -368,33 +417,16 @@ namespace SQLite
 		/// The mapping represents the schema of the columns of the database and contains 
 		/// methods to set and get properties of objects.
 		/// </returns>
-		public TableMapping GetMapping (Type type, CreateFlags createFlags = CreateFlags.None)
-		{
-			if (_mappings == null) {
-				_mappings = new Dictionary<string, TableMapping> ();
-			}
-			TableMapping map;
-			if (!_mappings.TryGetValue (type.FullName, out map)) {
-				map = new TableMapping (type, createFlags);
-				_mappings[type.FullName] = map;
-			}
-			return map;
-		}
+		public TableMapping GetMapping(Type type, CreateFlags createFlags = CreateFlags.None) => TableMapping.GetMapping(type, createFlags);
 
 		/// <summary>
 		/// Retrieves the mapping that is automatically generated for the given type.
 		/// </summary>
-		/// <param name="createFlags">
-		/// Optional flags allowing implicit PK and indexes based on naming conventions
-		/// </param>     
 		/// <returns>
 		/// The mapping represents the schema of the columns of the database and contains 
 		/// methods to set and get properties of objects.
 		/// </returns>
-		public TableMapping GetMapping<T> (CreateFlags createFlags = CreateFlags.None)
-		{
-			return GetMapping (typeof (T), createFlags);
-		}
+		public TableMapping GetMapping<T>() => TableMapping.GetMapping<T>();
 
 		private struct IndexedColumn
 		{
@@ -415,7 +447,7 @@ namespace SQLite
 		/// </summary>
 		public int DropTable<T> ()
 		{
-			return DropTable (GetMapping (typeof (T)));
+			return DropTable (GetMapping<T>());
 		}
 
 		/// <summary>
@@ -457,14 +489,7 @@ namespace SQLite
 		/// </returns>
 		public CreateTableResult CreateTable (Type ty, CreateFlags createFlags = CreateFlags.None)
 		{
-			if (_tables == null) {
-				_tables = new Dictionary<string, TableMapping> ();
-			}
-			TableMapping map;
-			if (!_tables.TryGetValue (ty.FullName, out map)) {
-				map = GetMapping (ty, createFlags);
-				_tables.Add (ty.FullName, map);
-			}
+			var map = GetMapping(ty, createFlags);
 
 			// Present a nice error if no columns specified
 			if (map.Columns.Length == 0) {
@@ -492,7 +517,12 @@ namespace SQLite
 				query += decl;
 				query += ")";
 
-				Execute (query);
+			    SQLite3.Result r;
+			    using (var cmd = NewCommand(query))
+			        r = cmd.Execute(null);
+
+				result = r == SQLite3.Result.Done ? CreateTableResult.Created : CreateTableResult.Error;
+
 			}
 			else {
 				result = CreateTableResult.Migrated;
@@ -524,12 +554,14 @@ namespace SQLite
 				}
 			}
 
+		    var success = true;
 			foreach (var indexName in indexes.Keys) {
 				var index = indexes[indexName];
-				var columns = index.Columns.OrderBy (i => i.Order).Select (i => i.ColumnName).ToArray ();
-				CreateIndex (indexName, index.TableName, columns, index.Unique);
+				var columns = index.Columns.OrderBy(i => i.Order).Select(i => i.ColumnName).ToArray();
+			    success = success && CreateIndex(indexName, index.TableName, columns, index.Unique);
 			}
 
+			result = success ? result : CreateTableResult.Error;
 			return result;
 		}
 
@@ -629,11 +661,16 @@ namespace SQLite
 		/// <param name="tableName">Name of the database table</param>
 		/// <param name="columnNames">An array of column names to index</param>
 		/// <param name="unique">Whether the index should be unique</param>
-		public int CreateIndex (string indexName, string tableName, string[] columnNames, bool unique = false)
+		public bool CreateIndex(string indexName, string tableName, string[] columnNames, bool unique = false)
 		{
 			const string sqlFormat = "create {2} index if not exists \"{3}\" on \"{0}\"(\"{1}\")";
 			var sql = String.Format (sqlFormat, tableName, string.Join ("\", \"", columnNames), unique ? "unique" : "", indexName);
-			return Execute (sql);
+		    SQLite3.Result r;
+
+		    using (var cmd = NewCommand(sql))
+		        r = cmd.Execute(null);
+
+		    return r == SQLite3.Result.Done;
 		}
 
 		/// <summary>
@@ -643,7 +680,7 @@ namespace SQLite
 		/// <param name="tableName">Name of the database table</param>
 		/// <param name="columnName">Name of the column to index</param>
 		/// <param name="unique">Whether the index should be unique</param>
-		public int CreateIndex (string indexName, string tableName, string columnName, bool unique = false)
+		public bool CreateIndex(string indexName, string tableName, string columnName, bool unique = false)
 		{
 			return CreateIndex (indexName, tableName, new string[] { columnName }, unique);
 		}
@@ -654,7 +691,7 @@ namespace SQLite
 		/// <param name="tableName">Name of the database table</param>
 		/// <param name="columnName">Name of the column to index</param>
 		/// <param name="unique">Whether the index should be unique</param>
-		public int CreateIndex (string tableName, string columnName, bool unique = false)
+		public bool CreateIndex(string tableName, string columnName, bool unique = false)
 		{
 			return CreateIndex (tableName + "_" + columnName, tableName, columnName, unique);
 		}
@@ -665,7 +702,7 @@ namespace SQLite
 		/// <param name="tableName">Name of the database table</param>
 		/// <param name="columnNames">An array of column names to index</param>
 		/// <param name="unique">Whether the index should be unique</param>
-		public int CreateIndex (string tableName, string[] columnNames, bool unique = false)
+		public bool CreateIndex(string tableName, string[] columnNames, bool unique = false)
 		{
 			return CreateIndex (tableName + "_" + string.Join ("_", columnNames), tableName, columnNames, unique);
 		}
@@ -677,7 +714,7 @@ namespace SQLite
 		/// <typeparam name="T">Type to reflect to a database table.</typeparam>
 		/// <param name="property">Property to index</param>
 		/// <param name="unique">Whether the index should be unique</param>
-		public int CreateIndex<T> (Expression<Func<T, object>> property, bool unique = false)
+		public bool CreateIndex<T>(Expression<Func<T, object>> property, bool unique = false)
 		{
 			MemberExpression mx;
 			if (property.Body.NodeType == ExpressionType.Convert) {
@@ -699,26 +736,25 @@ namespace SQLite
 			return CreateIndex (map.TableName, colName, unique);
 		}
 
-		public class ColumnInfo
+		public class ColumnInfo 
 		{
-			//			public int cid { get; set; }
+			//public int cid { get; set; }
 
-			[Column ("name")]
+			[Column("name")]
 			public string Name { get; set; }
 
-			//			[Column ("type")]
-			//			public string ColumnType { get; set; }
+			[Column("type")]
+			public string ColumnType { get; set; }
 
+			[Column("notnull")]
 			public int notnull { get; set; }
 
-			//			public string dflt_value { get; set; }
+			//public string dflt_value { get; set; }
 
-			//			public int pk { get; set; }
+			[Column("pk")]
+			public int PK { get; set; }
 
-			public override string ToString ()
-			{
-				return Name;
-			}
+			public override string ToString() => $"{Name} ({ColumnType})";
 		}
 
 		/// <summary>
@@ -758,9 +794,9 @@ namespace SQLite
 		/// Creates a new SQLiteCommand. Can be overridden to provide a sub-class.
 		/// </summary>
 		/// <seealso cref="SQLiteCommand.OnInstanceCreated"/>
-		protected virtual SQLiteCommand NewCommand ()
+		protected virtual SQLiteCommand NewCommand (string cmdText)
 		{
-			return new SQLiteCommand (this);
+			return new SQLiteCommand (this, cmdText);
 		}
 
 		/// <summary>
@@ -776,18 +812,41 @@ namespace SQLite
 		/// <returns>
 		/// A <see cref="SQLiteCommand"/>
 		/// </returns>
-		public SQLiteCommand CreateCommand (string cmdText, params object[] ps)
-		{
-			if (!_open)
-				throw SQLiteException.New (SQLite3.Result.Error, "Cannot create commands from unopened database");
+	    public SQLiteCommand CreateCommand(string cmdText, bool fromCache = false)
+	    {
+	        if (!_open)
+	            throw SQLiteException.New(SQLite3.Result.Error, "Cannot create commands from unopened database", sql: cmdText);
 
-			var cmd = NewCommand ();
-			cmd.CommandText = cmdText;
-			foreach (var o in ps) {
-				cmd.Bind (o);
-			}
-			return cmd;
-		}
+	        SQLiteCommand cmd = null;
+
+	        if (fromCache)
+	            cmd = GetCachedCommand(cmdText);
+
+	        if (cmd == null)
+	            cmd = NewCommand(cmdText);
+
+	        return cmd;
+	    }
+
+	    private SQLiteCommand GetCachedCommand(string commandName)
+	    {
+	        SQLiteCommand cachedCommand;
+
+	        if (!_cachedPreparedCommands.TryGetValue(commandName, out cachedCommand))
+	        {
+	            var prepCmd = NewCommand(commandName);
+
+	            cachedCommand = prepCmd;
+	            if (!_cachedPreparedCommands.TryAdd(commandName, prepCmd))
+	            {
+	                // concurrent add attempt this add, retreive a fresh copy
+	                prepCmd.Dispose();
+	                _cachedPreparedCommands.TryGetValue(commandName, out cachedCommand);
+	            }
+	        }
+
+	        return cachedCommand;
+	    }
 
 		/// <summary>
 		/// Creates a SQLiteCommand given the command text (SQL) with arguments. Place a '?'
@@ -806,28 +865,38 @@ namespace SQLite
 		/// <returns>
 		/// The number of rows modified in the database as a result of this execution.
 		/// </returns>
-		public int Execute (string query, params object[] args)
-		{
-			var cmd = CreateCommand (query, args);
+	    public int Execute(string query, params object[] args)
+	    {
+	        using (var cmd = NewCommand(query))
+	        {
+	            var result = cmd.ExecuteNonQuery(args);
+	            return result;
+	        }
+	    }
 
-			if (TimeExecution) {
-				if (_sw == null) {
-					_sw = new Stopwatch ();
-				}
-				_sw.Reset ();
-				_sw.Start ();
-			}
-
-			var r = cmd.ExecuteNonQuery ();
-
-			if (TimeExecution) {
-				_sw.Stop ();
-				_elapsedMilliseconds += _sw.ElapsedMilliseconds;
-				Tracer?.Invoke (string.Format ("Finished in {0} ms ({1:0.0} s total)", _sw.ElapsedMilliseconds, _elapsedMilliseconds / 1000.0));
-			}
-
-			return r;
-		}
+		/// <summary>
+		/// Creates a SQLiteCommand given the command text (SQL) with arguments. Place a '?'
+		/// in the command text for each of the arguments and then executes that command.
+		/// Use this method instead of Query when you don't expect rows back. Such cases include
+		/// INSERTs, UPDATEs, and DELETEs.
+		/// You can set the Trace or TimeExecution properties of the connection
+		/// to profile execution.
+		/// </summary>
+		/// <param name="query">
+		/// The fully escaped SQL.
+		/// </param>
+		/// <param name="args">
+		/// Arguments to substitute for the occurences of '?' in the query.
+		/// </param>
+		/// <returns>
+		/// The number of rows modified in the database as a result of this execution.
+		/// </returns>
+	    public int PreparedExecute(string query, params object[] args)
+	    {
+	        var cmd = CreateCommand(query, fromCache: true);
+	        var result = cmd.ExecuteNonQuery(args);
+	        return result;
+        }
 
 		/// <summary>
 		/// Creates a SQLiteCommand given the command text (SQL) with arguments. Place a '?'
@@ -845,28 +914,14 @@ namespace SQLite
 		/// <returns>
 		/// The number of rows modified in the database as a result of this execution.
 		/// </returns>
-		public T ExecuteScalar<T> (string query, params object[] args)
-		{
-			var cmd = CreateCommand (query, args);
-
-			if (TimeExecution) {
-				if (_sw == null) {
-					_sw = new Stopwatch ();
-				}
-				_sw.Reset ();
-				_sw.Start ();
-			}
-
-			var r = cmd.ExecuteScalar<T> ();
-
-			if (TimeExecution) {
-				_sw.Stop ();
-				_elapsedMilliseconds += _sw.ElapsedMilliseconds;
-				Tracer?.Invoke (string.Format ("Finished in {0} ms ({1:0.0} s total)", _sw.ElapsedMilliseconds, _elapsedMilliseconds / 1000.0));
-			}
-
-			return r;
-		}
+        public T ExecuteScalar<T>(string query, params object[] args)
+	    {
+	        using (var cmd = NewCommand(query))
+	        {
+	            var result = cmd.ExecuteScalar<T>(args);
+	            return result;
+	        }
+	    }
 
 		/// <summary>
 		/// Creates a SQLiteCommand given the command text (SQL) with arguments. Place a '?'
@@ -885,8 +940,11 @@ namespace SQLite
 		/// </returns>
 		public List<T> Query<T> (string query, params object[] args) where T : new()
 		{
-			var cmd = CreateCommand (query, args);
-			return cmd.ExecuteQuery<T> ();
+		    using (var cmd = CreateCommand(query, fromCache: false))
+		    {
+		        var result = cmd.ExecuteQuery<T>(args).ToList();
+		        return result;
+		    }
 		}
 
 		/// <summary>
@@ -906,11 +964,34 @@ namespace SQLite
 		/// The enumerator will call sqlite3_step on each call to MoveNext, so the database
 		/// connection must remain open for the lifetime of the enumerator.
 		/// </returns>
-		public IEnumerable<T> DeferredQuery<T> (string query, params object[] args) where T : new()
-		{
-			var cmd = CreateCommand (query, args);
-			return cmd.ExecuteDeferredQuery<T> ();
-		}
+	    public IEnumerable<T> PreparedQuery<T>(string query, params object[] args) where T : new()
+	    {
+	        var cmd = CreateCommand(query, fromCache: true);
+	        var result = cmd.ExecuteQuery<T>(args);
+	        return result;
+	    }
+		
+		/// <summary>
+		/// Creates a SQLiteCommand given the command text (SQL) with arguments. Place a '?'
+		/// in the command text for each of the arguments and then executes that command.
+		/// It returns each row of the result using the mapping automatically generated for
+		/// the given type.
+		/// </summary>
+		/// <param name="query">
+		/// The fully escaped SQL.
+		/// </param>
+		/// <param name="args">
+		/// Arguments to substitute for the occurences of '?' in the query.
+		/// </param>
+		/// <returns>
+		/// An enumerable with one result for each row returned by the query.
+		/// The enumerator will call sqlite3_step on each call to MoveNext, so the database
+		/// connection must remain open for the lifetime of the enumerator.
+		/// </returns>
+        public IEnumerable<T> DeferredQuery<T>(string query, params object[] args) where T : new()
+        {
+            return PreparedQuery<T>(query, args);
+        }
 
 		/// <summary>
 		/// Creates a SQLiteCommand given the command text (SQL) with arguments. Place a '?'
@@ -934,9 +1015,41 @@ namespace SQLite
 		/// </returns>
 		public List<object> Query (TableMapping map, string query, params object[] args)
 		{
-			var cmd = CreateCommand (query, args);
-			return cmd.ExecuteQuery<object> (map);
-		}
+	        using (var cmd = CreateCommand(query, fromCache: false))
+	        {
+	            var result = cmd.ExecuteQuery<object>(map, args).ToList();
+	            return result;
+	        }
+	    }
+
+	    /// <summary>
+	    /// Creates a SQLiteCommand given the command text (SQL) with arguments. Place a '?'
+	    /// in the command text for each of the arguments and then executes that command.
+	    /// It returns each row of the result using the specified mapping. This function is
+	    /// only used by libraries in order to query the database via introspection. It is
+	    /// normally not used.
+	    /// </summary>
+	    /// <param name="map">
+	    /// A <see cref="TableMapping"/> to use to convert the resulting rows
+	    /// into objects.
+	    /// </param>
+	    /// <param name="query">
+	    /// The fully escaped SQL.
+	    /// </param>
+	    /// <param name="args">
+	    /// Arguments to substitute for the occurences of '?' in the query.
+	    /// </param>
+	    /// <returns>
+	    /// An enumerable with one result for each row returned by the query.
+	    /// The enumerator will call sqlite3_step on each call to MoveNext, so the database
+	    /// connection must remain open for the lifetime of the enumerator.
+	    /// </returns>
+	    public IEnumerable<object> PreparedQuery(TableMapping map, string query, params object[] args)
+	    {
+	        var cmd = CreateCommand(query, fromCache: true);
+	        var result = cmd.ExecuteQuery<object>(map, args);
+	        return result;
+	    }
 
 		/// <summary>
 		/// Creates a SQLiteCommand given the command text (SQL) with arguments. Place a '?'
@@ -962,9 +1075,8 @@ namespace SQLite
 		/// </returns>
 		public IEnumerable<object> DeferredQuery (TableMapping map, string query, params object[] args)
 		{
-			var cmd = CreateCommand (query, args);
-			return cmd.ExecuteDeferredQuery<object> (map);
-		}
+	        return PreparedQuery(map, query, args);
+	    }
 
 		/// <summary>
 		/// Returns a queryable interface to the table represented by the given type.
@@ -1227,26 +1339,16 @@ namespace SQLite
 		/// <summary>
 		/// Rolls back the transaction that was begun by <see cref="BeginTransaction"/> or <see cref="SaveTransactionPoint"/>.
 		/// </summary>
-		public void Rollback ()
+		public void Rollback(bool noThrow = false)
 		{
-			RollbackTo (null, false);
+			RollbackTo(null, noThrow);
 		}
 
 		/// <summary>
 		/// Rolls back the savepoint created by <see cref="BeginTransaction"/> or SaveTransactionPoint.
 		/// </summary>
 		/// <param name="savepoint">The name of the savepoint to roll back to, as returned by <see cref="SaveTransactionPoint"/>.  If savepoint is null or empty, this method is equivalent to a call to <see cref="Rollback"/></param>
-		public void RollbackTo (string savepoint)
-		{
-			RollbackTo (savepoint, false);
-		}
-
-		/// <summary>
-		/// Rolls back the transaction that was begun by <see cref="BeginTransaction"/>.
-		/// </summary>
-		/// <param name="savepoint">The name of the savepoint to roll back to, as returned by <see cref="SaveTransactionPoint"/>.  If savepoint is null or empty, this method is equivalent to a call to <see cref="Rollback"/></param>
-		/// <param name="noThrow">true to avoid throwing exceptions, false otherwise</param>
-		void RollbackTo (string savepoint, bool noThrow)
+		public void RollbackTo(string savepoint, bool noThrow = false)
 		{
 			// Rolling back without a TO clause rolls backs all transactions 
 			//    and leaves the transaction stack empty.   
@@ -1281,7 +1383,7 @@ namespace SQLite
 			DoSavePointExecute (savepoint, "release ");
 		}
 
-		void DoSavePointExecute (string savepoint, string cmd)
+		private void DoSavePointExecute(string savepoint, string cmd)
 		{
 			// Validate the savepoint
 			int firstLen = savepoint.IndexOf ('D');
@@ -1345,7 +1447,8 @@ namespace SQLite
 		/// </summary>
 		/// <param name="objects">
 		/// An <see cref="IEnumerable"/> of the objects to insert.
-		/// <param name="runInTransaction"/>
+		/// </param>
+		/// <param name="runInTransaction">
 		/// A boolean indicating if the inserts should be wrapped in a transaction.
 		/// </param>
 		/// <returns>
@@ -1353,21 +1456,51 @@ namespace SQLite
 		/// </returns>
 		public int InsertAll (System.Collections.IEnumerable objects, bool runInTransaction = true)
 		{
-			var c = 0;
-			if (runInTransaction) {
-				RunInTransaction (() => {
-					foreach (var r in objects) {
-						c += Insert (r);
-					}
-				});
-			}
-			else {
-				foreach (var r in objects) {
-					c += Insert (r);
-				}
-			}
-			return c;
+		    return InsertAll(objects, "", null, runInTransaction);
 		}
+
+        /// <summary>
+        /// Inserts all specified objects.
+        /// </summary>
+        /// <param name="objects">
+        /// An <see cref="IEnumerable"/> of the objects to insert.
+        /// </param>
+        /// <param name="extra">
+        /// Literal SQL code that gets placed into the command. INSERT {extra} INTO ...
+        /// </param>
+        /// <param name="runInTransaction">
+        /// A boolean indicating if the inserts should be wrapped in a transaction.
+        /// </param>
+        /// <returns>
+        /// The number of rows added to the table.
+        /// </returns>
+        public int InsertAll(System.Collections.IEnumerable objects, string extra, bool runInTransaction = true)
+		{
+		    return InsertAll(objects, extra, null, runInTransaction);
+
+        }
+
+        /// <summary>
+        /// Inserts all specified objects.
+        /// </summary>
+        /// <param name="objects">
+        /// An <see cref="IEnumerable"/> of the objects to insert.
+        /// </param>
+        /// <param name="objType">
+        /// The type of object to insert.
+        /// </param>
+        /// <param name="runInTransaction">
+        /// A boolean indicating if the inserts should be wrapped in a transaction.
+        /// </param>
+        /// <returns>
+        /// The number of rows added to the table.
+        /// </returns>
+        public int InsertAll(System.Collections.IEnumerable objects, Type objType, bool runInTransaction = true)
+		{
+		    return InsertAll(objects, "", objType, runInTransaction);
+		}
+
+	    private static readonly SQLiteVersion MinInsertAllVersion = new SQLiteVersion(3007011); // 3.7.11
 
 		/// <summary>
 		/// Inserts all specified objects.
@@ -1378,36 +1511,6 @@ namespace SQLite
 		/// <param name="extra">
 		/// Literal SQL code that gets placed into the command. INSERT {extra} INTO ...
 		/// </param>
-		/// <param name="runInTransaction">
-		/// A boolean indicating if the inserts should be wrapped in a transaction.
-		/// </param>
-		/// <returns>
-		/// The number of rows added to the table.
-		/// </returns>
-		public int InsertAll (System.Collections.IEnumerable objects, string extra, bool runInTransaction = true)
-		{
-			var c = 0;
-			if (runInTransaction) {
-				RunInTransaction (() => {
-					foreach (var r in objects) {
-						c += Insert (r, extra);
-					}
-				});
-			}
-			else {
-				foreach (var r in objects) {
-					c += Insert (r);
-				}
-			}
-			return c;
-		}
-
-		/// <summary>
-		/// Inserts all specified objects.
-		/// </summary>
-		/// <param name="objects">
-		/// An <see cref="IEnumerable"/> of the objects to insert.
-		/// </param>
 		/// <param name="objType">
 		/// The type of object to insert.
 		/// </param>
@@ -1417,23 +1520,173 @@ namespace SQLite
 		/// <returns>
 		/// The number of rows added to the table.
 		/// </returns>
-		public int InsertAll (System.Collections.IEnumerable objects, Type objType, bool runInTransaction = true)
-		{
-			var c = 0;
-			if (runInTransaction) {
-				RunInTransaction (() => {
-					foreach (var r in objects) {
-						c += Insert (r, objType);
+		public int InsertAll(System.Collections.IEnumerable objects, string extra, Type objType, bool runInTransaction = true)
+	    {
+	        var useFallback = false;
+	        var count = 0;
+
+	        if (LibraryVersion < MinInsertAllVersion)
+	            useFallback = true;
+
+	        if (!useFallback) {
+		        var o = new List<object> ();
+	            foreach (var r in objects)
+	                if (r != null)
+	                    o.Add(r);
+
+	            // if there are no records just return 0
+	            if (o.Count == 0)
+	                return 0;
+
+	            // if there is only one object it is better to go through the old logic because the insert is already prepared
+	            if (!useFallback && o.Count == 1)
+	                useFallback = true;
+
+	            if (!useFallback)
+	            {
+	                var firstRecordType = objType;
+	                if (firstRecordType == null)
+	                    firstRecordType = o[0].GetType();
+
+	                // all the types need to match
+	                foreach (var r in o)
+	                {
+	                    if (r.GetType() != firstRecordType)
+	                    {
+	                        useFallback = true;
+	                        break;
+	                    }
+	                }
+	            }
+
+	            if (!useFallback)
+	            {
+	                if (runInTransaction)
+	                {
+	                    RunInTransaction(() => {
+	                        count = InternalInsertAll(o, extra, objType);
+	                    });
+	                }
+	                else
+	                {
+	                    count = InternalInsertAll(o, extra, objType);
+	                }
+	            }
+	        }
+
+	        if (useFallback)
+	        {
+	            if (runInTransaction)
+	            {
+	                RunInTransaction(() => {
+	                    foreach (var r in objects)
+	                        count += Insert(r, extra, objType);
+	                });
+	            }
+	            else
+	            {
+	                foreach (var r in objects)
+	                    count += Insert(r, extra, objType);
+	            }
+	        }
+
+	        return count;
+	    }
+
+	    private object[] InternalInsertRecordValues(TableMapping map, object obj, Type objType, bool replacing)
+	    {
+			if (map.PK != null && map.PK.IsAutoGuid)
+			{
+				// no GetProperty so search our way up the inheritance chain till we find it
+				PropertyInfo prop;
+				while (objType != null)
+				{
+					var info = objType.GetTypeInfo();
+					prop = info.GetDeclaredProperty(map.PK.PropertyName);
+					if (prop != null)
+					{
+						if (prop.GetValue(obj, null).Equals(Guid.Empty))
+						{
+							prop.SetValue(obj, Guid.NewGuid(), null);
+						}
+						break;
 					}
-				});
-			}
-			else {
-				foreach (var r in objects) {
-					c += Insert (r, objType);
+
+					objType = info.BaseType;
 				}
 			}
-			return c;
-		}
+
+	        var cols = replacing ? map.InsertOrReplaceColumns : map.InsertColumns;
+	        var vals = new object[cols.Length];
+
+	        for (var i = 0; i < vals.Length; i++)
+	        {
+	            var col = cols[i];
+	            var value = col.GetValue(obj);
+
+	            // primary key, auto increment, with a value of 0 should be considered a new incremented value
+	            if (col.IsPK && col.IsAutoInc && col.ColumnType == typeof(long) && Object.Equals(value, 0L))
+	                value = null;
+
+	            vals[i] = value;
+	        }
+
+	        return vals;
+	    }
+
+        private int InternalInsertAll(IList objects, string extra, Type objType)
+        {
+            if (objects.Count == 0)
+                return 0;
+
+            objType = objType ?? objects[0].GetType();
+
+	        int count = 0;
+            var map = GetMapping(objType);
+	        var replacing = string.Compare(extra, "OR REPLACE", StringComparison.OrdinalIgnoreCase) == 0;
+	        var cols = replacing ? map.InsertOrReplaceColumns : map.InsertColumns;
+
+            // todo: look up if this value was changed at runtime by using sqlite3_limit(db,SQLITE_LIMIT_VARIABLE_NUMBER,size)
+            const int SQLITE_LIMIT_VARIABLE_NUMBER = 999;
+
+	        var recordValues = new Queue<object[]>();
+            foreach(var obj in objects)
+                recordValues.Enqueue(InternalInsertRecordValues(map, obj, objType, replacing));
+
+            var line = $"({String.Join(",", cols.Select(c => "?"))}),";
+            while (recordValues.Count > 0)
+	        {
+	            var insertVals = new List<object>();
+	            var s = new StringBuilder();
+	            s.AppendFormat("insert {2} into \"{0}\"({1}) values ", map.TableName, String.Join(",", cols.Select(c => $"\"{c.Name}\"")), extra);
+
+                while (recordValues.Count > 0 && insertVals.Count + cols.Length < SQLITE_LIMIT_VARIABLE_NUMBER)
+	            {
+	                insertVals.AddRange(recordValues.Dequeue());
+	                s.Append(line);
+	            }
+
+	            try
+	            {
+	                // remove the last comma from the string
+	                var insertSql = s.ToString(0, s.Length - 1);
+                    count += Execute(insertSql, insertVals.ToArray());
+	            }
+	            catch (SQLiteException ex)
+	            {
+	                if (SQLite3.ExtendedErrCode(this.Handle) == SQLite3.ExtendedResult.ConstraintNotNull)
+	                {
+	                    throw NotNullConstraintViolationException.New(ex.Result, ex.Message);
+	                }
+	                throw;
+	            }
+	        }
+
+	        if (count > 0)
+	            OnTableChanged(map, NotifyTableChangedAction.Insert);
+
+	        return count;
+	    }
 
 		/// <summary>
 		/// Inserts the given object (and updates its
@@ -1558,27 +1811,17 @@ namespace SQLite
 		/// </returns>
 		public int Insert (object obj, string extra, Type objType)
 		{
-			if (obj == null || objType == null) {
+			if (obj == null) {
 				return 0;
 			}
 
-			var map = GetMapping (objType);
-
-			if (map.PK != null && map.PK.IsAutoGuid) {
-				if (map.PK.GetValue (obj).Equals (Guid.Empty)) {
-					map.PK.SetValue (obj, Guid.NewGuid ());
-				}
-			}
-
-			var replacing = string.Compare (extra, "OR REPLACE", StringComparison.OrdinalIgnoreCase) == 0;
-
+		    objType = objType ?? Orm.GetType (obj);
+			var map = GetMapping(objType);
+			var replacing = string.Compare(extra, "OR REPLACE", StringComparison.OrdinalIgnoreCase) == 0;
 			var cols = replacing ? map.InsertOrReplaceColumns : map.InsertColumns;
-			var vals = new object[cols.Length];
-			for (var i = 0; i < vals.Length; i++) {
-				vals[i] = cols[i].GetValue (obj);
-			}
+		    var vals = InternalInsertRecordValues(map, obj, objType, replacing);
 
-			var insertCmd = map.GetInsertCommand (this, extra);
+			var insertCmd = GetInsertCommand(map, extra);
 			int count;
 
 			lock (insertCmd) {
@@ -1605,6 +1848,42 @@ namespace SQLite
 			return count;
 		}
 
+	    public SQLiteCommand GetInsertCommand(TableMapping map, string extra)
+	    {
+	        var commandName = $"insert {extra} into \"{map.TableName}\"";
+
+	        SQLiteCommand cachedCommand;
+
+	        if (!_cachedPreparedCommands.TryGetValue(commandName, out cachedCommand)) {
+	            var cols = map.InsertColumns;
+	            string insertSql;
+
+	            // weird case to handle where there is only one column in the database, and it is an auto incrementing column
+	            if (!cols.Any() && map.Columns.Count() == 1 && map.Columns[0].IsAutoInc) {
+	                insertSql = $"insert {extra} into \"{map.TableName}\" default values";
+	            }
+	            else {
+	                if (String.Equals(extra, "OR REPLACE", StringComparison.OrdinalIgnoreCase))
+	                    cols = map.InsertOrReplaceColumns;
+
+	                insertSql = String.Format("insert {3} into \"{0}\"({1}) values ({2})", map.TableName,
+	                    String.Join(",", cols.Select(c => $"\"{c.Name}\"")),
+	                    String.Join(",", cols.Select(c => "?")), extra);
+	            }
+
+	            var prepCmd = new SQLiteCommand(this, insertSql);
+
+	            cachedCommand = prepCmd;
+	            if (!_cachedPreparedCommands.TryAdd(commandName, prepCmd)) {
+	                // concurrent add attempt this add, retreive a fresh copy
+	                prepCmd.Dispose();
+	                _cachedPreparedCommands.TryGetValue(commandName, out cachedCommand);
+	            }
+	        }
+
+	        return cachedCommand;
+	    }
+
 		/// <summary>
 		/// Updates all of the columns of a table using the specified object
 		/// except for its primary key.
@@ -1621,7 +1900,7 @@ namespace SQLite
 			if (obj == null) {
 				return 0;
 			}
-			return Update (obj, Orm.GetType (obj));
+			return Update(obj, "", Orm.GetType (obj));
 		}
 
 		/// <summary>
@@ -1640,54 +1919,98 @@ namespace SQLite
 		/// </returns>
 		public int Update (object obj, Type objType)
 		{
-			int rowsAffected = 0;
-			if (obj == null || objType == null) {
+			if (obj == null) {
+				return 0;
+			}
+			return Update(obj, "", objType);
+		}
+		
+		/// <summary>
+		/// Updates all of the columns of a table using the specified object
+		/// except for its primary key.
+		/// The object is required to have a primary key.
+		/// </summary>
+		/// <param name="obj">
+		/// The object to update. It must have a primary key designated using the PrimaryKeyAttribute.
+		/// </param>
+		/// <param name="objType">
+		/// The type of object to insert.
+		/// </param>
+		/// <returns>
+		/// The number of rows updated.
+		/// </returns>
+		public int Update(object obj, string extra, Type objType)
+		{		
+			if (obj == null) {
 				return 0;
 			}
 
-			var map = GetMapping (objType);
+		    objType = objType ?? Orm.GetType (obj);
+			var map = GetMapping(objType);
+		    var pk = map.PK;
+            var cols = map.UpdateColumns;
+            var vals = cols.Select(c => c.GetValue(obj));
 
-			var pk = map.PK;
+		    var ps = new List<object>(vals);
+		    ps.Add(pk.GetValue(obj));
 
-			if (pk == null) {
-				throw new NotSupportedException ("Cannot update " + map.TableName + ": it has no PK");
-			}
+		    var updateCmd = GetUpdateCommand(map, extra);
+		    int count;
 
-			var cols = from p in map.Columns
-					   where p != pk
-					   select p;
-			var vals = from c in cols
-					   select c.GetValue (obj);
-			var ps = new List<object> (vals);
-			if (ps.Count == 0) {
-				// There is a PK but no accompanying data,
-				// so reset the PK to make the UPDATE work.
-				cols = map.Columns;
-				vals = from c in cols
-					   select c.GetValue (obj);
-				ps = new List<object> (vals);
-			}
-			ps.Add (pk.GetValue (obj));
-			var q = string.Format ("update \"{0}\" set {1} where {2} = ? ", map.TableName, string.Join (",", (from c in cols
-																											  select "\"" + c.Name + "\" = ? ").ToArray ()), pk.Name);
+		    lock (updateCmd)
+		    {
+		        // We lock here to protect the prepared statement returned via GetInsertCommand.
+		        // A SQLite prepared statement can be bound for only one operation at a time.
+		        try
+		        {
+		            count = updateCmd.ExecuteNonQuery(ps.ToArray());
+		        }
+		        catch (SQLiteException ex) {
+		            if (ex.Result == SQLite3.Result.Constraint && SQLite3.ExtendedErrCode(this.Handle) == SQLite3.ExtendedResult.ConstraintNotNull) {
+		                throw NotNullConstraintViolationException.New(ex, map, obj);
+		            }
+                    throw;
+		        }
+		    }
 
-			try {
-				rowsAffected = Execute (q, ps.ToArray ());
-			}
-			catch (SQLiteException ex) {
+		    if (count > 0)
+		        OnTableChanged(map, NotifyTableChangedAction.Update);
 
-				if (ex.Result == SQLite3.Result.Constraint && SQLite3.ExtendedErrCode (this.Handle) == SQLite3.ExtendedResult.ConstraintNotNull) {
-					throw NotNullConstraintViolationException.New (ex, map, obj);
-				}
-
-				throw ex;
-			}
-
-			if (rowsAffected > 0)
-				OnTableChanged (map, NotifyTableChangedAction.Update);
-
-			return rowsAffected;
+			return count;
 		}
+
+	    public SQLiteCommand GetUpdateCommand(TableMapping map, string extra)
+	    {
+	        var commandName = $"update {extra} \"{map.TableName}\"";
+
+	        SQLiteCommand cachedCommand;
+
+	        if (!_cachedPreparedCommands.TryGetValue(commandName, out cachedCommand)) {
+	            var pk = map.PK;
+
+	            if (pk == null)
+	                throw new NotSupportedException("Cannot update " + map.TableName + ": it has no PK");
+
+	            var cols = map.UpdateColumns;
+	            string updateSql;
+
+                updateSql = String.Format("update {3} \"{0}\" set {1} where {2} = ?", map.TableName,
+                    String.Join(",", cols.Select(c => $"\"{c.Name}\" = ?")),
+                    pk.Name, extra);
+
+	            var prepCmd = new SQLiteCommand(this, updateSql);
+
+	            cachedCommand = prepCmd;
+	            if (!_cachedPreparedCommands.TryAdd(commandName, prepCmd))
+	            {
+	                // concurrent add attempt this add, retreive a fresh copy
+	                prepCmd.Dispose();
+	                _cachedPreparedCommands.TryGetValue(commandName, out cachedCommand);
+	            }
+	        }
+
+	        return cachedCommand;
+        }
 
 		/// <summary>
 		/// Updates all specified objects.
@@ -1736,9 +2059,10 @@ namespace SQLite
 				throw new NotSupportedException ("Cannot delete " + map.TableName + ": it has no PK");
 			}
 			var q = string.Format ("delete from \"{0}\" where \"{1}\" = ?", map.TableName, pk.Name);
-			var count = Execute (q, pk.GetValue (objectToDelete));
+			var count = PreparedExecute(q, pk.GetValue(objectToDelete));
 			if (count > 0)
 				OnTableChanged (map, NotifyTableChangedAction.Delete);
+
 			return count;
 		}
 
@@ -1778,9 +2102,10 @@ namespace SQLite
 				throw new NotSupportedException ("Cannot delete " + map.TableName + ": it has no PK");
 			}
 			var q = string.Format ("delete from \"{0}\" where \"{1}\" = ?", map.TableName, pk.Name);
-			var count = Execute (q, primaryKey);
+			var count = PreparedExecute(q, primaryKey);
 			if (count > 0)
-				OnTableChanged (map, NotifyTableChangedAction.Delete);
+				OnTableChanged(map, NotifyTableChangedAction.Delete);
+
 			return count;
 		}
 
@@ -1815,7 +2140,7 @@ namespace SQLite
 		public int DeleteAll (TableMapping map)
 		{
 			var query = string.Format ("delete from \"{0}\"", map.TableName);
-			var count = Execute (query);
+			var count = PreparedExecute(query);
 			if (count > 0)
 				OnTableChanged (map, NotifyTableChangedAction.Delete);
 			return count;
@@ -1837,22 +2162,24 @@ namespace SQLite
 			Dispose (true);
 		}
 
+	    private static readonly SQLiteVersion MinClose2Version = new SQLiteVersion(3007014); // 3.7.14
+
 		protected virtual void Dispose (bool disposing)
 		{
-			var useClose2 = LibVersionNumber >= 3007014;
+			var useClose2 = LibraryVersion >= MinClose2Version;
 
 			if (_open && Handle != NullHandle) {
 				try {
 					if (disposing) {
-						if (_mappings != null) {
-							foreach (var sqlInsertCommand in _mappings.Values) {
-								sqlInsertCommand.Dispose ();
-							}
-						}
+						foreach (var pair in _cachedPreparedCommands)
+							pair.Value.Dispose();
+
+						_cachedPreparedCommands.Clear();
 
 						var r = useClose2 ? SQLite3.Close2 (Handle) : SQLite3.Close (Handle);
-						if (r != SQLite3.Result.OK) {
-							string msg = SQLite3.GetErrmsg (Handle);
+						if (r != SQLite3.Result.OK)
+						{
+							string msg = SQLite3.GetErrorMessage(Handle);
 							throw SQLiteException.New (r, msg);
 						}
 					}
@@ -1861,13 +2188,16 @@ namespace SQLite
 					}
 				}
 				finally {
+#if USE_SQLITEPCL_RAW
+					Handle.Dispose();
+#endif
 					Handle = NullHandle;
 					_open = false;
 				}
 			}
 		}
 
-		void OnTableChanged (TableMapping table, NotifyTableChangedAction action)
+		private void OnTableChanged(TableMapping table, NotifyTableChangedAction action)
 		{
 			var ev = TableChanged;
 			if (ev != null)
@@ -1934,6 +2264,17 @@ namespace SQLite
 #else
 			DatabasePath = databasePath;
 #endif
+		}
+	}
+	
+	[AttributeUsage(AttributeTargets.Class)]
+	public class TableMapperAttribute : Attribute 
+	{
+		public Type Mapper { get; set; }
+
+		public TableMapperAttribute(Type mapper)
+		{
+			Mapper = mapper;
 		}
 	}
 
@@ -2038,65 +2379,97 @@ namespace SQLite
 	{
 	}
 
-	public class TableMapping
-	{
-		public Type MappedType { get; private set; }
+	public interface ITableMapper
+    {
+        List<TableMapping.Column> GetColumns(Type t, CreateFlags createFlags = CreateFlags.None);
 
-		public string TableName { get; private set; }
+        object CreateInstance(Type t);
 
-		public Column[] Columns { get; private set; }
+        Type GetSchema(Type t);
+    }
 
-		public Column PK { get; private set; }
+    public class TableMapping
+    {
+        private static readonly ConcurrentTableDictionary _mappings = new ConcurrentTableDictionary();
+
+        public static IEnumerable<TableMapping> TableMappings => _mappings.Values;
+
+        /// <summary>
+        /// Retrieves the mapping that is automatically generated for the given type.
+        /// </summary>
+        /// <returns>
+        /// The mapping represents the schema of the columns of the database and contains
+        /// methods to set and get properties of objects.
+        /// </returns>
+        public static TableMapping GetMapping(Type type, CreateFlags createFlags = CreateFlags.None)
+        {
+            TableMapping map;
+            if (!_mappings.TryGetValue(type, out map))
+            {
+                map = new TableMapping(type, createFlags);
+                if (!_mappings.TryAdd(type, map))
+                {
+                    // concurrent add attempt this add, retreive a fresh copy
+                    _mappings.TryGetValue(type, out map);
+                }
+            }
+
+            return map;
+        }
+
+        /// <summary>
+        /// Retrieves the mapping that is automatically generated for the given type.
+        /// </summary>
+        /// <returns>
+        /// The mapping represents the schema of the columns of the database and contains
+        /// methods to set and get properties of objects.
+        /// </returns>
+        public static TableMapping GetMapping<T>()
+        {
+            return GetMapping(typeof(T));
+        }
+
+        private readonly ITableMapper _mapper;
+
+        private Type Schema { get; }
+
+        public string TableName { get; }
+
+        public Column[] Columns { get; }
+
+        public Column PK { get; }
 
 		public string GetByPrimaryKeySql { get; private set; }
 
-		Column _autoPk;
-		Column[] _insertColumns;
-		Column[] _insertOrReplaceColumns;
+        private readonly Column _autoPk;
+        private Column[] _insertColumns;
+        private Column[] _insertOrReplaceColumns;
+        private Dictionary<string, Column> _columnNameIndex;
+        private Dictionary<string, Column> _columnPropertyNameIndex;
+        private Column[] _updateColumns;
 
-		public TableMapping (Type type, CreateFlags createFlags = CreateFlags.None)
-		{
-			MappedType = type;
+        private TableMapping(Type type, CreateFlags createFlags = CreateFlags.None)
+        {
+	        var typeInfo = type.GetTypeInfo ();
+            var mapperAttr = (TableMapperAttribute)typeInfo.GetCustomAttributes(typeof(TableMapperAttribute), true).FirstOrDefault();
+            var mapperType = mapperAttr != null ? mapperAttr.Mapper : typeof(DefaultTableMapper);
 
-			var typeInfo = type.GetTypeInfo ();
-			var tableAttr =
-				typeInfo.CustomAttributes
-						.Where (x => x.AttributeType == typeof (TableAttribute))
-						.Select (x => (TableAttribute)Orm.InflateAttribute (x))
-						.FirstOrDefault ();
+            _mapper = Activator.CreateInstance(mapperType) as ITableMapper;
+            if (_mapper == null)
+                throw new Exception($"{mapperType.Name} is not of type {nameof(ITableMapper)}.");
 
-			TableName = (tableAttr != null && !string.IsNullOrEmpty (tableAttr.Name)) ? tableAttr.Name : MappedType.Name;
+            Schema = _mapper.GetSchema(type);
 
-			var props = new List<PropertyInfo> ();
-			var baseType = type;
-			var propNames = new HashSet<string> ();
-			while (baseType != typeof (object)) {
-				var ti = baseType.GetTypeInfo ();
-				var newProps = (
-					from p in ti.DeclaredProperties
-					where
-						!propNames.Contains (p.Name) &&
-						p.CanRead && p.CanWrite &&
-						(p.GetMethod != null) && (p.SetMethod != null) &&
-						(p.GetMethod.IsPublic && p.SetMethod.IsPublic) &&
-						(!p.GetMethod.IsStatic) && (!p.SetMethod.IsStatic)
-					select p).ToList ();
-				foreach (var p in newProps) {
-					propNames.Add (p.Name);
-				}
-				props.AddRange (newProps);
-				baseType = ti.BaseType;
-			}
+            var tableAttr =
+                typeInfo.CustomAttributes
+                    .Where(x => x.AttributeType == typeof(TableAttribute))
+                    .Select(x => (TableAttribute)Orm.InflateAttribute(x))
+                    .FirstOrDefault();
 
-			var cols = new List<Column> ();
-			foreach (var p in props) {
-				var ignore = p.IsDefined (typeof (IgnoreAttribute), true);
-				if (!ignore) {
-					cols.Add (new Column (p, createFlags));
-				}
-			}
-			Columns = cols.ToArray ();
-			foreach (var c in Columns) {
+			TableName = (tableAttr != null && !string.IsNullOrEmpty (tableAttr.Name)) ? tableAttr.Name : Schema.Name;
+
+            Columns = _mapper.GetColumns(Schema, createFlags).ToArray();
+            foreach (var c in Columns) {
 				if (c.IsAutoInc && c.IsPK) {
 					_autoPk = c;
 				}
@@ -2107,185 +2480,167 @@ namespace SQLite
 
 			HasAutoIncPK = _autoPk != null;
 
-			if (PK != null) {
-				GetByPrimaryKeySql = string.Format ("select * from \"{0}\" where \"{1}\" = ?", TableName, PK.Name);
-			}
-			else {
-				// People should not be calling Get/Find without a PK
-				GetByPrimaryKeySql = string.Format ("select * from \"{0}\" limit 1", TableName);
-			}
-			_insertCommandMap = new ConcurrentStringDictionary ();
-		}
+            GetByPrimaryKeySql = PK != null
+                ? $"select * from \"{TableName}\" where \"{PK.Name}\" = ?"
+                : $"select * from \"{TableName}\" limit 1";
+        }
+
+        public object CreateInstance() => _mapper.CreateInstance(Schema);
 
 		public bool HasAutoIncPK { get; private set; }
 
-		public void SetAutoIncPK (object obj, long id)
-		{
-			if (_autoPk != null) {
-				_autoPk.SetValue (obj, Convert.ChangeType (id, _autoPk.ColumnType, null));
-			}
-		}
+        public void SetAutoIncPK(object obj, long id)
+        {
+            _autoPk?.SetValue(obj, Convert.ChangeType(id, _autoPk.ColumnType, null));
+        }
 
-		public Column[] InsertColumns {
-			get {
-				if (_insertColumns == null) {
-					_insertColumns = Columns.Where (c => !c.IsAutoInc).ToArray ();
-				}
-				return _insertColumns;
-			}
-		}
+        public Column[] UpdateColumns => _updateColumns ?? (_updateColumns = Columns.Where(c => !c.IsPK).ToArray());
 
-		public Column[] InsertOrReplaceColumns {
-			get {
-				if (_insertOrReplaceColumns == null) {
-					_insertOrReplaceColumns = Columns.ToArray ();
-				}
-				return _insertOrReplaceColumns;
-			}
-		}
+        public Column[] InsertColumns => _insertColumns ?? (_insertColumns = Columns.Where(c => !c.IsAutoInc).ToArray());
 
-		public Column FindColumnWithPropertyName (string propertyName)
-		{
-			var exact = Columns.FirstOrDefault (c => c.PropertyName == propertyName);
-			return exact;
-		}
+        public Column[] InsertOrReplaceColumns => _insertOrReplaceColumns ?? (_insertOrReplaceColumns = Columns.ToArray());
 
-		public Column FindColumn (string columnName)
-		{
-			var exact = Columns.FirstOrDefault (c => c.Name.ToLower () == columnName.ToLower ());
-			return exact;
-		}
+        private Dictionary<string, Column> ColumnNameIndex => _columnNameIndex ?? (_columnNameIndex = Columns.ToDictionary(x => x.Name));
 
-		ConcurrentStringDictionary _insertCommandMap;
+        private Dictionary<string, Column> ColumnPropertyNameIndex => _columnPropertyNameIndex ?? (_columnPropertyNameIndex = Columns.ToDictionary(x => x.PropertyName));
 
-		public PreparedSqlLiteInsertCommand GetInsertCommand (SQLiteConnection conn, string extra)
-		{
-			object prepCmdO;
+        public Column FindColumnWithPropertyName(string propertyName)
+        {
+            Column col = null;
+            ColumnPropertyNameIndex.TryGetValue(propertyName, out col);
+            return col;
+        }
 
-			if (!_insertCommandMap.TryGetValue (extra, out prepCmdO)) {
-				var prepCmd = CreateInsertCommand (conn, extra);
-				prepCmdO = prepCmd;
-				if (!_insertCommandMap.TryAdd (extra, prepCmd)) {
-					// Concurrent add attempt beat us.
-					prepCmd.Dispose ();
-					_insertCommandMap.TryGetValue (extra, out prepCmdO);
-				}
-			}
-			return (PreparedSqlLiteInsertCommand)prepCmdO;
-		}
+        public Column FindColumn(string columnName)
+        {
+            Column col = null;
+            ColumnNameIndex.TryGetValue(columnName, out col);
+            return col;
+        }
 
-		PreparedSqlLiteInsertCommand CreateInsertCommand (SQLiteConnection conn, string extra)
-		{
-			var cols = InsertColumns;
-			string insertSql;
-			if (!cols.Any () && Columns.Count () == 1 && Columns[0].IsAutoInc) {
-				insertSql = string.Format ("insert {1} into \"{0}\" default values", TableName, extra);
-			}
-			else {
-				var replacing = string.Compare (extra, "OR REPLACE", StringComparison.OrdinalIgnoreCase) == 0;
+        public override string ToString() => TableName;
 
-				if (replacing) {
-					cols = InsertOrReplaceColumns;
-				}
+        private class DefaultTableMapper : ITableMapper
+        {
+            private static readonly Action<PropertyInfo, object, object> _setValue = (prop, obj, val) => prop.SetValue(obj, val, null);
+            private static readonly Func<PropertyInfo, object, object> _getValue = (prop, obj) => prop.GetValue(obj, null);
 
-				insertSql = string.Format ("insert {3} into \"{0}\"({1}) values ({2})", TableName,
-								   string.Join (",", (from c in cols
-													  select "\"" + c.Name + "\"").ToArray ()),
-								   string.Join (",", (from c in cols
-													  select "?").ToArray ()), extra);
+            public List<TableMapping.Column> GetColumns(Type t, CreateFlags createFlags = CreateFlags.None)
+            {
+                var props = new List<PropertyInfo>();
+                var baseType = t;
+                var propNames = new HashSet<string>();
+                while (baseType != typeof(object))
+                {
+                    var ti = baseType.GetTypeInfo();
+                    var newProps = (
+                        from p in ti.DeclaredProperties
+                        where
+                        !propNames.Contains(p.Name) &&
+                        p.CanRead && p.CanWrite &&
+                        (p.GetMethod != null) && (p.SetMethod != null) &&
+                        (p.GetMethod.IsPublic && p.SetMethod.IsPublic) &&
+                        (!p.GetMethod.IsStatic) && (!p.SetMethod.IsStatic)
+                        select p).ToList();
+                    foreach (var p in newProps)
+                    {
+                        propNames.Add(p.Name);
+                    }
+                    props.AddRange(newProps);
+                    baseType = ti.BaseType;
+                }
 
-			}
+                var cols = new List<Column>();
+                foreach (var p in props)
+                {
+			    	var ignore = p.GetCustomAttributes (typeof(IgnoreAttribute), true).Count() > 0;
 
-			var insertCommand = new PreparedSqlLiteInsertCommand (conn);
-			insertCommand.CommandText = insertSql;
-			return insertCommand;
-		}
+                    if (p.CanWrite && !ignore)
+                        cols.Add(new Column(p, _setValue, _getValue, createFlags));
+                }
 
-		protected internal void Dispose ()
-		{
-			foreach (var pair in _insertCommandMap) {
-				((PreparedSqlLiteInsertCommand)pair.Value).Dispose ();
-			}
-			_insertCommandMap = null;
-		}
+                return cols;
+            }
 
-		public class Column
-		{
-			PropertyInfo _prop;
+            public object CreateInstance(Type t)
+            {
+                return Activator.CreateInstance(t);
+            }
 
-			public string Name { get; private set; }
+            public Type GetSchema(Type t) => t;
+        }
 
-			public PropertyInfo PropertyInfo => _prop;
+        public class Column
+        {
+            private readonly PropertyInfo _prop;
+            private readonly Action<PropertyInfo, object, object> _setValue;
+            private readonly Func<PropertyInfo, object, object> _getValue;
 
-			public string PropertyName { get { return _prop.Name; } }
+            public string Name { get; }
 
-			public Type ColumnType { get; private set; }
+            public string PropertyName { get; }
 
-			public string Collation { get; private set; }
+            public Type ColumnType { get; }
 
-			public bool IsAutoInc { get; private set; }
-			public bool IsAutoGuid { get; private set; }
+            public string Collation { get; }
 
-			public bool IsPK { get; private set; }
+            public bool IsAutoInc { get; }
 
-			public IEnumerable<IndexedAttribute> Indices { get; set; }
+            public bool IsAutoGuid { get; }
 
-			public bool IsNullable { get; private set; }
+            public bool IsPK { get; }
 
-			public int? MaxStringLength { get; private set; }
+            public IEnumerable<IndexedAttribute> Indices { get; }
+
+            public bool IsNullable { get; }
+
+			public int? MaxStringLength { get; }
 
 			public bool StoreAsText { get; private set; }
+			
+            public Column(PropertyInfo prop, Action<PropertyInfo, object, object> setValue, Func<PropertyInfo, object, object> getValue, CreateFlags createFlags)
+            {
+                var colAttr = (ColumnAttribute)prop.GetCustomAttributes(typeof(ColumnAttribute), true).FirstOrDefault();
 
-			public Column (PropertyInfo prop, CreateFlags createFlags = CreateFlags.None)
-			{
-				var colAttr = prop.CustomAttributes.FirstOrDefault (x => x.AttributeType == typeof (ColumnAttribute));
+                _prop = prop;
+                PropertyName = prop.Name;
 
-				_prop = prop;
-				Name = (colAttr != null && colAttr.ConstructorArguments.Count > 0) ?
-						colAttr.ConstructorArguments[0].Value?.ToString () :
-						prop.Name;
-				//If this type is Nullable<T> then Nullable.GetUnderlyingType returns the T, otherwise it returns null, so get the actual type instead
-				ColumnType = Nullable.GetUnderlyingType (prop.PropertyType) ?? prop.PropertyType;
-				Collation = Orm.Collation (prop);
+                _setValue = setValue;
+                _getValue = getValue;
 
-				IsPK = Orm.IsPK (prop) ||
-					(((createFlags & CreateFlags.ImplicitPK) == CreateFlags.ImplicitPK) &&
-					 	string.Compare (prop.Name, Orm.ImplicitPkName, StringComparison.OrdinalIgnoreCase) == 0);
+                Name = colAttr == null ? prop.Name : colAttr.Name;
+                //If this type is Nullable<T> then Nullable.GetUnderlyingType returns the T, otherwise it returns null, so get the actual type instead
+                ColumnType = Nullable.GetUnderlyingType(prop.PropertyType) ?? prop.PropertyType;
+                Collation = Orm.Collation(prop);
 
-				var isAuto = Orm.IsAutoInc (prop) || (IsPK && ((createFlags & CreateFlags.AutoIncPK) == CreateFlags.AutoIncPK));
-				IsAutoGuid = isAuto && ColumnType == typeof (Guid);
-				IsAutoInc = isAuto && !IsAutoGuid;
+                IsPK = Orm.IsPK(prop) ||
+                       (((createFlags & CreateFlags.ImplicitPK) == CreateFlags.ImplicitPK) &&
+                        string.Compare(prop.Name, Orm.ImplicitPkName, StringComparison.OrdinalIgnoreCase) == 0);
 
-				Indices = Orm.GetIndices (prop);
-				if (!Indices.Any ()
-					&& !IsPK
-					&& ((createFlags & CreateFlags.ImplicitIndex) == CreateFlags.ImplicitIndex)
-					&& Name.EndsWith (Orm.ImplicitIndexSuffix, StringComparison.OrdinalIgnoreCase)
-					) {
-					Indices = new IndexedAttribute[] { new IndexedAttribute () };
-				}
-				IsNullable = !(IsPK || Orm.IsMarkedNotNull (prop));
-				MaxStringLength = Orm.MaxStringLength (prop);
+                var isAuto = Orm.IsAutoInc(prop) || (IsPK && ((createFlags & CreateFlags.AutoIncPK) == CreateFlags.AutoIncPK));
+                IsAutoGuid = isAuto && ColumnType == typeof(Guid);
+                IsAutoInc = isAuto && !IsAutoGuid;
 
-				StoreAsText = prop.PropertyType.GetTypeInfo ().CustomAttributes.Any (x => x.AttributeType == typeof (StoreAsTextAttribute));
-			}
+                Indices = Orm.GetIndices(prop);
+                if (!Indices.Any()
+                    && !IsPK
+                    && ((createFlags & CreateFlags.ImplicitIndex) == CreateFlags.ImplicitIndex)
+                    && Name.EndsWith(Orm.ImplicitIndexSuffix, StringComparison.OrdinalIgnoreCase)
+                )
+                {
+                    Indices = new[] { new IndexedAttribute() };
+                }
+                IsNullable = !(IsPK || Orm.IsMarkedNotNull(prop));
+                MaxStringLength = Orm.MaxStringLength(prop);
+            }
 
-			public void SetValue (object obj, object val)
-			{
-				if (val != null && ColumnType.GetTypeInfo ().IsEnum) {
-					_prop.SetValue (obj, Enum.ToObject (ColumnType, val));
-				}
-				else {
-					_prop.SetValue (obj, val, null);
-				}
-			}
+            public void SetValue(object obj, object val) => _setValue(_prop, obj, val);
 
-			public object GetValue (object obj)
-			{
-				return _prop.GetValue (obj, null);
-			}
-		}
-	}
+            public object GetValue(object obj) => _getValue(_prop, obj);
+
+            public override string ToString() => $"{Name} ({ColumnType.Name})";
+        }
+    }
 
 	class EnumCacheInfo
 	{
@@ -2316,7 +2671,7 @@ namespace SQLite
 
 	static class EnumCache
 	{
-		static readonly Dictionary<Type, EnumCacheInfo> Cache = new Dictionary<Type, EnumCacheInfo> ();
+		private static readonly Dictionary<Type, EnumCacheInfo> Cache = new Dictionary<Type, EnumCacheInfo> ();
 
 		public static EnumCacheInfo GetInfo<T> ()
 		{
@@ -2496,198 +2851,369 @@ namespace SQLite
 		}
 	}
 
-	public partial class SQLiteCommand
-	{
-		SQLiteConnection _conn;
-		private List<Binding> _bindings;
+    /// <summary>
+    /// Since the insert or update never changed, we only need to prepare once.
+    /// </summary>
+    public class SQLiteCommand : IDisposable, IEquatable<SQLiteCommand>
+    {
+        private readonly static IntPtr NegativePointer = new IntPtr(-1);
 
-		public string CommandText { get; set; }
+        private const string DateTimeExactStoreFormat = "yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fff";
+
+
+        private bool _disposed;
+
+        public bool Prepared { get; private set; }
+
+        protected SQLiteConnection Connection { get; private set; }
+
+        public string CommandText { get; set; }
+
+        protected Sqlite3Statement Statement { get; set; }
+        internal static readonly Sqlite3Statement NullStatement = default(Sqlite3Statement);
 
 		internal SQLiteCommand (SQLiteConnection conn)
 		{
-			_conn = conn;
-			_bindings = new List<Binding> ();
-			CommandText = "";
-		}
+            Connection = conn;
+        }
 
-		public int ExecuteNonQuery ()
-		{
-			if (_conn.Trace) {
-				_conn.Tracer?.Invoke ("Executing: " + this);
-			}
+        internal SQLiteCommand(SQLiteConnection conn, string commandText)
+        {
+            Connection = conn;
+            CommandText = commandText;
+        }
 
-			var r = SQLite3.Result.OK;
-			var stmt = Prepare ();
-			r = SQLite3.Step (stmt);
-			Finalize (stmt);
-			if (r == SQLite3.Result.Done) {
-				int rowsAffected = SQLite3.Changes (_conn.Handle);
-				return rowsAffected;
-			}
-			else if (r == SQLite3.Result.Error) {
-				string msg = SQLite3.GetErrmsg (_conn.Handle);
-				throw SQLiteException.New (r, msg);
-			}
-			else if (r == SQLite3.Result.Constraint) {
-				if (SQLite3.ExtendedErrCode (_conn.Handle) == SQLite3.ExtendedResult.ConstraintNotNull) {
-					throw NotNullConstraintViolationException.New (r, SQLite3.GetErrmsg (_conn.Handle));
-				}
-			}
+        /// <summary>
+        /// Invoked every time an instance is loaded from the database.
+        /// </summary>
+        /// <param name='obj'>
+        /// The newly created object.
+        /// </param>
+        /// <remarks>
+        /// This can be overridden in combination with the <see cref="SQLiteConnection.NewCommand"/>
+        /// method to hook into the life-cycle of objects.
+        ///
+        /// Type safety is not possible because MonoTouch does not support virtual generic methods.
+        /// </remarks>
+        protected virtual void OnInstanceCreated(object obj)
+        {
+            // Can be overridden.
+        }
 
-			throw SQLiteException.New (r, r.ToString ());
-		}
+	    public IEnumerable<T> ExecuteQuery<T> ()
+	    {
+		    return ExecuteQuery<T> (Connection.GetMapping<T> (), null);
+	    }
 
-		public IEnumerable<T> ExecuteDeferredQuery<T> ()
-		{
-			return ExecuteDeferredQuery<T> (_conn.GetMapping (typeof (T)));
-		}
+	    public IEnumerable<T> ExecuteQuery<T>(object[] source)
+        {
+            return ExecuteQuery<T>(Connection.GetMapping<T>(), source);
+        }
 
-		public List<T> ExecuteQuery<T> ()
-		{
-			return ExecuteDeferredQuery<T> (_conn.GetMapping (typeof (T))).ToList ();
-		}
+        public IEnumerable<T> ExecuteQuery<T>(TableMapping map, object[] source)
+        {
+            CheckDisposed();
+            Log(nameof(Execute), source);
 
-		public List<T> ExecuteQuery<T> (TableMapping map)
-		{
-			return ExecuteDeferredQuery<T> (map).ToList ();
-		}
+            var sw = Stopwatch.StartNew();
+            try
+            {
+                var r = SQLite3.Result.OK;
 
-		/// <summary>
-		/// Invoked every time an instance is loaded from the database.
-		/// </summary>
-		/// <param name='obj'>
-		/// The newly created object.
-		/// </param>
-		/// <remarks>
-		/// This can be overridden in combination with the <see cref="SQLiteConnection.NewCommand"/>
-		/// method to hook into the life-cycle of objects.
-		///
-		/// Type safety is not possible because MonoTouch does not support virtual generic methods.
-		/// </remarks>
-		protected virtual void OnInstanceCreated (object obj)
-		{
-			// Can be overridden.
-		}
+                if (!Prepared)
+                {
+                    Statement = Prepare();
+                    Prepared = true;
+                }
 
-		public IEnumerable<T> ExecuteDeferredQuery<T> (TableMapping map)
-		{
-			if (_conn.Trace) {
-				_conn.Tracer?.Invoke ("Executing Query: " + this);
-			}
+                //bind the values.
+                if (source != null)
+                    for (int i = 0; i < source.Length; i++)
+                        BindParameter(Statement, i + 1, source[i], Connection.StoreDateTimeAsTicks);
 
-			var stmt = Prepare ();
-			try {
-				var cols = new TableMapping.Column[SQLite3.ColumnCount (stmt)];
+                var cols = new TableMapping.Column[SQLite3.ColumnCount(Statement)];
 
-				for (int i = 0; i < cols.Length; i++) {
-					var name = SQLite3.ColumnName16 (stmt, i);
-					cols[i] = map.FindColumn (name);
-				}
+                for (int i = 0; i < cols.Length; i++)
+                {
+                    var name = SQLite3.ColumnName16(Statement, i);
+                    cols[i] = map.FindColumn(name);
+                }
 
-				while (SQLite3.Step (stmt) == SQLite3.Result.Row) {
-					var obj = Activator.CreateInstance (map.MappedType);
-					for (int i = 0; i < cols.Length; i++) {
-						if (cols[i] == null)
-							continue;
-						var colType = SQLite3.ColumnType (stmt, i);
-						var val = ReadCol (stmt, i, colType, cols[i].ColumnType);
-						cols[i].SetValue (obj, val);
-					}
-					OnInstanceCreated (obj);
-					yield return (T)obj;
-				}
-			}
-			finally {
-				SQLite3.Finalize (stmt);
-			}
-		}
+                while (SQLite3.Step(Statement) == SQLite3.Result.Row)
+                {
+                    var obj = map.CreateInstance();
+                    for (int i = 0; i < cols.Length; i++)
+                    {
+                        if (cols[i] == null)
+                            continue;
+                        var colType = SQLite3.ColumnType(Statement, i);
+                        var val = ReadCol(Statement, i, colType, cols[i].ColumnType);
+                        cols[i].SetValue(obj, val);
+                    }
+                    OnInstanceCreated(obj);
+                    yield return (T) obj;
+                }
 
-		public T ExecuteScalar<T> ()
-		{
-			if (_conn.Trace) {
-				_conn.Tracer?.Invoke ("Executing Query: " + this);
-			}
+                if (r == SQLite3.Result.Done || r == SQLite3.Result.OK) { }
+                else
+                {
+                    var msg = SQLite3.GetErrorMessage(Connection.Handle);
 
-			T val = default (T);
+                    if (r == SQLite3.Result.Constraint && SQLite3.ExtendedErrCode(Connection.Handle) == SQLite3.ExtendedResult.ConstraintNotNull)
+                        throw NotNullConstraintViolationException.New(r, msg, sql: CommandText);
 
-			var stmt = Prepare ();
+                    throw SQLiteException.New(r, msg, sql: CommandText);
+                }
+            }
+            finally
+            {
+                SQLite3.Reset(Statement);
 
-			try {
-				var r = SQLite3.Step (stmt);
-				if (r == SQLite3.Result.Row) {
-					var colType = SQLite3.ColumnType (stmt, 0);
-					val = (T)ReadCol (stmt, 0, colType, typeof (T));
-				}
-				else if (r == SQLite3.Result.Done) {
-				}
-				else {
-					throw SQLiteException.New (r, SQLite3.GetErrmsg (_conn.Handle));
-				}
-			}
-			finally {
-				Finalize (stmt);
-			}
+                sw.Stop();
+                Log(sw);
+            }
+        }
+
+	    public T ExecuteScalar<T> ()
+	    {
+		    return ExecuteScalar<T> (null);
+	    }
+
+		public T ExecuteScalar<T>(object[] source)
+        {
+            CheckDisposed();
+            Log(nameof(ExecuteScalar), source);
+
+            var sw = Stopwatch.StartNew();
+            T val = default(T);
+
+            try
+            {
+                var r = InternalExecute(source);
+
+                if (r == SQLite3.Result.Row)
+                {
+                    var colType = SQLite3.ColumnType(Statement, 0);
+                    val = (T) ReadCol(Statement, 0, colType, typeof(T));
+                }
+                else if (r == SQLite3.Result.Done || r == SQLite3.Result.OK) { }
+            }
+            finally
+            {
+                SQLite3.Reset(Statement);
+
+                sw.Stop();
+                Log(sw);
+            }
 
 			return val;
 		}
 
-		public void Bind (string name, object val)
-		{
-			_bindings.Add (new Binding {
-				Name = name,
-				Value = val
-			});
-		}
+	    public int ExecuteNonQuery ()
+	    {
+		    return ExecuteNonQuery (null);
+	    }
 
-		public void Bind (object val)
-		{
-			Bind (null, val);
-		}
+	    public int ExecuteNonQuery(object[] source)
+        {
+            CheckDisposed();
+            Log(nameof(ExecuteNonQuery), source);
 
-		public override string ToString ()
-		{
-			var parts = new string[1 + _bindings.Count];
-			parts[0] = CommandText;
-			var i = 1;
-			foreach (var b in _bindings) {
-				parts[i] = string.Format ("  {0}: {1}", i - 1, b.Value);
-				i++;
-			}
-			return string.Join (Environment.NewLine, parts);
-		}
+            var sw = Stopwatch.StartNew();
+            try
+            {
+                var r = InternalExecute(source);
 
-		Sqlite3Statement Prepare ()
+                if (r == SQLite3.Result.Done || r == SQLite3.Result.OK || r == SQLite3.Result.Row)
+                {
+                    int rowsAffected = SQLite3.Changes(Connection.Handle);
+                    return rowsAffected;
+                }
+
+                return 0;
+            }
+            finally
+            {
+                SQLite3.Reset(Statement);
+
+                sw.Stop();
+                Log(sw);
+            }
+        }
+
+	    public SQLite3.Result Execute ()
+	    {
+		    return Execute (null);
+	    }
+
+		public SQLite3.Result Execute(object[] source)
+        {
+            CheckDisposed();
+            Log(nameof(Execute), source);
+
+            var sw = Stopwatch.StartNew();
+            try
+            {
+                return InternalExecute(source);
+            }
+            finally
+            {
+                SQLite3.Reset(Statement);
+
+                sw.Stop();
+                Log(sw);
+            }
+        }
+
+        private SQLite3.Result InternalExecute(object[] source)
+        {
+
+            var r = SQLite3.Result.OK;
+
+            if (!Prepared)
+            {
+                Statement = Prepare();
+                Prepared = true;
+            }
+
+            //bind the values.
+            if (source != null)
+                for (int i = 0; i < source.Length; i++)
+                    BindParameter(Statement, i + 1, source[i], Connection.StoreDateTimeAsTicks);
+
+            r = SQLite3.Step(Statement);
+
+            if (r == SQLite3.Result.Done || r == SQLite3.Result.OK || r == SQLite3.Result.Row)
+            {
+                return r;
+            }
+            else
+            {
+                var msg = SQLite3.GetErrorMessage(Connection.Handle);
+
+                if (r == SQLite3.Result.Constraint && SQLite3.ExtendedErrCode(Connection.Handle) == SQLite3.ExtendedResult.ConstraintNotNull)
+                    throw NotNullConstraintViolationException.New(r, msg, sql: CommandText);
+
+                throw SQLiteException.New(r, msg, sql: CommandText);
+            }
+        }
+
+        private void Log(Stopwatch sw)
+        {
+            if (Connection.Trace && sw.Elapsed > Connection.TraceTimeExceeding)
+            {
+                Connection.Tracer($"Database took {sw.ElapsedMilliseconds} ms to execute: {CommandText}");
+            }
+        }
+
+        private void Log(string method, object[] source)
+        {
+            if (Connection.Trace)
+            {
+                var parts = new List<string>();
+                parts.Add(CommandText);
+
+                if (source != null)
+                {
+                    var index = 0;
+                    foreach (var b in source)
+                        parts.Add($"  {index++}: {b}");
+                }
+
+                Connection.Tracer($"{method}: {String.Join(Environment.NewLine, parts)}");
+            }
+        }
+
+        protected virtual Sqlite3Statement Prepare()
 		{
-			var stmt = SQLite3.Prepare2 (_conn.Handle, CommandText);
-			BindAll (stmt);
+			var stmt = SQLite3.Prepare2(Connection.Handle, CommandText);
 			return stmt;
 		}
 
-		void Finalize (Sqlite3Statement stmt)
+		private object ReadCol (Sqlite3Statement stmt, int index, SQLite3.ColType type, Type clrType)
 		{
-			SQLite3.Finalize (stmt);
-		}
-
-		void BindAll (Sqlite3Statement stmt)
-		{
-			int nextIdx = 1;
-			foreach (var b in _bindings) {
-				if (b.Name != null) {
-					b.Index = SQLite3.BindParameterIndex (stmt, b.Name);
+			if (type == SQLite3.ColType.Null) {
+				return null;
+			}
+			else {
+				var clrTypeInfo = clrType.GetTypeInfo ();
+				if (clrType == typeof (String)) {
+					return SQLite3.ColumnString (stmt, index);
+				}
+				else if (clrType == typeof (Int32)) {
+					return (int)SQLite3.ColumnInt (stmt, index);
+				}
+				else if (clrType == typeof (Boolean)) {
+					return SQLite3.ColumnInt (stmt, index) == 1;
+				}
+				else if (clrType == typeof (double)) {
+					return SQLite3.ColumnDouble (stmt, index);
+				}
+				else if (clrType == typeof (float)) {
+					return (float)SQLite3.ColumnDouble (stmt, index);
+				}
+				else if (clrType == typeof (TimeSpan)) {
+					return new TimeSpan (SQLite3.ColumnInt64 (stmt, index));
+				}
+				else if (clrType == typeof (DateTime)) {
+					if (Connection.StoreDateTimeAsTicks) {
+						return new DateTime (SQLite3.ColumnInt64 (stmt, index));
+					}
+					else {
+						var text = SQLite3.ColumnString (stmt, index);
+						DateTime resultDate;
+						if (!DateTime.TryParseExact (text, DateTimeExactStoreFormat, System.Globalization.CultureInfo.InvariantCulture, System.Globalization.DateTimeStyles.None, out resultDate)) {
+							resultDate = DateTime.Parse (text);
+						}
+						return resultDate;
+					}
+				}
+				else if (clrType == typeof (DateTimeOffset)) {
+					return new DateTimeOffset (SQLite3.ColumnInt64 (stmt, index), TimeSpan.Zero);
+				}
+				else if (clrTypeInfo.IsEnum) {
+					if (type == SQLite3.ColType.Text) {
+						var value = SQLite3.ColumnString (stmt, index);
+						return Enum.Parse (clrType, value.ToString (), true);
+					}
+					else
+						return SQLite3.ColumnInt (stmt, index);
+				}
+				else if (clrType == typeof (Int64)) {
+					return SQLite3.ColumnInt64 (stmt, index);
+				}
+				else if (clrType == typeof (UInt32)) {
+					return (uint)SQLite3.ColumnInt64 (stmt, index);
+				}
+				else if (clrType == typeof (decimal)) {
+					return (decimal)SQLite3.ColumnDouble (stmt, index);
+				}
+				else if (clrType == typeof (Byte)) {
+					return (byte)SQLite3.ColumnInt (stmt, index);
+				}
+				else if (clrType == typeof (UInt16)) {
+					return (ushort)SQLite3.ColumnInt (stmt, index);
+				}
+				else if (clrType == typeof (Int16)) {
+					return (short)SQLite3.ColumnInt (stmt, index);
+				}
+				else if (clrType == typeof (sbyte)) {
+					return (sbyte)SQLite3.ColumnInt (stmt, index);
+				}
+				else if (clrType == typeof (byte[])) {
+					return SQLite3.ColumnByteArray (stmt, index);
+				}
+				else if (clrType == typeof (Guid)) {
+					var text = SQLite3.ColumnString (stmt, index);
+					return new Guid (text);
 				}
 				else {
-					b.Index = nextIdx++;
+					throw new NotSupportedException ("Don't know how to read " + clrType);
 				}
-
-				BindParameter (stmt, b.Index, b.Value, _conn.StoreDateTimeAsTicks);
 			}
 		}
 
-		internal static IntPtr NegativePointer = new IntPtr (-1);
-
-		const string DateTimeExactStoreFormat = "yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fff";
-
-		internal static void BindParameter (Sqlite3Statement stmt, int index, object value, bool storeDateTimeAsTicks)
+		private static void BindParameter (Sqlite3Statement stmt, int index, object value, bool storeDateTimeAsTicks)
 		{
 			if (value == null) {
 				SQLite3.BindNull (stmt, index);
@@ -2749,194 +3275,84 @@ namespace SQLite
 			}
 		}
 
-		class Binding
-		{
-			public string Name { get; set; }
 
-			public object Value { get; set; }
+	    public void ResetStatement()
+	    {
+	        try
+	        {
+	            SQLite3.Finalize(Statement);
+	        }
+	        finally
+	        {
+	            Statement = NullStatement;
+	            Prepared = false;
+	        }
+	    }
 
-			public int Index { get; set; }
-		}
-
-		object ReadCol (Sqlite3Statement stmt, int index, SQLite3.ColType type, Type clrType)
-		{
-			if (type == SQLite3.ColType.Null) {
-				return null;
-			}
-			else {
-				var clrTypeInfo = clrType.GetTypeInfo ();
-				if (clrType == typeof (String)) {
-					return SQLite3.ColumnString (stmt, index);
-				}
-				else if (clrType == typeof (Int32)) {
-					return (int)SQLite3.ColumnInt (stmt, index);
-				}
-				else if (clrType == typeof (Boolean)) {
-					return SQLite3.ColumnInt (stmt, index) == 1;
-				}
-				else if (clrType == typeof (double)) {
-					return SQLite3.ColumnDouble (stmt, index);
-				}
-				else if (clrType == typeof (float)) {
-					return (float)SQLite3.ColumnDouble (stmt, index);
-				}
-				else if (clrType == typeof (TimeSpan)) {
-					return new TimeSpan (SQLite3.ColumnInt64 (stmt, index));
-				}
-				else if (clrType == typeof (DateTime)) {
-					if (_conn.StoreDateTimeAsTicks) {
-						return new DateTime (SQLite3.ColumnInt64 (stmt, index));
-					}
-					else {
-						var text = SQLite3.ColumnString (stmt, index);
-						DateTime resultDate;
-						if (!DateTime.TryParseExact (text, DateTimeExactStoreFormat, System.Globalization.CultureInfo.InvariantCulture, System.Globalization.DateTimeStyles.None, out resultDate)) {
-							resultDate = DateTime.Parse (text);
-						}
-						return resultDate;
-					}
-				}
-				else if (clrType == typeof (DateTimeOffset)) {
-					return new DateTimeOffset (SQLite3.ColumnInt64 (stmt, index), TimeSpan.Zero);
-				}
-				else if (clrTypeInfo.IsEnum) {
-					if (type == SQLite3.ColType.Text) {
-						var value = SQLite3.ColumnString (stmt, index);
-						return Enum.Parse (clrType, value.ToString (), true);
-					}
-					else
-						return SQLite3.ColumnInt (stmt, index);
-				}
-				else if (clrType == typeof (Int64)) {
-					return SQLite3.ColumnInt64 (stmt, index);
-				}
-				else if (clrType == typeof (UInt32)) {
-					return (uint)SQLite3.ColumnInt64 (stmt, index);
-				}
-				else if (clrType == typeof (decimal)) {
-					return (decimal)SQLite3.ColumnDouble (stmt, index);
-				}
-				else if (clrType == typeof (Byte)) {
-					return (byte)SQLite3.ColumnInt (stmt, index);
-				}
-				else if (clrType == typeof (UInt16)) {
-					return (ushort)SQLite3.ColumnInt (stmt, index);
-				}
-				else if (clrType == typeof (Int16)) {
-					return (short)SQLite3.ColumnInt (stmt, index);
-				}
-				else if (clrType == typeof (sbyte)) {
-					return (sbyte)SQLite3.ColumnInt (stmt, index);
-				}
-				else if (clrType == typeof (byte[])) {
-					return SQLite3.ColumnByteArray (stmt, index);
-				}
-				else if (clrType == typeof (Guid)) {
-					var text = SQLite3.ColumnString (stmt, index);
-					return new Guid (text);
-				}
-				else {
-					throw new NotSupportedException ("Don't know how to read " + clrType);
-				}
-			}
-		}
-	}
-
-	/// <summary>
-	/// Since the insert never changed, we only need to prepare once.
-	/// </summary>
-	public class PreparedSqlLiteInsertCommand : IDisposable
-	{
-		public bool Initialized { get; set; }
-
-		protected SQLiteConnection Connection { get; set; }
-
-		public string CommandText { get; set; }
-
-		protected Sqlite3Statement Statement { get; set; }
-		internal static readonly Sqlite3Statement NullStatement = default (Sqlite3Statement);
-
-		internal PreparedSqlLiteInsertCommand (SQLiteConnection conn)
-		{
-			Connection = conn;
-		}
-
-		public int ExecuteNonQuery (object[] source)
-		{
-			if (Connection.Trace) {
-				Connection.Tracer?.Invoke ("Executing: " + CommandText);
-			}
-
-			var r = SQLite3.Result.OK;
-
-			if (!Initialized) {
-				Statement = Prepare ();
-				Initialized = true;
-			}
-
-			//bind the values.
-			if (source != null) {
-				for (int i = 0; i < source.Length; i++) {
-					SQLiteCommand.BindParameter (Statement, i + 1, source[i], Connection.StoreDateTimeAsTicks);
-				}
-			}
-			r = SQLite3.Step (Statement);
-
-			if (r == SQLite3.Result.Done) {
-				int rowsAffected = SQLite3.Changes (Connection.Handle);
-				SQLite3.Reset (Statement);
-				return rowsAffected;
-			}
-			else if (r == SQLite3.Result.Error) {
-				string msg = SQLite3.GetErrmsg (Connection.Handle);
-				SQLite3.Reset (Statement);
-				throw SQLiteException.New (r, msg);
-			}
-			else if (r == SQLite3.Result.Constraint && SQLite3.ExtendedErrCode (Connection.Handle) == SQLite3.ExtendedResult.ConstraintNotNull) {
-				SQLite3.Reset (Statement);
-				throw NotNullConstraintViolationException.New (r, SQLite3.GetErrmsg (Connection.Handle));
-			}
-			else {
-				SQLite3.Reset (Statement);
-				throw SQLiteException.New (r, r.ToString ());
-			}
-		}
-
-		protected virtual Sqlite3Statement Prepare ()
-		{
-			var stmt = SQLite3.Prepare2 (Connection.Handle, CommandText);
-			return stmt;
-		}
-
-		public void Dispose ()
+        public void Dispose()
 		{
 			Dispose (true);
 			GC.SuppressFinalize (this);
 		}
 
-		private void Dispose (bool disposing)
+	    private void CheckDisposed()
+	    {
+	        if (_disposed)
+	            throw new ObjectDisposedException(nameof(SQLiteCommand), $"Disposed Query: {CommandText}");
+        }
+
+	    private void Dispose(bool disposing)
+	    {
+	        if (!_disposed && Statement != NullStatement)
+	        {
+	            _disposed = true;
+
+	            ResetStatement();
+	            Connection = null;
+	        }
+	    }
+
+	    ~SQLiteCommand()
 		{
-			if (Statement != NullStatement) {
-				try {
-					SQLite3.Finalize (Statement);
-				}
-				finally {
-					Statement = NullStatement;
-					Connection = null;
-				}
-			}
+			Dispose(false);
 		}
 
-		~PreparedSqlLiteInsertCommand ()
-		{
-			Dispose (false);
-		}
-	}
+	    public override string ToString() => CommandText;
+
+	    public bool Equals(SQLiteCommand other)
+	    {
+	        return string.Equals(CommandText, other.CommandText);
+	    }
+
+	    public override bool Equals(object obj)
+	    {
+	        if (ReferenceEquals(null, obj)) return false;
+	        if (ReferenceEquals(this, obj)) return true;
+	        if (obj.GetType() != this.GetType()) return false;
+	        return Equals((SQLiteCommand)obj);
+	    }
+
+	    public override int GetHashCode()
+	    {
+	        return (CommandText != null ? CommandText.GetHashCode() : 0);
+	    }
+
+        public static bool operator ==(SQLiteCommand left, SQLiteCommand right)
+	    {
+	        return Equals(left, right);
+	    }
+
+	    public static bool operator !=(SQLiteCommand left, SQLiteCommand right)
+	    {
+	        return !Equals(left, right);
+	    }
+    }
 
 	public enum CreateTableResult
 	{
 		Created,
 		Migrated,
+		Error
 	}
 
 	public class CreateTablesResult
@@ -3056,10 +3472,11 @@ namespace SQLite
 			var w = CompileExpr (pred, args);
 			cmdText += " where " + w.CommandText;
 
-			var command = Connection.CreateCommand (cmdText, args.ToArray ());
-
-			int result = command.ExecuteNonQuery ();
-			return result;
+		    using (var command = new SQLiteCommand(Connection, cmdText))
+		    {
+                var result = command.ExecuteNonQuery(args.ToArray());
+		        return result;
+		    }
 		}
 
 		/// <summary>
@@ -3130,7 +3547,7 @@ namespace SQLite
 			return AddOrderBy<U> (orderExpr, false);
 		}
 
-		TableQuery<T> AddOrderBy<U> (Expression<Func<T, U>> orderExpr, bool asc)
+		private TableQuery<T> AddOrderBy<U>(Expression<Func<T, U>> orderExpr, bool asc)
 		{
 			if (orderExpr.NodeType == ExpressionType.Lambda) {
 				var lambda = (LambdaExpression)orderExpr;
@@ -3203,7 +3620,7 @@ namespace SQLite
 		//	return q;
 		//}
 
-		private SQLiteCommand GenerateCommand (string selectionList)
+		private Tuple<string, object[]> GetCommandText(string selectionList)
 		{
 			if (_joinInner != null && _joinOuter != null) {
 				throw new NotSupportedException ("Joins are not supported.");
@@ -3228,11 +3645,58 @@ namespace SQLite
 					}
 					cmdText += " offset " + _offset.Value;
 				}
-				return Connection.CreateCommand (cmdText, args.ToArray ());
-			}
-		}
 
-		class CompileResult
+#if DEBUG_BROAD_QUERY_CHECK
+				var queryTooBroadCheck = "select " + selectionList + " from \"" + Table.TableName + "\"";
+				if (cmdText == queryTooBroadCheck)
+					Debugger.Break();
+#endif
+
+			    return new Tuple<string, object[]>(cmdText, args.ToArray());
+			}
+        }
+
+	    private TResult ExecuteCommand<TResult>(string selectionList, Func<SQLiteCommand, object[], TResult> exec)
+	    {
+	        var command = GetCommandText(selectionList);
+	        using (var cmd = new SQLiteCommand(Connection, command.Item1))
+	            return exec(cmd, command.Item2);
+	    }
+
+	    private SQLiteCommandEnumerator<T> GetCommandEnumerator(string selectionList, Func<SQLiteCommand, object[], IEnumerable<T>> exec)
+	    {
+	        var command = GetCommandText(selectionList);
+	        var cmd = new SQLiteCommand(Connection, command.Item1);
+	        return new SQLiteCommandEnumerator<T>(cmd, exec(cmd, command.Item2).GetEnumerator());
+	    }
+
+        private class SQLiteCommandEnumerator<TResult> : IEnumerator<TResult>
+	    {
+	        private readonly SQLiteCommand _cmd;
+	        private readonly IEnumerator<TResult> _e;
+
+	        public SQLiteCommandEnumerator(SQLiteCommand cmd, IEnumerator<TResult> e)
+	        {
+	            _cmd = cmd;
+	            _e = e;
+	        }
+
+	        public bool MoveNext() => _e.MoveNext();
+
+	        public void Reset() => _e.Reset();
+
+	        public TResult Current => _e.Current;
+
+	        object IEnumerator.Current => Current;
+
+	        public void Dispose()
+	        {
+	            _e.Dispose();
+                _cmd.Dispose();
+	        }
+	    }
+
+        private class CompileResult
 		{
 			public string CommandText { get; set; }
 
@@ -3511,10 +3975,32 @@ namespace SQLite
 			}
 			else if (n == ExpressionType.NotEqual) {
 				return "!=";
-			}
-			else {
+			} else {
 				throw new NotSupportedException ("Cannot get SQL for: " + n);
 			}
+		}
+		
+		public bool Any()
+		{
+            // For example, the below line will generate a SQL query like:
+            // select 1 from files where uuid = ? limit 1;
+            // for conn.Table<FilesSyncRecord>().Where(x => x.Uuid == uuid).Any();
+		    return Take(1).ExecuteCommand("1", (cmd, args) => cmd.ExecuteScalar<int>(args)) > 0;
+		}
+
+		public bool Any(Expression<Func<T, bool>> predExpr)
+		{
+			return Where(predExpr).Any();
+		}
+
+		public bool All()
+		{
+			throw new NotSupportedException();
+		}
+
+		public bool All(Expression<Func<T, bool>> predExpr)
+		{
+			throw new NotSupportedException();
 		}
 
 		/// <summary>
@@ -3522,7 +4008,7 @@ namespace SQLite
 		/// </summary>
 		public int Count ()
 		{
-			return GenerateCommand ("count(*)").ExecuteScalar<int> ();
+		    return ExecuteCommand("count(*)", (cmd, args) => cmd.ExecuteScalar<int>(args));
 		}
 
 		/// <summary>
@@ -3535,11 +4021,11 @@ namespace SQLite
 
 		public IEnumerator<T> GetEnumerator ()
 		{
-			if (!_deferred)
-				return GenerateCommand ("*").ExecuteQuery<T> ().GetEnumerator ();
+		    if (!_deferred)
+		        return GetCommandEnumerator("*", (cmd, args) => cmd.ExecuteQuery<T>(args));
 
-			return GenerateCommand ("*").ExecuteDeferredQuery<T> ().GetEnumerator ();
-		}
+            return ExecuteCommand("*", (cmd, args) => cmd.ExecuteQuery<T>(args).ToList()).GetEnumerator();
+        }
 
 		System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator ()
 		{
@@ -3551,7 +4037,7 @@ namespace SQLite
 		/// </summary>
 		public List<T> ToList ()
 		{
-			return GenerateCommand ("*").ExecuteQuery<T> ();
+		    return ExecuteCommand("*", (cmd, args) => cmd.ExecuteQuery<T>(args).ToList());
 		}
 
 		/// <summary>
@@ -3559,7 +4045,7 @@ namespace SQLite
 		/// </summary>
 		public T[] ToArray ()
 		{
-			return GenerateCommand ("*").ExecuteQuery<T> ().ToArray ();
+		    return ExecuteCommand("*", (cmd, args) => cmd.ExecuteQuery<T>(args).ToArray());
 		}
 
 		/// <summary>
@@ -3585,7 +4071,8 @@ namespace SQLite
 		/// </summary>
 		public T First (Expression<Func<T, bool>> predExpr)
 		{
-			return Where (predExpr).First ();
+			var query = Where(predExpr).Take(1);
+			return query.ToList<T>().First();
 		}
 
 		/// <summary>
@@ -3594,13 +4081,15 @@ namespace SQLite
 		/// </summary>
 		public T FirstOrDefault (Expression<Func<T, bool>> predExpr)
 		{
-			return Where (predExpr).FirstOrDefault ();
+			var query = Where(predExpr).Take(1);
+			return query.ToList<T>().FirstOrDefault();
 		}
 	}
 
 	public static class SQLite3
 	{
-		public enum Result : int
+        // https://www.sqlite.org/rescode.html
+        public enum Result : int
 		{
 			OK = 0,
 			Error = 1,
@@ -3635,7 +4124,8 @@ namespace SQLite
 			Done = 101
 		}
 
-		public enum ExtendedResult : int
+        // https://www.sqlite.org/rescode.html
+        public enum ExtendedResult : int
 		{
 			IOErrorRead = (Result.IOError | (1 << 8)),
 			IOErrorShortRead = (Result.IOError | (2 << 8)),
@@ -3661,7 +4151,7 @@ namespace SQLite
 			IOErrorSeek = (Result.IOError | (22 << 8)),
 			IOErrorDeleteNoEnt = (Result.IOError | (23 << 8)),
 			IOErrorMMap = (Result.IOError | (24 << 8)),
-			LockedSharedcache = (Result.Locked | (1 << 8)),
+			LockedSharedCache = (Result.Locked | (1 << 8)),
 			BusyRecovery = (Result.Busy | (1 << 8)),
 			CannottOpenNoTempDir = (Result.CannotOpen | (1 << 8)),
 			CannotOpenIsDir = (Result.CannotOpen | (2 << 8)),
@@ -3755,7 +4245,7 @@ namespace SQLite
             var r = Prepare2 (db, query, System.Text.UTF8Encoding.UTF8.GetByteCount (query), out stmt, IntPtr.Zero);
 #endif
 			if (r != Result.OK) {
-				throw SQLiteException.New (r, GetErrmsg (db));
+				throw SQLiteException.New (r, GetErrorMessage (db));
 			}
 			return stmt;
 		}
@@ -3773,11 +4263,11 @@ namespace SQLite
 		public static extern long LastInsertRowid (IntPtr db);
 
 		[DllImport(LibraryPath, EntryPoint = "sqlite3_errmsg16", CallingConvention=CallingConvention.Cdecl)]
-		public static extern IntPtr Errmsg (IntPtr db);
+		public static extern IntPtr ErrorMessage (IntPtr db);
 
-		public static string GetErrmsg (IntPtr db)
+		public static string GetErrorMessage (IntPtr db)
 		{
-			return Marshal.PtrToStringUni (Errmsg (db));
+			return Marshal.PtrToStringUni (ErrorMessage (db));
 		}
 
 		[DllImport(LibraryPath, EntryPoint = "sqlite3_bind_parameter_index", CallingConvention=CallingConvention.Cdecl)]
@@ -3901,8 +4391,9 @@ namespace SQLite
 			stmt = new Sqlite3Statement();
 			var r = Sqlite3.sqlite3_prepare_v2(db, query, -1, ref stmt, 0);
 #endif
-			if (r != 0) {
-				throw SQLiteException.New ((Result)r, GetErrmsg (db));
+			if (r != 0)
+			{
+				throw SQLiteException.New((Result) r, GetErrorMessage(db), sql: query);
 			}
 			return stmt;
 		}
@@ -3927,10 +4418,20 @@ namespace SQLite
 			return Sqlite3.sqlite3_last_insert_rowid (db);
 		}
 
-		public static string GetErrmsg (Sqlite3DatabaseHandle db)
+		public static string GetErrorMessage(Sqlite3DatabaseHandle db)
 		{
-			return Sqlite3.sqlite3_errmsg (db);
+			return Sqlite3.sqlite3_errmsg(db);
 		}
+
+	    public static string GetErrorString(SQLite3.Result result)
+	    {
+	        return Sqlite3.sqlite3_errstr((int)result);
+	    }
+
+	    public static string GetErrorString(SQLite3.ExtendedResult result)
+	    {
+	        return Sqlite3.sqlite3_errstr((int)result);
+	    }
 
 		public static int BindParameterIndex (Sqlite3Statement stmt, string name)
 		{
@@ -4073,6 +4574,100 @@ namespace SQLite
 			Null = 5
 		}
 	}
+
+    /// <seealso href="https://sqlite.org/c3ref/c_source_id.html"/>
+    public struct SQLiteVersion : IEquatable<SQLiteVersion>, IComparable<SQLiteVersion>, IComparable
+    {
+        /// <summary>
+        /// Indicates whether the two SQLiteVersion instances are equal to each other.
+        /// </summary>
+        /// <param name="x">A SQLiteVersion instance.</param>
+        /// <param name="y">A SQLiteVersion instance.</param>
+        /// <returns><see langword="true"/> if the two instances are equal to each other; otherwise,  <see langword="false"/>.</returns>
+        public static bool operator ==(SQLiteVersion x, SQLiteVersion y) => x.Equals(y);
+
+        /// <summary>
+        /// Indicates whether the two SQLiteVersion instances are not equal each other.
+        /// </summary>
+        /// <param name="x">A SQLiteVersion instance.</param>
+        /// <param name="y">A SQLiteVersion instance.</param>
+        /// <returns><see langword="true"/> if the two instances are not equal to each other; otherwise,  <see langword="false"/>.</returns>
+        public static bool operator !=(SQLiteVersion x, SQLiteVersion y) => !(x == y);
+
+        /// <summary>
+        /// Indicates if the the first SQLiteVersion is greater than or equal to the second.
+        /// </summary>
+        /// <param name="x">A SQLiteVersion instance.</param>
+        /// <param name="y">A SQLiteVersion instance.</param>
+        /// <returns><see langword="true"/>if the the first SQLiteVersion is greater than or equal to the second; otherwise, <see langword="false"/>.</returns>
+        public static bool operator >=(SQLiteVersion x, SQLiteVersion y) => x._version >= y._version;
+
+        /// <summary>
+        /// Indicates if the the first SQLiteVersion is greater than the second.
+        /// </summary>
+        /// <param name="x">A SQLiteVersion instance.</param>
+        /// <param name="y">A SQLiteVersion instance.</param>
+        /// <returns><see langword="true"/>if the the first SQLiteVersion is greater than the second; otherwise, <see langword="false"/>.</returns>
+        public static bool operator >(SQLiteVersion x, SQLiteVersion y) => x._version > y._version;
+
+        /// <summary>
+        /// Indicates if the the first SQLiteVersion is less than or equal to the second.
+        /// </summary>
+        /// <param name="x">A SQLiteVersion instance.</param>
+        /// <param name="y">A SQLiteVersion instance.</param>
+        /// <returns><see langword="true"/>if the the first SQLiteVersion is less than or equal to the second; otherwise, <see langword="false"/>.</returns>
+        public static bool operator <=(SQLiteVersion x, SQLiteVersion y) => x._version <= y._version;
+
+        /// <summary>
+        /// Indicates if the the first SQLiteVersion is less than the second.
+        /// </summary>
+        /// <param name="x">A SQLiteVersion instance.</param>
+        /// <param name="y">A SQLiteVersion instance.</param>
+        /// <returns><see langword="true"/>if the the first SQLiteVersion is less than the second; otherwise, <see langword="false"/>.</returns>
+        public static bool operator <(SQLiteVersion x, SQLiteVersion y) => x._version < y._version;
+
+        private readonly int _version;
+
+        public SQLiteVersion(int version)
+        {
+            this._version = version;
+        }
+
+        /// <summary>
+        /// Gets the major version number.
+        /// </summary>
+        public int Major => _version / 1000000;
+
+        /// <summary>
+        /// Gets the minor version number.
+        /// </summary>
+        public int Minor => (_version / 1000) % 1000;
+
+        /// <summary>
+        /// Gets the release version number.
+        /// </summary>
+        public int Release => _version % 1000;
+
+        /// <summary>
+        /// Converts the version number as an integer with the value (Major*1000000 + Minor*1000 + Release).
+        /// </summary>
+        /// <returns>The version number as an integer</returns>
+        public int ToInt32() => _version;
+
+        public override string ToString() => $"{this.Major}.{this.Minor}.{this.Release}";
+        public override int GetHashCode() => _version;
+        public bool Equals(SQLiteVersion other) => this._version == other._version;
+        public override bool Equals(object other) => other is SQLiteVersion && this == (SQLiteVersion)other;
+        public int CompareTo(SQLiteVersion other) => this._version.CompareTo(other._version);
+        public int CompareTo(object obj)
+        {
+            if (obj is SQLiteVersion)
+            {
+                return this.CompareTo((SQLiteVersion)obj);
+            }
+            throw new ArgumentException("Can only compare to other SQLiteVersion");
+        }
+    }
 }
 
 #if NO_CONCURRENT
@@ -4093,5 +4688,3 @@ namespace SQLite.Extensions
 	}
 }
 #endif
-
-

--- a/src/SQLiteAsync.cs
+++ b/src/SQLiteAsync.cs
@@ -350,7 +350,7 @@ namespace SQLite
 		/// <param name="tableName">Name of the database table</param>
 		/// <param name="columnName">Name of the column to index</param>
 		/// <param name="unique">Whether the index should be unique</param>
-		public Task<int> CreateIndexAsync (string tableName, string columnName, bool unique = false)
+		public Task<bool> CreateIndexAsync (string tableName, string columnName, bool unique = false)
 		{
 			return WriteAsync (conn => conn.CreateIndex (tableName, columnName, unique));
 		}
@@ -362,7 +362,7 @@ namespace SQLite
 		/// <param name="tableName">Name of the database table</param>
 		/// <param name="columnName">Name of the column to index</param>
 		/// <param name="unique">Whether the index should be unique</param>
-		public Task<int> CreateIndexAsync (string indexName, string tableName, string columnName, bool unique = false)
+		public Task<bool> CreateIndexAsync (string indexName, string tableName, string columnName, bool unique = false)
 		{
 			return WriteAsync (conn => conn.CreateIndex (indexName, tableName, columnName, unique));
 		}
@@ -373,7 +373,7 @@ namespace SQLite
 		/// <param name="tableName">Name of the database table</param>
 		/// <param name="columnNames">An array of column names to index</param>
 		/// <param name="unique">Whether the index should be unique</param>
-		public Task<int> CreateIndexAsync (string tableName, string[] columnNames, bool unique = false)
+		public Task<bool> CreateIndexAsync (string tableName, string[] columnNames, bool unique = false)
 		{
 			return WriteAsync (conn => conn.CreateIndex (tableName, columnNames, unique));
 		}
@@ -385,7 +385,7 @@ namespace SQLite
 		/// <param name="tableName">Name of the database table</param>
 		/// <param name="columnNames">An array of column names to index</param>
 		/// <param name="unique">Whether the index should be unique</param>
-		public Task<int> CreateIndexAsync (string indexName, string tableName, string[] columnNames, bool unique = false)
+		public Task<bool> CreateIndexAsync (string indexName, string tableName, string[] columnNames, bool unique = false)
 		{
 			return WriteAsync (conn => conn.CreateIndex (indexName, tableName, columnNames, unique));
 		}
@@ -397,7 +397,7 @@ namespace SQLite
 		/// <typeparam name="T">Type to reflect to a database table.</typeparam>
 		/// <param name="property">Property to index</param>
 		/// <param name="unique">Whether the index should be unique</param>
-		public Task<int> CreateIndexAsync<T> (Expression<Func<T, object>> property, bool unique = false)
+		public Task<bool> CreateIndexAsync<T> (Expression<Func<T, object>> property, bool unique = false)
 		{
 			return WriteAsync (conn => conn.CreateIndex (property, unique));
 		}
@@ -830,10 +830,10 @@ namespace SQLite
 		/// The mapping represents the schema of the columns of the database and contains 
 		/// methods to set and get properties of objects.
 		/// </returns>
-		public Task<TableMapping> GetMappingAsync<T> (CreateFlags createFlags = CreateFlags.None)
+		public Task<TableMapping> GetMappingAsync<T> ()
 			where T : new()
 		{
-			return ReadAsync (conn => conn.GetMapping<T> (createFlags));
+			return ReadAsync (conn => conn.GetMapping<T> ());
 		}
 
 		/// <summary>
@@ -986,10 +986,7 @@ namespace SQLite
 		/// </returns>
 		public Task<T> ExecuteScalarAsync<T> (string query, params object[] args)
 		{
-			return WriteAsync (conn => {
-				var command = conn.CreateCommand (query, args);
-				return command.ExecuteScalar<T> ();
-			});
+			return WriteAsync (conn => conn.ExecuteScalar<T>(query, args));
 		}
 
 		/// <summary>

--- a/tests/NotNullAttributeTest.cs
+++ b/tests/NotNullAttributeTest.cs
@@ -298,7 +298,7 @@ namespace SQLite.Tests
 					db.Insert (obj);
 
 					map = db.GetMapping<NotNullNoPK> ();
-					map.GetInsertCommand (db, "OR REPLACE").ExecuteNonQuery (new object[] { 1, null, 123, null, null, null });
+					db.GetInsertCommand (map, "OR REPLACE").ExecuteNonQuery (new object[] { 1, null, 123, null, null, null });
 				}
 				catch (NotNullConstraintViolationException) {
 					return;


### PR DESCRIPTION
1. added a `TableMapping` cache
2. added a `TableMapper` class to allow custom type parsing
3. improved `InsertAll` with bulk operation if using 3.7.11+
4. allow any command to be prepared and cached
5. all executions use `SQLiteCommand` and abide by timing
6. added `SQLiteVersion` class for easy comparisons
7. included executing SQL in exceptions when available for debugging purposes