### PR TITLE
add bulk insert that was included in 3.7.11

### DIFF
--- a/src/SQLiteAsync.cs
+++ b/src/SQLiteAsync.cs
@@ -873,15 +873,19 @@ namespace SQLite
 		/// </summary>
 		/// <param name="objects">
 		/// An <see cref="IEnumerable"/> of the objects to insert.
-		/// <param name="runInTransaction"/>
+		/// </param>
+		/// <param name="runInTransaction">
 		/// A boolean indicating if the inserts should be wrapped in a transaction.
+		/// </param>
+		/// <param name="bulkInsert">
+		/// A boolean indicating if the bulk insert command should be uses. INSERT INTO ... VALUES ...
 		/// </param>
 		/// <returns>
 		/// The number of rows added to the table.
 		/// </returns>
-		public Task<int> InsertAllAsync (IEnumerable objects, bool runInTransaction = true)
+		public Task<int> InsertAllAsync (IEnumerable objects, bool runInTransaction = true, bool bulkInsert = false)
 		{
-			return WriteAsync (conn => conn.InsertAll (objects, runInTransaction));
+			return WriteAsync (conn => conn.InsertAll (objects, runInTransaction, bulkInsert));
 		}
 
 		/// <summary>
@@ -896,12 +900,15 @@ namespace SQLite
 		/// <param name="runInTransaction">
 		/// A boolean indicating if the inserts should be wrapped in a transaction.
 		/// </param>
+		/// <param name="bulkInsert">
+		/// A boolean indicating if the bulk insert command should be uses. INSERT INTO ... VALUES ...
+		/// </param>
 		/// <returns>
 		/// The number of rows added to the table.
 		/// </returns>
-		public Task<int> InsertAllAsync (IEnumerable objects, string extra, bool runInTransaction = true)
+		public Task<int> InsertAllAsync (IEnumerable objects, string extra, bool runInTransaction = true, bool bulkInsert = false)
 		{
-			return WriteAsync (conn => conn.InsertAll (objects, extra, runInTransaction));
+			return WriteAsync (conn => conn.InsertAll (objects, extra, runInTransaction, bulkInsert));
 		}
 
 		/// <summary>
@@ -916,12 +923,40 @@ namespace SQLite
 		/// <param name="runInTransaction">
 		/// A boolean indicating if the inserts should be wrapped in a transaction.
 		/// </param>
+		/// <param name="bulkInsert">
+		/// A boolean indicating if the bulk insert command should be uses. INSERT INTO ... VALUES ...
+		/// </param>
 		/// <returns>
 		/// The number of rows added to the table.
 		/// </returns>
-		public Task<int> InsertAllAsync (IEnumerable objects, Type objType, bool runInTransaction = true)
+		public Task<int> InsertAllAsync (IEnumerable objects, Type objType, bool runInTransaction = true, bool bulkInsert = false)
 		{
-			return WriteAsync (conn => conn.InsertAll (objects, objType, runInTransaction));
+			return WriteAsync (conn => conn.InsertAll (objects, objType, runInTransaction, bulkInsert));
+		}
+
+		/// <summary>
+		/// Inserts all specified objects.
+		/// </summary>
+		/// <param name="objects">
+		/// An <see cref="IEnumerable"/> of the objects to insert.
+		/// </param>
+		/// <param name="extra">
+		/// Literal SQL code that gets placed into the command. INSERT {extra} INTO ...
+		/// </param>
+		/// <param name="objType">
+		/// The type of object to insert.
+		/// </param>
+		/// <param name="runInTransaction">
+		/// A boolean indicating if the inserts should be wrapped in a transaction.
+		/// </param>
+		/// <param name="bulkInsert">
+		/// A boolean indicating if the bulk insert command should be uses. INSERT INTO ... VALUES ...
+		/// </param>
+		/// <returns>
+		/// The number of rows added to the table.
+		/// </returns>
+		public Task<int> InsertAllAsync (IEnumerable objects, string extra, Type objType, bool runInTransaction = true, bool bulkInsert = false) {
+			return WriteAsync (conn => conn.InsertAll (objects, extra, objType, runInTransaction, bulkInsert));
 		}
 
 		/// <summary>

--- a/tests/AsyncTests.cs
+++ b/tests/AsyncTests.cs
@@ -493,6 +493,38 @@ namespace SQLite.Tests
 		}
 
 		[Test]
+		public void TestBulkInsertAllAsync () {
+			// create a bunch of customers...
+			List<Customer> customers = new List<Customer> ();
+			for (int index = 0; index < 100; index++) {
+				Customer customer = new Customer ();
+				customer.FirstName = "foo";
+				customer.LastName = "bar";
+				customer.Email = Guid.NewGuid ().ToString ();
+				customers.Add (customer);
+			}
+
+			// connect...
+			string path = null;
+			var conn = GetConnection (ref path);
+			conn.CreateTableAsync<Customer> ().Wait ();
+
+			// insert them all...
+			conn.InsertAllAsync (customers, bulkInsert: true).Wait ();
+
+			var inObjs = conn.GetConnection().CreateCommand ("select * from Customer").ExecuteQuery<Customer> ().ToList ();
+
+			// check...
+			using (SQLiteConnection check = new SQLiteConnection (path)) {
+				for (int index = 0; index < inObjs.Count; index++) {
+					// load it back and check...
+					Customer loaded = check.Get<Customer> (inObjs[index].Id);
+					Assert.AreEqual (loaded.Email, inObjs[index].Email);
+				}
+			}
+		}
+
+		[Test]
 		public void TestRunInTransactionAsync ()
 		{
 			// connect...


### PR DESCRIPTION
-  this improves the bulk inserting performance by executing everything in a few number of calls
- this needs to be turned on by passing bulkInsert: true, this was nessisary because it breaks support for updating the primary key of collection objects
- added support for a new `SQLiteVersion` object that allows easier comparison

This is the breakup of #599 that was asked for.