### PR TITLE
Add Contains method with StringComparison parameter.

### DIFF
--- a/nuget/SQLite-net-base/SQLite-net-base.csproj
+++ b/nuget/SQLite-net-base/SQLite-net-base.csproj
@@ -28,6 +28,9 @@
     <Compile Include="..\..\src\SQLiteAsync.cs">
       <Link>SQLiteAsync.cs</Link>
     </Compile>
+	<Compile Include="..\..\src\StringContainsExtension.cs">
+	<Link>StringContainsExtension.cs</Link>
+	</Compile>
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="SQLitePCLRaw.core" Version="1.1.13" />

--- a/nuget/SQLite-net-sqlcipher/SQLite-net-sqlcipher.csproj
+++ b/nuget/SQLite-net-sqlcipher/SQLite-net-sqlcipher.csproj
@@ -32,5 +32,8 @@
     <Compile Include="..\..\src\SQLiteAsync.cs">
       <Link>SQLiteAsync.cs</Link>
     </Compile>
+	<Compile Include="..\..\src\StringContainsExtension.cs">
+	<Link>StringContainsExtension.cs</Link>
+	</Compile>
   </ItemGroup>
 </Project>

--- a/nuget/SQLite-net-std/SQLite-net-std.csproj
+++ b/nuget/SQLite-net-std/SQLite-net-std.csproj
@@ -32,5 +32,8 @@
     <Compile Include="..\..\src\SQLiteAsync.cs">
       <Link>SQLiteAsync.cs</Link>
     </Compile>
+	<Compile Include="..\..\src\StringContainsExtension.cs">
+	<Link>StringContainsExtension.cs</Link>
+	</Compile>
   </ItemGroup>
 </Project>

--- a/nuget/SQLite-net/SQLite-net.csproj
+++ b/nuget/SQLite-net/SQLite-net.csproj
@@ -32,7 +32,8 @@
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugSymbols>false</DebugSymbols>
-    <DebugType></DebugType>
+    <DebugType>
+    </DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
     <DefineConstants>RELEASE;USE_SQLITEPCL_RAW</DefineConstants>
@@ -51,6 +52,9 @@
     <Compile Include="..\..\src\SQLiteAsync.cs">
       <Link>SQLiteAsync.cs</Link>
     </Compile>
+    <Compile Include="..\..\src\StringContainsExtension.cs">
+	<Link>StringContainsExtension.cs</Link>
+	</Compile>
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Properties\" />

--- a/src/SQLite.cs
+++ b/src/SQLite.cs
@@ -3561,6 +3561,20 @@ namespace SQLite
 					sqlCall = "(" + args[0].CommandText + " like " + args[1].CommandText + ")";
 				}
 				else if (call.Method.Name == "Contains" && args.Length == 2) {
+					if (call.Object != null && call.Object.Type == typeof(string)) {
+						var startsWithCmpOp = (StringComparison)args[1].Value;
+						switch (startsWithCmpOp) {
+							case StringComparison.Ordinal:
+							case StringComparison.CurrentCulture:
+								sqlCall = "( instr(" + obj.CommandText + "," + args[0].CommandText + ") >0 )";
+								break;
+							case StringComparison.OrdinalIgnoreCase:
+							case StringComparison.CurrentCultureIgnoreCase:
+								sqlCall = "(" + obj.CommandText + " like ( '%' || " + args[0].CommandText + " || '%'))";
+								break;
+						}
+					}
+					else
 					sqlCall = "(" + args[1].CommandText + " in " + args[0].CommandText + ")";
 				}
 				else if (call.Method.Name == "Contains" && args.Length == 1) {

--- a/src/StringContainsExtension.cs
+++ b/src/StringContainsExtension.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SQLite_net
+{
+	/// <summary>
+	/// Class for Contains extension with StringComparison option
+	/// </summary>
+	public static class StringContainsExtension
+	{
+		/// <summary>
+		/// Contains extension with StringComparison option
+		/// </summary>
+		/// <param name="source"></param>
+		/// <param name="value"></param>
+		/// <param name="comparisonType"></param>
+		/// <returns></returns>
+		public static bool Contains (this string source, string value, StringComparison comparisonType)
+		{
+			throw new NotImplementedException ("Method not implemented: for sqlite purpose only");
+		}
+	}
+}


### PR DESCRIPTION
When writing a TableQuery using "Contains" method, you always have a case-sensitive result, even if everything should work in a case-insensitive way.
This is due to the way the SELECT is constructed by the TableQuery class (now "instr" sqlite function is used, resulting always in a case-sensitive result).

I added an extension to Contains method, allowing developer to indicate which StringComparison option to use (like StartsWith/EndsWith method). If a case-insensitive option is specified, the sql code is constructed with LIKE instead of instr().