### PR TITLE
Compile FTS "match" operator correctly in queries

### DIFF
--- a/src/SQLite.cs
+++ b/src/SQLite.cs
@@ -3389,8 +3389,8 @@ namespace SQLite
 
 				var sqlCall = "";
 
-				if (call.Method.Name == "Like" && args.Length == 2) {
-					sqlCall = "(" + args[0].CommandText + " like " + args[1].CommandText + ")";
+				if ((call.Method.Name == "Like" || call.Method.Name == "Match") && args.Length == 2) {
+					sqlCall = "(" + args[0].CommandText + " " + call.Method.Name.ToLower() + " " + args[1].CommandText + ")";
 				}
 				else if (call.Method.Name == "Contains" && args.Length == 2) {
 					sqlCall = "(" + args[1].CommandText + " in " + args[0].CommandText + ")";


### PR DESCRIPTION
This will compile the full text search operator 'match' correctly.

"[FTSFieldName] match ?" instead of "match([FTSFieldName, ?)"

sqliteconnection.Table<FTSTable>().Where(x => x.FTSField.Match("ftsexpression*"));