### PR TITLE
use default parameter to Task.Factory.StartNew to do the same as Task.Run

### DIFF
--- a/src/SQLiteAsync.cs
+++ b/src/SQLiteAsync.cs
@@ -180,7 +180,7 @@ namespace SQLite
 		{
 			return Task.Factory.StartNew (() => {
 				SQLiteConnectionPool.Shared.CloseConnection (_connectionString, _openFlags);
-			});
+			}, CancellationToken.None, TaskCreationOptions.DenyChildAttach, TaskScheduler.Default);
 		}
 
 		Task<T> ReadAsync<T> (Func<SQLiteConnectionWithLock, T> read)
@@ -190,7 +190,7 @@ namespace SQLite
 				using (conn.Lock ()) {
 					return read (conn);
 				}
-			});
+			}, CancellationToken.None, TaskCreationOptions.DenyChildAttach, TaskScheduler.Default);
 		}
 
 		Task<T> WriteAsync<T> (Func<SQLiteConnectionWithLock, T> write)
@@ -200,7 +200,7 @@ namespace SQLite
 				using (conn.Lock ()) {
 					return write (conn);
 				}
-			});
+			}, CancellationToken.None, TaskCreationOptions.DenyChildAttach, TaskScheduler.Default);
 		}
 
 		/// <summary>
@@ -1155,7 +1155,7 @@ namespace SQLite
 				using (conn.Lock ()) {
 					return read (conn);
 				}
-			});
+			}, CancellationToken.None, TaskCreationOptions.DenyChildAttach, TaskScheduler.Default);
 		}
 
 		Task<U> WriteAsync<U> (Func<SQLiteConnectionWithLock, U> write)
@@ -1165,7 +1165,7 @@ namespace SQLite
 				using (conn.Lock ()) {
 					return write (conn);
 				}
-			});
+			}, CancellationToken.None, TaskCreationOptions.DenyChildAttach, TaskScheduler.Default);
 		}
 
 		/// <summary>


### PR DESCRIPTION
according to this article : https://blogs.msdn.microsoft.com/pfxteam/2011/10/24/task-run-vs-task-factory-startnew/

add default Task.Factory.StartNew parameter to do the same with Task.Run