### PR TITLE
Fix #796 Wrong results with StartsWith linq query and parameter

### DIFF
--- a/src/SQLite.cs
+++ b/src/SQLite.cs
@@ -3551,8 +3551,14 @@ namespace SQLite
 				var args = new CompileResult[call.Arguments.Count];
 				var obj = call.Object != null ? CompileExpr (call.Object, queryArgs) : null;
 
+				List<object> notUsedQueryArgs = new List<object> ();
 				for (var i = 0; i < args.Length; i++) {
-					args[i] = CompileExpr (call.Arguments[i], queryArgs);
+					if (i == 1 && (call.Method.Name == "StartsWith" || call.Method.Name == "EndsWith")) {
+						args[i] = CompileExpr (call.Arguments[i], notUsedQueryArgs);
+					}
+					else {
+						args[i] = CompileExpr (call.Arguments[i], queryArgs);
+					}
 				}
 
 				var sqlCall = "";

--- a/src/SQLite.cs
+++ b/src/SQLite.cs
@@ -3573,40 +3573,34 @@ namespace SQLite
 				}
 				else if (call.Method.Name == "StartsWith" && args.Length >= 1) {
 					var startsWithCmpOp = StringComparison.CurrentCulture;
-					string sDummyCondForParamTwo = string.Empty;
 					if (args.Length == 2) {
 						startsWithCmpOp = (StringComparison)args[1].Value;
-						var enumIntValue = Convert.ToInt32 (startsWithCmpOp);
-						sDummyCondForParamTwo = " and (" + args[1].CommandText + " = " + enumIntValue.ToString () + ")";
 					}
 					switch (startsWithCmpOp) {
 						case StringComparison.Ordinal:
 						case StringComparison.CurrentCulture:
-							sqlCall = "(( substr(" + obj.CommandText + ", 1, " + args[0].Value.ToString ().Length + ") =  " + args[0].CommandText + ")" + sDummyCondForParamTwo + ")";
+							sqlCall = "( substr(" + obj.CommandText + ", 1, " + args[0].Value.ToString ().Length + ") =  " + args[0].CommandText + ")";
 							break;
 						case StringComparison.OrdinalIgnoreCase:
 						case StringComparison.CurrentCultureIgnoreCase:
-							sqlCall = "((" + obj.CommandText + " like (" + args[0].CommandText + " || '%'))" + sDummyCondForParamTwo + ")";
+							sqlCall = "(" + obj.CommandText + " like (" + args[0].CommandText + " || '%'))";
 							break;
 					}
 
 				}
 				else if (call.Method.Name == "EndsWith" && args.Length >= 1) {
 					var endsWithCmpOp = StringComparison.CurrentCulture;
-					string sDummyCondForParamTwo = string.Empty;
 					if (args.Length == 2) {
 						endsWithCmpOp = (StringComparison)args[1].Value;
-						var enumIntValue = Convert.ToInt32 (endsWithCmpOp);
-						sDummyCondForParamTwo = " and (" + args[1].CommandText + " = " + enumIntValue.ToString () + ")";
 					}
 					switch (endsWithCmpOp) {
 						case StringComparison.Ordinal:
 						case StringComparison.CurrentCulture:
-							sqlCall = "(( substr(" + obj.CommandText + ", length(" + obj.CommandText + ") - " + args[0].Value.ToString ().Length + "+1, " + args[0].Value.ToString ().Length + ") =  " + args[0].CommandText + ")" + sDummyCondForParamTwo + ")";
+							sqlCall = "( substr(" + obj.CommandText + ", length(" + obj.CommandText + ") - " + args[0].Value.ToString ().Length + "+1, " + args[0].Value.ToString ().Length + ") =  " + args[0].CommandText + ")";
 							break;
 						case StringComparison.OrdinalIgnoreCase:
 						case StringComparison.CurrentCultureIgnoreCase:
-							sqlCall = "((" + obj.CommandText + " like ('%' || " + args[0].CommandText + "))" + sDummyCondForParamTwo + ")";
+							sqlCall = "(" + obj.CommandText + " like ('%' || " + args[0].CommandText + "))";
 							break;
 					}
 				}

--- a/src/SQLite.cs
+++ b/src/SQLite.cs
@@ -3573,34 +3573,40 @@ namespace SQLite
 				}
 				else if (call.Method.Name == "StartsWith" && args.Length >= 1) {
 					var startsWithCmpOp = StringComparison.CurrentCulture;
+					string sDummyCondForParamTwo = string.Empty;
 					if (args.Length == 2) {
 						startsWithCmpOp = (StringComparison)args[1].Value;
+						var enumIntValue = Convert.ToInt32 (startsWithCmpOp);
+						sDummyCondForParamTwo = " and (" + args[1].CommandText + " = " + enumIntValue.ToString () + ")";
 					}
 					switch (startsWithCmpOp) {
 						case StringComparison.Ordinal:
 						case StringComparison.CurrentCulture:
-							sqlCall = "( substr(" + obj.CommandText + ", 1, " + args[0].Value.ToString ().Length + ") =  " + args[0].CommandText + ")";
+							sqlCall = "(( substr(" + obj.CommandText + ", 1, " + args[0].Value.ToString ().Length + ") =  " + args[0].CommandText + ")" + sDummyCondForParamTwo + ")";
 							break;
 						case StringComparison.OrdinalIgnoreCase:
 						case StringComparison.CurrentCultureIgnoreCase:
-							sqlCall = "(" + obj.CommandText + " like (" + args[0].CommandText + " || '%'))";
+							sqlCall = "((" + obj.CommandText + " like (" + args[0].CommandText + " || '%'))" + sDummyCondForParamTwo + ")";
 							break;
 					}
 
 				}
 				else if (call.Method.Name == "EndsWith" && args.Length >= 1) {
 					var endsWithCmpOp = StringComparison.CurrentCulture;
+					string sDummyCondForParamTwo = string.Empty;
 					if (args.Length == 2) {
 						endsWithCmpOp = (StringComparison)args[1].Value;
+						var enumIntValue = Convert.ToInt32 (endsWithCmpOp);
+						sDummyCondForParamTwo = " and (" + args[1].CommandText + " = " + enumIntValue.ToString () + ")";
 					}
 					switch (endsWithCmpOp) {
 						case StringComparison.Ordinal:
 						case StringComparison.CurrentCulture:
-							sqlCall = "( substr(" + obj.CommandText + ", length(" + obj.CommandText + ") - " + args[0].Value.ToString ().Length + "+1, " + args[0].Value.ToString ().Length + ") =  " + args[0].CommandText + ")";
+							sqlCall = "(( substr(" + obj.CommandText + ", length(" + obj.CommandText + ") - " + args[0].Value.ToString ().Length + "+1, " + args[0].Value.ToString ().Length + ") =  " + args[0].CommandText + ")" + sDummyCondForParamTwo + ")";
 							break;
 						case StringComparison.OrdinalIgnoreCase:
 						case StringComparison.CurrentCultureIgnoreCase:
-							sqlCall = "(" + obj.CommandText + " like ('%' || " + args[0].CommandText + "))";
+							sqlCall = "((" + obj.CommandText + " like ('%' || " + args[0].CommandText + "))" + sDummyCondForParamTwo + ")";
 							break;
 					}
 				}

--- a/tests/StringQueryTest.cs
+++ b/tests/StringQueryTest.cs
@@ -73,14 +73,6 @@ namespace SQLite.Tests
 
             var bs = db.Table<Product> ().Where (x => x.Name.StartsWith ("B")).ToList ();
 			Assert.AreEqual (1, bs.Count);
-
-			var lfs3 = db.Table<Product> ().Where (x => x.Name.StartsWith ("f", StringComparison.OrdinalIgnoreCase)
-				&& x.Name.StartsWith ("f", StringComparison.OrdinalIgnoreCase)).ToList ();
-			Assert.AreEqual (2, lfs3.Count);
-
-			var lfs4 = db.Table<Product> ().Where (x => x.Name.StartsWith ("f", StringComparison.OrdinalIgnoreCase))
-				.Where (x => x.Name.StartsWith ("foob", StringComparison.OrdinalIgnoreCase)).ToList ();
-			Assert.AreEqual (1, lfs4.Count);
 		}
 		
 		[Test]
@@ -90,21 +82,10 @@ namespace SQLite.Tests
 		    Assert.AreEqual (2, fs.Count);
 
 		    var lfs = db.Table<Product>().Where(x => x.Name.EndsWith("Ar")).ToList();
-		    Assert.AreEqual(0, lfs.Count);			
-
-			var bs = db.Table<Product> ().Where (x => x.Name.EndsWith ("o")).ToList ();
+		    Assert.AreEqual(0, lfs.Count);
+		    
+            var bs = db.Table<Product> ().Where (x => x.Name.EndsWith ("o")).ToList ();
 			Assert.AreEqual (1, bs.Count);
-
-			var lfs2 = db.Table<Product> ().Where (x => x.Name.EndsWith ("Ar", StringComparison.OrdinalIgnoreCase)).ToList ();
-			Assert.AreEqual (2, lfs2.Count);
-
-			var lfs3 = db.Table<Product> ().Where (x => x.Name.EndsWith ("Ar", StringComparison.OrdinalIgnoreCase)
-							&& x.Name.EndsWith ("Ar", StringComparison.OrdinalIgnoreCase)).ToList ();
-			Assert.AreEqual (2, lfs3.Count);
-
-			var lfs4 = db.Table<Product> ().Where (x => x.Name.EndsWith ("Ar", StringComparison.OrdinalIgnoreCase))
-							.Where (x => x.Name.EndsWith ("oBar", StringComparison.OrdinalIgnoreCase)).ToList ();
-			Assert.AreEqual (1, lfs4.Count);
 		}
 		
 		[Test]

--- a/tests/StringQueryTest.cs
+++ b/tests/StringQueryTest.cs
@@ -73,6 +73,14 @@ namespace SQLite.Tests
 
             var bs = db.Table<Product> ().Where (x => x.Name.StartsWith ("B")).ToList ();
 			Assert.AreEqual (1, bs.Count);
+
+			var lfs3 = db.Table<Product> ().Where (x => x.Name.StartsWith ("f", StringComparison.OrdinalIgnoreCase)
+				&& x.Name.StartsWith ("f", StringComparison.OrdinalIgnoreCase)).ToList ();
+			Assert.AreEqual (2, lfs3.Count);
+
+			var lfs4 = db.Table<Product> ().Where (x => x.Name.StartsWith ("f", StringComparison.OrdinalIgnoreCase))
+				.Where (x => x.Name.StartsWith ("foob", StringComparison.OrdinalIgnoreCase)).ToList ();
+			Assert.AreEqual (1, lfs4.Count);
 		}
 		
 		[Test]
@@ -82,10 +90,21 @@ namespace SQLite.Tests
 		    Assert.AreEqual (2, fs.Count);
 
 		    var lfs = db.Table<Product>().Where(x => x.Name.EndsWith("Ar")).ToList();
-		    Assert.AreEqual(0, lfs.Count);
-		    
-            var bs = db.Table<Product> ().Where (x => x.Name.EndsWith ("o")).ToList ();
+		    Assert.AreEqual(0, lfs.Count);			
+
+			var bs = db.Table<Product> ().Where (x => x.Name.EndsWith ("o")).ToList ();
 			Assert.AreEqual (1, bs.Count);
+
+			var lfs2 = db.Table<Product> ().Where (x => x.Name.EndsWith ("Ar", StringComparison.OrdinalIgnoreCase)).ToList ();
+			Assert.AreEqual (2, lfs2.Count);
+
+			var lfs3 = db.Table<Product> ().Where (x => x.Name.EndsWith ("Ar", StringComparison.OrdinalIgnoreCase)
+							&& x.Name.EndsWith ("Ar", StringComparison.OrdinalIgnoreCase)).ToList ();
+			Assert.AreEqual (2, lfs3.Count);
+
+			var lfs4 = db.Table<Product> ().Where (x => x.Name.EndsWith ("Ar", StringComparison.OrdinalIgnoreCase))
+							.Where (x => x.Name.EndsWith ("oBar", StringComparison.OrdinalIgnoreCase)).ToList ();
+			Assert.AreEqual (1, lfs4.Count);
 		}
 		
 		[Test]

--- a/tests/StringQueryTest.cs
+++ b/tests/StringQueryTest.cs
@@ -73,6 +73,14 @@ namespace SQLite.Tests
 
             var bs = db.Table<Product> ().Where (x => x.Name.StartsWith ("B")).ToList ();
 			Assert.AreEqual (1, bs.Count);
+
+			var lfs3 = db.Table<Product> ().Where (x => x.Name.StartsWith ("f", StringComparison.OrdinalIgnoreCase)
+				&& x.Name.StartsWith ("f", StringComparison.OrdinalIgnoreCase)).ToList ();
+			Assert.AreEqual (2, lfs3.Count);
+
+			var lfs4 = db.Table<Product> ().Where (x => x.Name.StartsWith ("f", StringComparison.OrdinalIgnoreCase))
+				.Where (x => x.Name.StartsWith ("foob", StringComparison.OrdinalIgnoreCase)).ToList ();
+			Assert.AreEqual (1, lfs4.Count);
 		}
 		
 		[Test]
@@ -86,6 +94,17 @@ namespace SQLite.Tests
 		    
             var bs = db.Table<Product> ().Where (x => x.Name.EndsWith ("o")).ToList ();
 			Assert.AreEqual (1, bs.Count);
+
+			var lfs2 = db.Table<Product> ().Where (x => x.Name.EndsWith ("Ar", StringComparison.OrdinalIgnoreCase)).ToList ();
+			Assert.AreEqual (2, lfs2.Count);
+
+			var lfs3 = db.Table<Product> ().Where (x => x.Name.EndsWith ("Ar", StringComparison.OrdinalIgnoreCase)
+							&& x.Name.EndsWith ("Ar", StringComparison.OrdinalIgnoreCase)).ToList ();
+			Assert.AreEqual (2, lfs3.Count);
+
+			var lfs4 = db.Table<Product> ().Where (x => x.Name.EndsWith ("Ar", StringComparison.OrdinalIgnoreCase))
+							.Where (x => x.Name.EndsWith ("oBar", StringComparison.OrdinalIgnoreCase)).ToList ();
+			Assert.AreEqual (1, lfs4.Count);
 		}
 		
 		[Test]


### PR DESCRIPTION
Wrong results with StartsWith linq query and parameter
Use dummy parameter in query because linq parameters which are not used in the sqlite query are not working.
Fix and a few more tests are added.