### PR TITLE
Custom datetime format, string-based timespan

### DIFF
--- a/src/SQLite.cs
+++ b/src/SQLite.cs
@@ -2154,11 +2154,8 @@ namespace SQLite
 		/// If you use DateTimeOffset properties, it will be always stored as ticks regardingless
 		/// the storeDateTimeAsTicks parameter.
 		/// </param>
-		/// <param name="dateTimeStringFormat">
-		/// Specifies the format to use when storing DateTime properties as strings.
-		/// </param>
-		public SQLiteConnectionString (string databasePath, bool storeDateTimeAsTicks = true, string dateTimeStringFormat = DateTimeSqliteDefaultFormat)
-			: this (databasePath, SQLiteOpenFlags.Create | SQLiteOpenFlags.ReadWrite, storeDateTimeAsTicks, dateTimeStringFormat: dateTimeStringFormat)
+		public SQLiteConnectionString (string databasePath, bool storeDateTimeAsTicks = true)
+			: this (databasePath, SQLiteOpenFlags.Create | SQLiteOpenFlags.ReadWrite, storeDateTimeAsTicks)
 		{
 		}
 

--- a/src/SQLiteAsync.cs
+++ b/src/SQLiteAsync.cs
@@ -137,6 +137,11 @@ namespace SQLite
 		/// Whether to store DateTime properties as ticks (true) or strings (false).
 		/// </summary>
 		public bool StoreDateTimeAsTicks => GetConnection ().StoreDateTimeAsTicks;
+		
+		/// <summary>
+		/// Whether to store TimeSpan properties as ticks (true) or strings (false).
+		/// </summary>
+		public bool StoreTimeSpanAsTicks => GetConnection ().StoreTimeSpanAsTicks;
 
 		/// <summary>
 		/// Whether to writer queries to <see cref="Tracer"/> during execution.

--- a/tests/DateTimeTest.cs
+++ b/tests/DateTimeTest.cs
@@ -39,6 +39,14 @@ namespace SQLite.Tests
 			TestDateTime (db);
 		}
 
+		[TestCase("o")]
+		[TestCase("MMM'-'dd'-'yyyy' 'HH':'mm':'ss'.'fffffff")]
+		public void AsCustomStrings (string format)
+		{
+			var db = new TestDb (false, format);
+			TestDateTime (db);
+		}
+
 		[Test]
 		public void AsyncAsTicks ()
 		{
@@ -50,6 +58,14 @@ namespace SQLite.Tests
 		public void AsyncAsString ()
 		{
 			var db = new SQLiteAsyncConnection (TestPath.GetTempFileName (), false);
+			TestAsyncDateTime (db);
+		}
+
+		[TestCase("o")]
+		[TestCase("MMM'-'dd'-'yyyy' 'HH':'mm':'ss'.'fffffff")]
+		public void AsyncAsCustomStrings (string format)
+		{
+			var db = new SQLiteAsyncConnection (new SQLiteConnectionString (TestPath.GetTempFileName (), false, dateTimeStringFormat: format));
 			TestAsyncDateTime (db);
 		}
 

--- a/tests/DateTimeTest.cs
+++ b/tests/DateTimeTest.cs
@@ -35,12 +35,12 @@ namespace SQLite.Tests
 		[Test]
 		public void AsStrings ()
 		{
-			var db = new TestDb (storeDateTimeAsTicks: false);			
+			var db = new TestDb (storeDateTimeAsTicks: false);
 			TestDateTime (db);
 		}
 
-		[TestCase("o")]
-		[TestCase("MMM'-'dd'-'yyyy' 'HH':'mm':'ss'.'fffffff")]
+		[TestCase ("o")]
+		[TestCase ("MMM'-'dd'-'yyyy' 'HH':'mm':'ss'.'fffffff")]
 		public void AsCustomStrings (string format)
 		{
 			var db = new TestDb (CustomDateTimeString (format));
@@ -61,8 +61,8 @@ namespace SQLite.Tests
 			TestAsyncDateTime (db);
 		}
 
-		[TestCase("o")]
-		[TestCase("MMM'-'dd'-'yyyy' 'HH':'mm':'ss'.'fffffff")]
+		[TestCase ("o")]
+		[TestCase ("MMM'-'dd'-'yyyy' 'HH':'mm':'ss'.'fffffff")]
 		public void AsyncAsCustomStrings (string format)
 		{
 			var db = new SQLiteAsyncConnection (CustomDateTimeString (format));

--- a/tests/DateTimeTest.cs
+++ b/tests/DateTimeTest.cs
@@ -43,7 +43,7 @@ namespace SQLite.Tests
 		[TestCase("MMM'-'dd'-'yyyy' 'HH':'mm':'ss'.'fffffff")]
 		public void AsCustomStrings (string format)
 		{
-			var db = new TestDb (false, format);
+			var db = new TestDb (CustomDateTimeString (format));
 			TestDateTime (db);
 		}
 
@@ -65,9 +65,11 @@ namespace SQLite.Tests
 		[TestCase("MMM'-'dd'-'yyyy' 'HH':'mm':'ss'.'fffffff")]
 		public void AsyncAsCustomStrings (string format)
 		{
-			var db = new SQLiteAsyncConnection (new SQLiteConnectionString (TestPath.GetTempFileName (), false, dateTimeStringFormat: format));
+			var db = new SQLiteAsyncConnection (CustomDateTimeString (format));
 			TestAsyncDateTime (db);
 		}
+
+		SQLiteConnectionString CustomDateTimeString (string dateTimeFormat) => new SQLiteConnectionString (TestPath.GetTempFileName (), false, dateTimeFormat);
 
 		void TestAsyncDateTime (SQLiteAsyncConnection db)
 		{

--- a/tests/SQLite.Tests.csproj
+++ b/tests/SQLite.Tests.csproj
@@ -84,6 +84,7 @@
     <Compile Include="BackupTest.cs" />
     <Compile Include="ReadmeTest.cs" />
     <Compile Include="QueryTest.cs" />
+    <Compile Include="TimeSpanTest.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/tests/TestDb.cs
+++ b/tests/TestDb.cs
@@ -60,7 +60,7 @@ namespace SQLite.Tests
 				EnableWriteAheadLogging ();
 		}
 
-		public TestDb (bool storeDateTimeAsTicks, string dateTimeFormat, bool wal = true) : base (new SQLiteConnectionString (TestPath.GetTempFileName (), storeDateTimeAsTicks, dateTimeStringFormat: dateTimeFormat))
+		public TestDb (SQLiteConnectionString connectionString, bool wal = true) : base (connectionString)
 		{
 			Trace = true;
 			if (wal)

--- a/tests/TestDb.cs
+++ b/tests/TestDb.cs
@@ -60,6 +60,13 @@ namespace SQLite.Tests
 				EnableWriteAheadLogging ();
 		}
 
+		public TestDb (bool storeDateTimeAsTicks, string dateTimeFormat, bool wal = true) : base (new SQLiteConnectionString (TestPath.GetTempFileName (), storeDateTimeAsTicks, dateTimeStringFormat: dateTimeFormat))
+		{
+			Trace = true;
+			if (wal)
+				EnableWriteAheadLogging ();
+		}
+
 		public TestDb (string path, bool storeDateTimeAsTicks = true, object key = null, bool wal = true) : base (new SQLiteConnectionString (path, storeDateTimeAsTicks, key: key))
 		{
 			Trace = true;

--- a/tests/TimeSpanTest.cs
+++ b/tests/TimeSpanTest.cs
@@ -1,0 +1,85 @@
+﻿using System;
+using System.Threading.Tasks;
+
+#if NETFX_CORE
+using Microsoft.VisualStudio.TestPlatform.UnitTestFramework;
+using SetUp = Microsoft.VisualStudio.TestPlatform.UnitTestFramework.TestInitializeAttribute;
+using TestFixture = Microsoft.VisualStudio.TestPlatform.UnitTestFramework.TestClassAttribute;
+using Test = Microsoft.VisualStudio.TestPlatform.UnitTestFramework.TestMethodAttribute;
+#else
+using NUnit.Framework;
+#endif
+
+namespace SQLite.Tests
+{
+	[TestFixture]
+	public class TimeSpanTest
+	{
+		class TestObj
+		{
+			[PrimaryKey, AutoIncrement]
+			public int Id { get; set; }
+
+			public string Name { get; set; }
+			public TimeSpan Duration { get; set; }
+		}
+
+		[Test]
+		public void AsTicks ()
+		{
+			var db = new TestDb (TimeSpanAsTicks (true));
+			TestTimeSpan (db);
+		}
+
+		[Test]
+		public void AsStrings ()
+		{
+			var db = new TestDb (TimeSpanAsTicks (false));
+			TestTimeSpan (db);
+		}
+
+		[Test]
+		public void AsyncAsTicks ()
+		{
+			var db = new SQLiteAsyncConnection (TimeSpanAsTicks (true));
+			TestAsyncTimeSpan (db);
+		}
+
+		[Test]
+		public void AsyncAsStrings ()
+		{
+			var db = new SQLiteAsyncConnection (TimeSpanAsTicks (false));
+			TestAsyncTimeSpan (db);
+		}
+
+		SQLiteConnectionString TimeSpanAsTicks (bool asTicks = true) => new SQLiteConnectionString (TestPath.GetTempFileName (), SQLiteOpenFlags.Create | SQLiteOpenFlags.ReadWrite, true, storeTimeSpanAsTicks: asTicks);
+
+		void TestAsyncTimeSpan (SQLiteAsyncConnection db)
+		{
+			db.CreateTableAsync<TestObj> ().Wait ();
+
+			TestObj o, o2;
+
+			o = new TestObj {
+				Duration = new TimeSpan (42, 12, 33, 20, 501),
+			};
+			db.InsertAsync (o).Wait ();
+			o2 = db.GetAsync<TestObj> (o.Id).Result;
+			Assert.AreEqual (o.Duration, o2.Duration);
+		}
+
+		void TestTimeSpan (TestDb db)
+		{
+			db.CreateTable<TestObj> ();
+
+			TestObj o, o2;
+
+			o = new TestObj {
+				Duration = new TimeSpan (42, 12, 33, 20, 501),
+			};
+			db.Insert (o);
+			o2 = db.Get<TestObj> (o.Id);
+			Assert.AreEqual (o.Duration, o2.Duration);
+		}
+	}
+}


### PR DESCRIPTION
We're working with databases that are consumed by tools written in languages other than C#.  It's quite a hassle to convert between the C# native ticks format and a more portable one (or worse, mixing the formats in the same DB). This patch lets us specify the format string for `DateTime`s, as well as an option to use strings for `TimeSpan`s.  `DateTimeOffset`s are unchanged.