### PR TITLE
Add support for mapping columns to nested object properties

### DIFF
--- a/tests/NestedObjectPropertyMappingTest.cs
+++ b/tests/NestedObjectPropertyMappingTest.cs
@@ -1,0 +1,177 @@
+﻿using System;
+using System.Collections.Generic;
+
+#if NETFX_CORE
+using Microsoft.VisualStudio.TestPlatform.UnitTestFramework;
+using SetUp = Microsoft.VisualStudio.TestPlatform.UnitTestFramework.TestInitializeAttribute;
+using TestFixture = Microsoft.VisualStudio.TestPlatform.UnitTestFramework.TestClassAttribute;
+using Test = Microsoft.VisualStudio.TestPlatform.UnitTestFramework.TestMethodAttribute;
+#else
+using NUnit.Framework;
+#endif
+
+namespace SQLite.Tests
+{
+	[TestFixture]
+	public class NestedObjectPropertyMappingTest
+	{
+		SQLiteConnection db;
+
+		int fooId = 1;
+		int fooReferenceId = 3;
+		string fooName = "Foo Table";
+		string fooDescription = "The main table.";
+		string fooReferenceName = "Referenced table.";
+		string fooReferenceDescription = "A table referenced by the main table";
+
+		class FooTable
+		{
+			[PrimaryKey]
+			public int Id { get; set; }
+
+			public string FooName { get; set; }
+
+			public string FooDescription { get; set; }
+
+			public int FooTableReferenceId { get; set; }
+		}
+
+		class FooTableReference
+		{
+			[PrimaryKey]
+			public int Id { get; set; }
+
+			public string ReferenceName { get; set; }
+
+			public string ReferenceDescription { get; set; }
+		}
+
+		class FooDTO
+		{
+			public int Id { get; set; }
+
+			public string Name { get; set; }
+
+			public string Description { get; set; }
+
+			public FooNestedObject NestedObject { get; set; }
+		}
+
+		class FooNestedObject
+		{
+			public int Id { get; set; }
+
+			public string NestedName { get; set; }
+
+			public string NestedDescription { get; set; }
+			
+			public FooNestedObject NestedChild { get; set; }
+		}
+
+		public NestedObjectPropertyMappingTest()
+		{
+			SetupDb ();
+		}
+
+		void SetupDb()
+		{
+			db = new TestDb ();
+
+			db.CreateTable<FooTable> ();
+			db.CreateTable<FooTableReference> ();
+
+			db.Insert (new FooTable {
+				Id = fooId,
+				FooName = fooName,
+				FooDescription = fooDescription,
+				FooTableReferenceId = fooReferenceId
+			});
+			db.Insert (new FooTableReference {
+				Id = fooReferenceId,
+				ReferenceName = fooReferenceName,
+				ReferenceDescription = fooReferenceDescription,
+			});
+		}
+
+		[Test]
+		public void SelectNestedObject ()
+		{
+			string query =
+				$" select" +
+				$" fooTable.{nameof (FooTable.Id)} as '{nameof (FooDTO.Id)}'," +
+				$" fooTable.{nameof (FooTable.FooName)} as '{nameof (FooDTO.Name)}'," +
+				$" fooTable.{nameof (FooTable.FooDescription)} as '{nameof (FooDTO.Description)}'," +
+				$" fooTableReference.{nameof (FooTableReference.Id)} as '{nameof (FooDTO.NestedObject)}.{nameof (FooNestedObject.Id)}'," +
+				$" fooTableReference.{nameof (FooTableReference.ReferenceName)} as '{nameof (FooDTO.NestedObject)}.{nameof (FooNestedObject.NestedName)}'," +
+				$" fooTableReference.{nameof (FooTableReference.ReferenceDescription)} as '{nameof (FooDTO.NestedObject)}.{nameof (FooNestedObject.NestedDescription)}'" +
+				$" from {nameof (FooTable)} as fooTable" +
+				$" join {nameof (FooTableReference)} fooTableReference on fooTable.{nameof (FooTable.FooTableReferenceId)} = fooTableReference.{nameof (FooTableReference.Id)}" +
+				$" where fooTable.{nameof (FooTable.Id)} = {fooId}";
+			var dtoArray = db.Query<FooDTO> (query);
+			var dto = dtoArray[0];
+
+			Assert.AreEqual (dto.Id, fooId);
+			Assert.AreEqual (dto.Name, fooName);
+			Assert.AreEqual (dto.Description, fooDescription);
+			Assert.IsNotNull (dto.NestedObject);
+			Assert.AreEqual (dto.NestedObject.Id, fooReferenceId);
+			Assert.AreEqual (dto.NestedObject.NestedName, fooReferenceName);
+			Assert.AreEqual (dto.NestedObject.NestedDescription, fooReferenceDescription);
+		}
+
+		[Test]
+		public void SelectNestedObjectChildObjectProperty ()
+		{
+			string query =
+				$" select" +
+				$" fooTable.{nameof (FooTable.Id)} as '{nameof (FooDTO.Id)}'," +
+				$" fooTable.{nameof (FooTable.FooName)} as '{nameof (FooDTO.Name)}'," +
+				$" fooTable.{nameof (FooTable.FooDescription)} as '{nameof (FooDTO.Description)}'," +
+				$" fooTableReference.{nameof (FooTableReference.Id)} as '{nameof (FooDTO.NestedObject)}.{nameof (FooNestedObject.Id)}'," +
+				$" fooTableReference.{nameof (FooTableReference.ReferenceName)} as '{nameof (FooDTO.NestedObject)}.{nameof (FooNestedObject.NestedName)}'," +
+				$" fooTableReference.{nameof (FooTableReference.ReferenceDescription)} as '{nameof (FooDTO.NestedObject)}.{nameof (FooNestedObject.NestedChild)}.{nameof (FooNestedObject.NestedDescription)}'" +
+				$" from {nameof (FooTable)} as fooTable" +
+				$" join {nameof (FooTableReference)} fooTableReference on fooTable.{nameof (FooTable.FooTableReferenceId)} = fooTableReference.{nameof (FooTableReference.Id)}" +
+				$" where fooTable.{nameof (FooTable.Id)} = {fooId}";
+			var dtoArray = db.Query<FooDTO> (query);
+			var dto = dtoArray[0];
+
+			Assert.AreEqual (dto.Id, fooId);
+			Assert.AreEqual (dto.Name, fooName);
+			Assert.AreEqual (dto.Description, fooDescription);
+			Assert.IsNotNull (dto.NestedObject);
+			Assert.AreEqual (dto.NestedObject.Id, fooReferenceId);
+			Assert.AreEqual (dto.NestedObject.NestedName, fooReferenceName);
+
+			//Does not map to a nested object of a nested object - only goes one level deep.
+			Assert.IsNull (dto.NestedObject.NestedChild);
+		}
+
+		[Test]
+		public void SelectNonExistentNestedObjectProperty ()
+		{
+			string query =
+				$" select" +
+				$" fooTable.{nameof (FooTable.Id)} as '{nameof (FooDTO.Id)}'," +
+				$" fooTable.{nameof (FooTable.FooName)} as '{nameof (FooDTO.Name)}'," +
+				$" fooTable.{nameof (FooTable.FooDescription)} as '{nameof (FooDTO.Description)}'," +
+				$" fooTableReference.{nameof (FooTableReference.Id)} as '{nameof (FooDTO.NestedObject)}.{nameof (FooNestedObject.Id)}'," +
+				$" fooTableReference.{nameof (FooTableReference.ReferenceName)} as '{nameof (FooDTO.NestedObject)}.{nameof (FooNestedObject.NestedName)}'," +
+				$" fooTableReference.{nameof (FooTableReference.ReferenceDescription)} as '{nameof (FooDTO.NestedObject)}.Foo'" +
+				$" from {nameof (FooTable)} as fooTable" +
+				$" join {nameof (FooTableReference)} fooTableReference on fooTable.{nameof (FooTable.FooTableReferenceId)} = fooTableReference.{nameof (FooTableReference.Id)}" +
+				$" where fooTable.{nameof (FooTable.Id)} = {fooId}";
+			var dtoArray = db.Query<FooDTO> (query);
+			var dto = dtoArray[0];
+
+			Assert.AreEqual (dto.Id, fooId);
+			Assert.AreEqual (dto.Name, fooName);
+			Assert.AreEqual (dto.Description, fooDescription);
+			Assert.IsNotNull (dto.NestedObject);
+			Assert.AreEqual (dto.NestedObject.Id, fooReferenceId);
+			Assert.AreEqual (dto.NestedObject.NestedName, fooReferenceName);
+			Assert.IsNull (dto.NestedObject.NestedDescription);
+		}
+	}
+}
+

--- a/tests/SQLite.Tests.csproj
+++ b/tests/SQLite.Tests.csproj
@@ -84,6 +84,7 @@
     <Compile Include="BackupTest.cs" />
     <Compile Include="ReadmeTest.cs" />
     <Compile Include="QueryTest.cs" />
+    <Compile Include="NestedObjectPropertyMappingTest.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/tests/SQLite.Tests.iOS/SQLiteTestsiOS.csproj
+++ b/tests/SQLite.Tests.iOS/SQLiteTestsiOS.csproj
@@ -153,6 +153,9 @@
     <Compile Include="..\QueryTest.cs">
       <Link>QueryTest.cs</Link>
     </Compile>
+    <Compile Include="..\NestedObjectPropertyMappingTest.cs">
+      <Link>NestedObjectPropertyMappingTest.cs</Link>
+    </Compile>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
 </Project>


### PR DESCRIPTION
Current functionality does not allow the user to select and map columns to nested object properties of the return type when using the Query<T> function.

This change will allow the user to alias a column as NestedObject.PropertyName, which will instantiate the NestedObject (if no default value) and assign the value of the column to the specified PropertyName of the NestedObject. 

Example:
Given the table structure and DTO
```
//Table
class Foo
{
	public int Id { get; set; }
	public int FooReferenceId { get; set; }
}
//Table
class FooReference
{
	public int Id { get; set; }
	public string Name { get; set; }
}

//DTO
class FooModel 
{
	public int Id { get; set; }
	public int FooReferenceId { get; set; }
	public FooReference FooReferenceProperty { get; set; }
}
```

Current implementation would force us to populate the nested object `FooReferenceProperty` and its properties by combining multiple queries and in memory assignment like so:
```
string fooQuery =
	 " select" +
	 " fooTable.Id as 'Id'," +
	 " fooTable.FooReferenceId as 'FooReferenceId'" +
	 " from Foo as foo" +
	 " join FooReference fooReference on foo.FooReferenceId = fooReference.Id" +
	 " where foo.Id = 1";
var fooResult = db.Query<FooModel> (fooQuery);

var fooReferenceQuery = 
	 " select" +
	 " fooReference.Id as 'Id'," +
	 " fooReference.Name as 'Name'" +
	 " from Foo as foo" +
	 " join FooReference fooReference on foo.FooReferenceId = fooReference.Id" +
	 " where foo.Id = 1";
var fooReferenceResult = db.Query<FooReference> (fooQuery);

foreach (var item in fooResult)
{
	item.FooReferenceProperty = fooReferenceResult.FirstOrDefault (x => x.Id == item.FooReferenceId);
}
```
Doing this can become very cumbersome, especially when several nested objects are involved.

This modified implementation of `ExecuteDeferredQuery` will allow us to populate the nested object `FooReferenceProperty` and its properties with just a single `Query` call:
```
string fooQuery =
	 " select" +
	 " fooTable.Id as 'Id'," +
	 " fooTable.FooReferenceId as 'FooReferenceId'," +
	 " fooReference.Id as 'FooReferenceProperty.Id'," +
	 " fooReference.Name as 'FooReferenceProperty.Name'" +
	 " from Foo as foo" +
	 " join FooReference fooReference on foo.FooReferenceId = fooReference.Id" +
	 " where foo.Id = 1";
var fooResult = db.Query<FooModel> (fooQuery);
```
Note: Mapping will only be valid to the nested objects of the root object. This change does not support mapping to nested objects of nested objects. 