### PR TITLE
Issues: The right way to do prepared statements

### DIFF
--- a/src/SQLite.cs
+++ b/src/SQLite.cs
@@ -853,6 +853,33 @@ namespace SQLite
 		}
 
 		/// <summary>
+        ///     Creates a new SQLiteCommand given the command text with arguments. Place a "[@:]VVV"
+        ///     in the command text for each of the arguments.
+        /// </summary>
+        /// <param name="cmdText">
+        ///     The fully escaped SQL.
+        /// </param>
+        /// <param name="args">
+        ///     Arguments to substitute for the occurences of "[@:]VVV" in the command text.
+        /// </param>
+        /// <returns>
+        ///     A <see cref="SQLiteCommand" />
+        /// </returns>
+        public SQLiteCommand CreateCommand(string cmdText, Dictionary<string, object> args)
+        {
+            if (!this._open)
+                throw SQLiteException.New(SQLite3.Result.Error, "Cannot create commands from unopened database");
+
+            SQLiteCommand cmd = NewCommand();
+            cmd.CommandText = cmdText;
+            foreach (var kv in args)
+            {
+                cmd.Bind(kv.Key, kv.Value);
+            }
+            return cmd;
+        }
+
+		/// <summary>
 		/// Creates a SQLiteCommand given the command text (SQL) with arguments. Place a '?'
 		/// in the command text for each of the arguments and then executes that command.
 		/// Use this method instead of Query when you don't expect rows back. Such cases include


### PR DESCRIPTION
To properly do prepared statements
Overload `CreateCommand(string cmdText, Dictionary<string, object> args)`