### PR TITLE
allow comparison with nullable parameter

### DIFF
--- a/src/SQLite.cs
+++ b/src/SQLite.cs
@@ -3575,6 +3575,11 @@ namespace SQLite
 				return "(" + parameter.CommandText + " is ?)";
 			else if (expression.NodeType == ExpressionType.NotEqual)
 				return "(" + parameter.CommandText + " is not ?)";
+			else if (expression.NodeType == ExpressionType.GreaterThan
+				|| expression.NodeType == ExpressionType.GreaterThanOrEqual
+				|| expression.NodeType == ExpressionType.LessThan
+				|| expression.NodeType == ExpressionType.LessThanOrEqual)
+				return "(" + parameter.CommandText + " < ?)"; // always false
 			else
 				throw new NotSupportedException ("Cannot compile Null-BinaryExpression with type " + expression.NodeType.ToString ());
 		}


### PR DESCRIPTION
allow queries like

var nullableInt = default(int?);
connection
  .Table<Test>()
  .Where(x => x.Int < nullableInt);

which is equivalent to
connection
  .Query<Test>("SELECT * FROM [Test] WHERE [Int] < ?", nullableInt);