### PR TITLE
Added option to sture Guids as Blobs #284

### DIFF
--- a/src/SQLite.cs
+++ b/src/SQLite.cs
@@ -2777,7 +2777,7 @@ namespace SQLite
 
 		const string DateTimeExactStoreFormat = "yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fff";
 
-		internal static void BindParameter (IntPtr stmt, int index, object value, 
+		internal static void BindParameter (Sqlite3Statement stmt, int index, object value, 
 			bool storeDateTimeAsTicks,
 			bool connStoreGuidsAsBlobs)
 		{

--- a/src/SQLite.cs
+++ b/src/SQLite.cs
@@ -2029,6 +2029,7 @@ namespace SQLite
 		public string ConnectionString { get; private set; }
 		public string DatabasePath { get; private set; }
 		public bool StoreDateTimeAsTicks { get; private set; }
+		public bool StoreGuidsAsBlobs { get; private set; }
 
 #if NETFX_CORE
 		static readonly string MetroStyleDataPath = Windows.Storage.ApplicationData.Current.LocalFolder.Path;
@@ -2046,10 +2047,11 @@ namespace SQLite
 
 #endif
 
-		public SQLiteConnectionString (string databasePath, bool storeDateTimeAsTicks)
+		public SQLiteConnectionString (string databasePath, bool storeDateTimeAsTicks, bool storeGuidsAsBlobs)
 		{
 			ConnectionString = databasePath;
 			StoreDateTimeAsTicks = storeDateTimeAsTicks;
+			StoreGuidsAsBlobs = storeGuidsAsBlobs;
 
 #if NETFX_CORE
 			DatabasePath = IsInMemoryPath(databasePath)

--- a/src/SQLiteAsync.cs
+++ b/src/SQLiteAsync.cs
@@ -54,8 +54,9 @@ namespace SQLite
 		/// If you use DateTimeOffset properties, it will be always stored as ticks regardingless
 		/// the storeDateTimeAsTicks parameter.
 		/// </param>
-		public SQLiteAsyncConnection (string databasePath, bool storeDateTimeAsTicks = true)
-			: this (databasePath, SQLiteOpenFlags.FullMutex | SQLiteOpenFlags.ReadWrite | SQLiteOpenFlags.Create, storeDateTimeAsTicks)
+		/// <param name="storeGuidsAsBlobs"></param>
+		public SQLiteAsyncConnection (string databasePath, bool storeDateTimeAsTicks = true, bool storeGuidsAsBlobs = false)
+			: this (databasePath, SQLiteOpenFlags.FullMutex | SQLiteOpenFlags.ReadWrite | SQLiteOpenFlags.Create, storeDateTimeAsTicks, storeGuidsAsBlobs)
 		{
 		}
 
@@ -76,11 +77,12 @@ namespace SQLite
 		/// If you use DateTimeOffset properties, it will be always stored as ticks regardingless
 		/// the storeDateTimeAsTicks parameter.
 		/// </param>
-		public SQLiteAsyncConnection (string databasePath, SQLiteOpenFlags openFlags, bool storeDateTimeAsTicks = true)
+		/// <param name="storeGuidsAsBlobs"></param>
+		public SQLiteAsyncConnection (string databasePath, SQLiteOpenFlags openFlags, bool storeDateTimeAsTicks = true, bool storeGuidsAsBlobs = false)
 		{
 			_openFlags = openFlags;
 			isFullMutex = _openFlags.HasFlag (SQLiteOpenFlags.FullMutex);
-			_connectionString = new SQLiteConnectionString (databasePath, storeDateTimeAsTicks);
+			_connectionString = new SQLiteConnectionString (databasePath, storeDateTimeAsTicks, storeGuidsAsBlobs);
 			if(isFullMutex)
 				_fullMutexReadConnection = new SQLiteConnectionWithLock (_connectionString, openFlags) { SkipLock = true };
 		}
@@ -1411,7 +1413,7 @@ namespace SQLite
 		/// <param name="connectionString">Connection string containing the DatabasePath.</param>
 		/// <param name="openFlags">Open flags.</param>
 		public SQLiteConnectionWithLock (SQLiteConnectionString connectionString, SQLiteOpenFlags openFlags)
-			: base (connectionString.DatabasePath, openFlags, connectionString.StoreDateTimeAsTicks)
+			: base (connectionString.DatabasePath, openFlags, connectionString.StoreDateTimeAsTicks, connectionString.StoreGuidsAsBlobs)
 		{
 		}
 

--- a/tests/AsyncTests.cs
+++ b/tests/AsyncTests.cs
@@ -151,7 +151,7 @@ namespace SQLite.Tests
 			catch (Exception) {
 			}
 #else
-			_connectionString = Path.Combine (Path.GetTempPath (), DatabaseName);
+			_connectionString = Path.Combine (Path.GetTempPath (), $"{TestContext.CurrentContext.Test.Name}_{DatabaseName}");
 			_path = _connectionString;
 			System.IO.File.Delete (_path);
 #endif
@@ -797,8 +797,7 @@ namespace SQLite.Tests
 			// check...
 			Assert.AreEqual ("7", loaded.FirstName);
 		}
-
-
+		
         [Test]
         public void TestAsyncGetWithExpression()
         {
@@ -857,7 +856,6 @@ namespace SQLite.Tests
 
 			conn.CloseAsync ().Wait ();
 		}
-
-
+		
 	}
 }

--- a/tests/GuidAsBlobsTests.cs
+++ b/tests/GuidAsBlobsTests.cs
@@ -59,7 +59,49 @@ namespace SQLite.Tests {
             db.Close();
         }
 
-        [Test]
+	    [Test]
+	    public void ShouldQueryGuidCorrectly () {
+		    var db = new TestDb (TestPath.GetTempFileName ());
+
+		    var obj1 = new TestObj () { Id = new Guid ("36473164-C9E4-4CDF-B266-A0B287C85623"), Text = "First Guid Object" };
+		    var obj2 = new TestObj () { Id = new Guid ("BC5C4C4A-CA57-4B61-8B53-9FD4673528B6"), Text = "Second Guid Object" };
+
+		    var numIn1 = db.Insert (obj1);
+		    var numIn2 = db.Insert (obj2);
+		    Assert.AreEqual (1, numIn1);
+		    Assert.AreEqual (1, numIn2);
+
+		    var result = db.Query<TestObj> ("select * from TestObj where id = ?", obj2.Id).ToList ();
+		    Assert.AreEqual (1, result.Count);
+		    Assert.AreEqual (obj2.Text, result[0].Text);
+		    
+		    Assert.AreEqual (obj2.Id, result[0].Id);
+
+		    db.Close ();
+	    }
+		
+	    [Test]
+	    public void ShouldQueryGuidCorrectlyUsingLinq () {
+		    var db = new TestDb (TestPath.GetTempFileName ());
+
+		    var obj1 = new TestObj () { Id = new Guid ("36473164-C9E4-4CDF-B266-A0B287C85623"), Text = "First Guid Object" };
+		    var obj2 = new TestObj () { Id = new Guid ("BC5C4C4A-CA57-4B61-8B53-9FD4673528B6"), Text = "Second Guid Object" };
+
+		    var numIn1 = db.Insert (obj1);
+		    var numIn2 = db.Insert (obj2);
+		    Assert.AreEqual (1, numIn1);
+		    Assert.AreEqual (1, numIn2);
+
+		    var result = db.Table<TestObj> ().Where (to => to.Id == obj2.Id).ToList ();
+		    Assert.AreEqual (1, result.Count);
+		    Assert.AreEqual (obj2.Text, result[0].Text);
+
+		    Assert.AreEqual (obj2.Id, result[0].Id);
+
+		    db.Close ();
+	    }
+
+		[Test]
         public void AutoGuid_HasGuid()
         {
             var db = new SQLiteConnection(TestPath.GetTempFileName(), storeGuidsAsBlobs: true);

--- a/tests/GuidAsBlobsTests.cs
+++ b/tests/GuidAsBlobsTests.cs
@@ -1,0 +1,106 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+
+#if NETFX_CORE
+using Microsoft.VisualStudio.TestPlatform.UnitTestFramework;
+using SetUp = Microsoft.VisualStudio.TestPlatform.UnitTestFramework.TestInitializeAttribute;
+using TestFixture = Microsoft.VisualStudio.TestPlatform.UnitTestFramework.TestClassAttribute;
+using Test = Microsoft.VisualStudio.TestPlatform.UnitTestFramework.TestMethodAttribute;
+#else
+using NUnit.Framework;
+#endif
+
+
+namespace SQLite.Tests {
+    [TestFixture]
+    public class GuidAsBlobsTests {
+        public class TestObj {
+            [PrimaryKey]
+            public Guid Id { get; set; }
+            public String Text { get; set; }
+
+            public override string ToString() {
+                return string.Format("[TestObj: Id={0}, Text={1}]", Id, Text);
+            }
+
+        }
+
+        public class TestDb : SQLiteConnection
+        {
+	        public TestDb (String path)
+		        : base (path, storeGuidsAsBlobs: true) {
+                CreateTable<TestObj>();
+            }
+        }
+
+        [Test]
+        public void ShouldPersistAndReadGuid() {
+            var db = new TestDb(TestPath.GetTempFileName());
+
+            var obj1 = new TestObj() { Id=new Guid("36473164-C9E4-4CDF-B266-A0B287C85623"), Text = "First Guid Object" };
+            var obj2 = new TestObj() {  Id=new Guid("BC5C4C4A-CA57-4B61-8B53-9FD4673528B6"), Text = "Second Guid Object" };
+
+            var numIn1 = db.Insert(obj1);
+            var numIn2 = db.Insert(obj2);
+            Assert.AreEqual(1, numIn1);
+            Assert.AreEqual(1, numIn2);
+
+            var result = db.Query<TestObj>("select * from TestObj").ToList();
+            Assert.AreEqual(2, result.Count);
+            Assert.AreEqual(obj1.Text, result[0].Text);
+            Assert.AreEqual(obj2.Text, result[1].Text);
+
+            Assert.AreEqual(obj1.Id, result[0].Id);
+            Assert.AreEqual(obj2.Id, result[1].Id);
+
+            db.Close();
+        }
+
+        [Test]
+        public void AutoGuid_HasGuid()
+        {
+            var db = new SQLiteConnection(TestPath.GetTempFileName(), storeGuidsAsBlobs: true);
+            db.CreateTable<TestObj>(CreateFlags.AutoIncPK);
+
+            var guid1 = new Guid("36473164-C9E4-4CDF-B266-A0B287C85623");
+            var guid2 = new Guid("BC5C4C4A-CA57-4B61-8B53-9FD4673528B6");
+
+            var obj1 = new TestObj() { Id = guid1, Text = "First Guid Object" };
+            var obj2 = new TestObj() { Id = guid2, Text = "Second Guid Object" };
+
+            var numIn1 = db.Insert(obj1);
+            var numIn2 = db.Insert(obj2);
+            Assert.AreEqual(guid1, obj1.Id);
+            Assert.AreEqual(guid2, obj2.Id);
+
+            db.Close();
+        }
+
+        [Test]
+        public void AutoGuid_EmptyGuid()
+        {
+            var db = new SQLiteConnection(TestPath.GetTempFileName(), storeGuidsAsBlobs: true);
+            db.CreateTable<TestObj>(CreateFlags.AutoIncPK);
+
+            var guid1 = new Guid("36473164-C9E4-4CDF-B266-A0B287C85623");
+            var guid2 = new Guid("BC5C4C4A-CA57-4B61-8B53-9FD4673528B6");
+
+            var obj1 = new TestObj() { Text = "First Guid Object" };
+            var obj2 = new TestObj() { Text = "Second Guid Object" };
+
+            Assert.AreEqual(Guid.Empty, obj1.Id);
+            Assert.AreEqual(Guid.Empty, obj2.Id);
+
+            var numIn1 = db.Insert(obj1);
+            var numIn2 = db.Insert(obj2);
+            Assert.AreNotEqual(Guid.Empty, obj1.Id);
+            Assert.AreNotEqual(Guid.Empty, obj2.Id);
+            Assert.AreNotEqual(obj1.Id, obj2.Id);
+
+            db.Close();
+        }
+    }
+}

--- a/tests/SQLite.Tests.csproj
+++ b/tests/SQLite.Tests.csproj
@@ -48,6 +48,7 @@
     <Compile Include="EnumNullableTest.cs" />
     <Compile Include="EnumTest.cs" />
     <Compile Include="ExceptionAssert.cs" />
+    <Compile Include="GuidAsBlobsTests.cs" />
     <Compile Include="InsertTest.cs" />
     <Compile Include="CreateTableTest.cs" />
     <Compile Include="GuidTests.cs" />

--- a/tests/SQLite.Tests.csproj
+++ b/tests/SQLite.Tests.csproj
@@ -10,13 +10,15 @@
     <RootNamespace>SQLite.Tests</RootNamespace>
     <AssemblyName>SQLite.Tests</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>True</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>False</Optimize>
     <OutputPath>bin\Debug</OutputPath>
-    <DefineConstants>DEBUG</DefineConstants>
+    <DefineConstants>DEBUG;USE_SQLITEPCL_RAW</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>False</ConsolePause>
@@ -33,6 +35,18 @@
     <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
       <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
       <Private>True</Private>
+    </Reference>
+    <Reference Include="SQLitePCLRaw.batteries_green, Version=1.1.11.121, Culture=neutral, PublicKeyToken=a84b7dcfb1391f7f, processorArchitecture=MSIL">
+      <HintPath>..\packages\SQLitePCLRaw.bundle_green.1.1.11\lib\net45\SQLitePCLRaw.batteries_green.dll</HintPath>
+    </Reference>
+    <Reference Include="SQLitePCLRaw.batteries_v2, Version=1.1.11.121, Culture=neutral, PublicKeyToken=8226ea5df37bcae9, processorArchitecture=MSIL">
+      <HintPath>..\packages\SQLitePCLRaw.bundle_green.1.1.11\lib\net45\SQLitePCLRaw.batteries_v2.dll</HintPath>
+    </Reference>
+    <Reference Include="SQLitePCLRaw.core, Version=1.1.11.121, Culture=neutral, PublicKeyToken=1488e028ca7ab535, processorArchitecture=MSIL">
+      <HintPath>..\packages\SQLitePCLRaw.core.1.1.11\lib\net45\SQLitePCLRaw.core.dll</HintPath>
+    </Reference>
+    <Reference Include="SQLitePCLRaw.provider.e_sqlite3, Version=1.1.11.121, Culture=neutral, PublicKeyToken=9c301db686d0bd12, processorArchitecture=MSIL">
+      <HintPath>..\packages\SQLitePCLRaw.provider.e_sqlite3.net45.1.1.11\lib\net45\SQLitePCLRaw.provider.e_sqlite3.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -84,6 +98,19 @@
     <Compile Include="SQLCipherTest.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
   </ItemGroup>
+  <Import Project="..\packages\SQLitePCLRaw.lib.e_sqlite3.linux.1.1.11\build\net35\SQLitePCLRaw.lib.e_sqlite3.linux.targets" Condition="Exists('..\packages\SQLitePCLRaw.lib.e_sqlite3.linux.1.1.11\build\net35\SQLitePCLRaw.lib.e_sqlite3.linux.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\SQLitePCLRaw.lib.e_sqlite3.linux.1.1.11\build\net35\SQLitePCLRaw.lib.e_sqlite3.linux.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\SQLitePCLRaw.lib.e_sqlite3.linux.1.1.11\build\net35\SQLitePCLRaw.lib.e_sqlite3.linux.targets'))" />
+    <Error Condition="!Exists('..\packages\SQLitePCLRaw.lib.e_sqlite3.osx.1.1.11\build\net35\SQLitePCLRaw.lib.e_sqlite3.osx.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\SQLitePCLRaw.lib.e_sqlite3.osx.1.1.11\build\net35\SQLitePCLRaw.lib.e_sqlite3.osx.targets'))" />
+    <Error Condition="!Exists('..\packages\SQLitePCLRaw.lib.e_sqlite3.v110_xp.1.1.11\build\net35\SQLitePCLRaw.lib.e_sqlite3.v110_xp.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\SQLitePCLRaw.lib.e_sqlite3.v110_xp.1.1.11\build\net35\SQLitePCLRaw.lib.e_sqlite3.v110_xp.targets'))" />
+  </Target>
+  <Import Project="..\packages\SQLitePCLRaw.lib.e_sqlite3.osx.1.1.11\build\net35\SQLitePCLRaw.lib.e_sqlite3.osx.targets" Condition="Exists('..\packages\SQLitePCLRaw.lib.e_sqlite3.osx.1.1.11\build\net35\SQLitePCLRaw.lib.e_sqlite3.osx.targets')" />
+  <Import Project="..\packages\SQLitePCLRaw.lib.e_sqlite3.v110_xp.1.1.11\build\net35\SQLitePCLRaw.lib.e_sqlite3.v110_xp.targets" Condition="Exists('..\packages\SQLitePCLRaw.lib.e_sqlite3.v110_xp.1.1.11\build\net35\SQLitePCLRaw.lib.e_sqlite3.v110_xp.targets')" />
 </Project>

--- a/tests/packages.config
+++ b/tests/packages.config
@@ -1,4 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="NUnit" version="2.6.4" targetFramework="net45" />
+  <package id="SQLitePCLRaw.bundle_green" version="1.1.11" targetFramework="net45" />
+  <package id="SQLitePCLRaw.core" version="1.1.11" targetFramework="net45" />
+  <package id="SQLitePCLRaw.lib.e_sqlite3.linux" version="1.1.11" targetFramework="net45" />
+  <package id="SQLitePCLRaw.lib.e_sqlite3.osx" version="1.1.11" targetFramework="net45" />
+  <package id="SQLitePCLRaw.lib.e_sqlite3.v110_xp" version="1.1.11" targetFramework="net45" />
+  <package id="SQLitePCLRaw.provider.e_sqlite3.net45" version="1.1.11" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Hi!

This PR adds the ability to store guids as blobs in the database and fixes issue #284

I added unit tests for both, async and sync connection.

This feature is very important for interoperability with EF Core, which is based on Microsoft.Data.Sqlite. The latter stores guids as blobs always and does not, and *will never* support any other option, as can be read in the following issue:
https://github.com/aspnet/Microsoft.Data.Sqlite/issues/273

Also: I found a nice article which can help to look at the blob-guids in the database - as they are obviously not that readable anymore...
https://neosmart.net/blog/2018/converting-a-binary-blob-guid-to-text-in-sql/