### PR TITLE
Support the raw key data with explicit salt.

### DIFF
--- a/src/SQLite.cs
+++ b/src/SQLite.cs
@@ -362,7 +362,7 @@ namespace SQLite
 		void SetKey (byte[] key)
 		{
 			if (key == null) throw new ArgumentNullException (nameof (key));
-			if (key.Length != 32) throw new ArgumentException ("Key must be 32 bytes (256-bit)", nameof(key));
+			if (key.Length != 32 && key.Length != 48) throw new ArgumentException ("Key must be 32 bytes (256-bit) or 48 bytes (384-bit)", nameof(key));
 			var s = String.Join ("", key.Select (x => x.ToString ("X2")));
 			Execute ("pragma key = \"x'" + s + "'\"");
 		}


### PR DESCRIPTION
Hello

This doesn't support 48 bytes encryption key format.
In this key format, the first 32 bytes will be used as the raw encryption key, and the remaining 16 bytes will be used as the salt.
https://www.zetetic.net/sqlcipher/sqlcipher-api/#key

Thanks.