### PR TITLE
ExecuteScalar<T>() with System.Nullable<T> support

### DIFF
--- a/src/SQLite.cs
+++ b/src/SQLite.cs
@@ -2869,6 +2869,11 @@ namespace SQLite
 			}
 			else {
 				var clrTypeInfo = clrType.GetTypeInfo ();
+				if (clrTypeInfo.IsGenericType && clrTypeInfo.GetGenericTypeDefinition () == typeof (Nullable<>)) {
+					clrType = clrTypeInfo.GenericTypeArguments[0];
+					clrTypeInfo = clrType.GetTypeInfo ();
+				}
+
 				if (clrType == typeof (String)) {
 					return SQLite3.ColumnString (stmt, index);
 				}

--- a/tests/ScalarTest.cs
+++ b/tests/ScalarTest.cs
@@ -55,6 +55,37 @@ namespace SQLite.Tests
 
 			Assert.AreEqual (2, r);
 		}
+
+		[Test]
+		public void SelectNullableSingleRowValue ()
+		{
+			var db = CreateDb ();
+
+			var r = db.ExecuteScalar<int?> ("SELECT Two FROM TestTable WHERE Id = 1 LIMIT 1");
+
+			Assert.AreEqual (true, r.HasValue);
+			Assert.AreEqual (2, r);
+		}
+
+		[Test]
+		public void SelectNoRowValue ()
+		{
+			var db = CreateDb ();
+
+			var r = db.ExecuteScalar<int?> ("SELECT Two FROM TestTable WHERE Id = 999");
+
+			Assert.AreEqual (false, r.HasValue);
+		}
+
+		[Test]
+		public void SelectNullRowValue ()
+		{
+			var db = CreateDb ();
+
+			var r = db.ExecuteScalar<int?> ("SELECT null AS Unknown FROM TestTable WHERE Id = 1 LIMIT 1");
+
+			Assert.AreEqual (false, r.HasValue);
+		}
 	}
 }
 


### PR DESCRIPTION
When using ExecuteScalar<T>() with value types, no NULL values can be determined. Extension of  ExecuteScalar<T>()/ReadCol() to support System.Nullable<T>.