### PR TITLE
Performance Optimization: Fast Column Setters

### DIFF
--- a/src/SQLite.cs
+++ b/src/SQLite.cs
@@ -3444,8 +3444,6 @@ namespace SQLite
 
 		/// <summary>
 		/// This creates a strongly typed delegate that will permit fast setting of column values given a Sqlite3Statement and a column index.
-		///
-		/// Note that this has an extra check to see if it should create a nullable version of the delegate.
 		/// </summary>
 		/// <typeparam name="ObjectType">The type of the object whose member column is being set</typeparam>
 		/// <typeparam name="ColumnMemberType">The CLR type of the member in the object which corresponds to the given SQLite columnn</typeparam>

--- a/src/SQLite.cs
+++ b/src/SQLite.cs
@@ -2906,10 +2906,9 @@ namespace SQLite
 
 				for (int i = 0; i < cols.Length; i++) {
 					var name = SQLite3.ColumnName16 (stmt, i);
-					var colType = SQLite3.ColumnType (stmt, i);
 					cols[i] = map.FindColumn (name);
 					if (cols[i] != null)
-						fastColumnSetters[i] = FastColumnSetter.GetFastSetter<T> (_conn, colType, cols[i]);
+						fastColumnSetters[i] = FastColumnSetter.GetFastSetter<T> (_conn, cols[i]);
 				}
 
 				while (SQLite3.Step (stmt) == SQLite3.Result.Row) {
@@ -3254,22 +3253,17 @@ namespace SQLite
 		/// </summary>
 		/// <typeparam name="T">The type of the destination object that the query will read into</typeparam>
 		/// <param name="conn">The active connection.  Note that this is primarily needed in order to read preferences regarding how certain data types (such as TimeSpan / DateTime) should be encoded in the database.</param>
-		/// <param name="colType">The column type as stored in SQLite</param>
 		/// <param name="column">The table mapping used to map the statement column to a member of the destination object type</param>
 		/// <returns>
 		/// A delegate for fast-setting of object members from statement columns.
 		///
 		/// If no fast setter is available for the requested column (enums in particular cause headache), then this function returns null.
 		/// </returns>
-		internal static Action<T, Sqlite3Statement, int> GetFastSetter<T> (SQLiteConnection conn, SQLite3.ColType colType, TableMapping.Column column)
+		internal static Action<T, Sqlite3Statement, int> GetFastSetter<T> (SQLiteConnection conn, TableMapping.Column column)
 		{
 			Action<T, Sqlite3Statement, int> fastSetter = null;
 
-			Type clrType = column.ColumnType;
-
-			if (colType == SQLite3.ColType.Null) {
-				return null;
-			}
+			Type clrType = column.PropertyInfo.PropertyType;
 
 			var clrTypeInfo = clrType.GetTypeInfo ();
 			if (clrTypeInfo.IsGenericType && clrTypeInfo.GetGenericTypeDefinition () == typeof (Nullable<>)) {
@@ -3283,33 +3277,33 @@ namespace SQLite
 				});
 			}
 			else if (clrType == typeof (Int32)) {
-				fastSetter = CreateTypedSetterDelegate<T, int> (column, (stmt, index)=>{
+				fastSetter = CreateNullableTypedSetterDelegate<T, int> (column, (stmt, index)=>{
 					return SQLite3.ColumnInt (stmt, index);
 				});
 			}
 			else if (clrType == typeof (Boolean)) {
-				fastSetter = CreateTypedSetterDelegate<T, bool> (column, (stmt, index) => {
+				fastSetter = CreateNullableTypedSetterDelegate<T, bool> (column, (stmt, index) => {
 					return SQLite3.ColumnInt (stmt, index) == 1;
 				});
 			}
 			else if (clrType == typeof (double)) {
-				fastSetter = CreateTypedSetterDelegate<T, double> (column, (stmt, index) => {
+				fastSetter = CreateNullableTypedSetterDelegate<T, double> (column, (stmt, index) => {
 					return SQLite3.ColumnDouble (stmt, index);
 				});
 			}
 			else if (clrType == typeof (float)) {
-				fastSetter = CreateTypedSetterDelegate<T, float> (column, (stmt, index) => {
+				fastSetter = CreateNullableTypedSetterDelegate<T, float> (column, (stmt, index) => {
 					return (float) SQLite3.ColumnDouble (stmt, index);
 				});
 			}
 			else if (clrType == typeof (TimeSpan)) {
 				if (conn.StoreTimeSpanAsTicks) {
-					fastSetter = CreateTypedSetterDelegate<T, TimeSpan> (column, (stmt, index) => {
+					fastSetter = CreateNullableTypedSetterDelegate<T, TimeSpan> (column, (stmt, index) => {
 						return new TimeSpan (SQLite3.ColumnInt64 (stmt, index));
 					});
 				}
 				else {
-					fastSetter = CreateTypedSetterDelegate<T, TimeSpan> (column, (stmt, index) => {
+					fastSetter = CreateNullableTypedSetterDelegate<T, TimeSpan> (column, (stmt, index) => {
 						var text = SQLite3.ColumnString (stmt, index);
 						TimeSpan resultTime;
 						if (!TimeSpan.TryParseExact (text, "c", System.Globalization.CultureInfo.InvariantCulture, System.Globalization.TimeSpanStyles.None, out resultTime)) {
@@ -3321,12 +3315,12 @@ namespace SQLite
 			}
 			else if (clrType == typeof (DateTime)) {
 				if (conn.StoreDateTimeAsTicks) {
-					fastSetter = CreateTypedSetterDelegate<T, DateTime> (column, (stmt, index) => {
+					fastSetter = CreateNullableTypedSetterDelegate<T, DateTime> (column, (stmt, index) => {
 						return new DateTime (SQLite3.ColumnInt64 (stmt, index));
 					});
 				}
 				else {
-					fastSetter = CreateTypedSetterDelegate<T, DateTime> (column, (stmt, index) => {
+					fastSetter = CreateNullableTypedSetterDelegate<T, DateTime> (column, (stmt, index) => {
 						var text = SQLite3.ColumnString (stmt, index);
 						DateTime resultDate;
 						if (!DateTime.TryParseExact (text, conn.DateTimeStringFormat, System.Globalization.CultureInfo.InvariantCulture, conn.DateTimeStyle, out resultDate)) {
@@ -3337,7 +3331,7 @@ namespace SQLite
 				}
 			}
 			else if (clrType == typeof (DateTimeOffset)) {
-				fastSetter = CreateTypedSetterDelegate<T, DateTimeOffset> (column, (stmt, index) => {
+				fastSetter = CreateNullableTypedSetterDelegate<T, DateTimeOffset> (column, (stmt, index) => {
 					return new DateTimeOffset (SQLite3.ColumnInt64 (stmt, index), TimeSpan.Zero);
 				});
 			}
@@ -3345,37 +3339,37 @@ namespace SQLite
 				// NOTE: Not sure of a good way (if any?) to do a strongly-typed fast setter like this for enumerated types -- for now, return null and column sets will revert back to the safe (but slow) Reflection-based method of column prop.Set()
 			}
 			else if (clrType == typeof (Int64)) {
-				fastSetter = CreateTypedSetterDelegate<T, Int64> (column, (stmt, index) => {
+				fastSetter = CreateNullableTypedSetterDelegate<T, Int64> (column, (stmt, index) => {
 					return SQLite3.ColumnInt64 (stmt, index);
 				});
 			}
 			else if (clrType == typeof (UInt32)) {
-				fastSetter = CreateTypedSetterDelegate<T, UInt32> (column, (stmt, index) => {
+				fastSetter = CreateNullableTypedSetterDelegate<T, UInt32> (column, (stmt, index) => {
 					return (uint)SQLite3.ColumnInt64 (stmt, index);
 				});
 			}
 			else if (clrType == typeof (decimal)) {
-				fastSetter = CreateTypedSetterDelegate<T, decimal> (column, (stmt, index) => {
+				fastSetter = CreateNullableTypedSetterDelegate<T, decimal> (column, (stmt, index) => {
 					return (decimal)SQLite3.ColumnDouble (stmt, index);
 				});
 			}
 			else if (clrType == typeof (Byte)) {
-				fastSetter = CreateTypedSetterDelegate<T, Byte> (column, (stmt, index) => {
+				fastSetter = CreateNullableTypedSetterDelegate<T, Byte> (column, (stmt, index) => {
 					return (byte)SQLite3.ColumnInt (stmt, index);
 				});
 			}
 			else if (clrType == typeof (UInt16)) {
-				fastSetter = CreateTypedSetterDelegate<T, UInt16> (column, (stmt, index) => {
+				fastSetter = CreateNullableTypedSetterDelegate<T, UInt16> (column, (stmt, index) => {
 					return (ushort)SQLite3.ColumnInt (stmt, index);
 				});
 			}
 			else if (clrType == typeof (Int16)) {
-				fastSetter = CreateTypedSetterDelegate<T, Int16> (column, (stmt, index) => {
+				fastSetter = CreateNullableTypedSetterDelegate<T, Int16> (column, (stmt, index) => {
 					return (short)SQLite3.ColumnInt (stmt, index);
 				});
 			}
 			else if (clrType == typeof (sbyte)) {
-				fastSetter = CreateTypedSetterDelegate<T, sbyte> (column, (stmt, index) => {
+				fastSetter = CreateNullableTypedSetterDelegate<T, sbyte> (column, (stmt, index) => {
 					return (sbyte)SQLite3.ColumnInt (stmt, index);
 				});
 			}
@@ -3385,7 +3379,7 @@ namespace SQLite
 				});
 			}
 			else if (clrType == typeof (Guid)) {
-				fastSetter = CreateTypedSetterDelegate<T, Guid> (column, (stmt, index) => {
+				fastSetter = CreateNullableTypedSetterDelegate<T, Guid> (column, (stmt, index) => {
 					var text = SQLite3.ColumnString (stmt, index);
 					return new Guid (text);
 				});
@@ -3409,13 +3403,49 @@ namespace SQLite
 				});
 			}
 			else {
-				// Note: Will fall back to the slow setter method in the event that we are unable to create a fast setter delegate for a particular column type
+				// NOTE: Will fall back to the slow setter method in the event that we are unable to create a fast setter delegate for a particular column type
 			}
 			return fastSetter;
 		}
 
 		/// <summary>
 		/// This creates a strongly typed delegate that will permit fast setting of column values given a Sqlite3Statement and a column index.
+		///
+		/// Note that this is identical to CreateTypedSetterDelegate(), but has an extra check to see if it should create a nullable version of the delegate.
+		/// </summary>
+		/// <typeparam name="ObjectType">The type of the object whose member column is being set</typeparam>
+		/// <typeparam name="ColumnMemberType">The CLR type of the member in the object which corresponds to the given SQLite columnn</typeparam>
+		/// <param name="column">The column mapping that identifies the target member of the destination object</param>
+		/// <param name="getColumnValue">A lambda that can be used to retrieve the column value at query-time</param>
+		/// <returns>A strongly-typed delegate</returns>
+		private static Action<ObjectType, Sqlite3Statement, int> CreateNullableTypedSetterDelegate<ObjectType, ColumnMemberType> (TableMapping.Column column, Func<Sqlite3Statement, int, ColumnMemberType> getColumnValue) where ColumnMemberType : struct
+		{
+			var clrTypeInfo = column.PropertyInfo.PropertyType.GetTypeInfo();
+			bool isNullable = false;
+
+			if (clrTypeInfo.IsGenericType && clrTypeInfo.GetGenericTypeDefinition () == typeof (Nullable<>)) {
+				isNullable = true;
+			}
+
+			if (isNullable) {
+				var setProperty = (Action<ObjectType, ColumnMemberType?>)Delegate.CreateDelegate (
+						typeof (Action<ObjectType, ColumnMemberType?>), null,
+						column.PropertyInfo.GetSetMethod ());
+
+				return (o, stmt, i) => {
+					var colType = SQLite3.ColumnType (stmt, i);
+					if (colType != SQLite3.ColType.Null)
+						setProperty.Invoke (o, getColumnValue.Invoke (stmt, i));
+				};
+			}
+
+			return CreateTypedSetterDelegate<ObjectType, ColumnMemberType> (column, getColumnValue);
+		}
+
+		/// <summary>
+		/// This creates a strongly typed delegate that will permit fast setting of column values given a Sqlite3Statement and a column index.
+		///
+		/// Note that this has an extra check to see if it should create a nullable version of the delegate.
 		/// </summary>
 		/// <typeparam name="ObjectType">The type of the object whose member column is being set</typeparam>
 		/// <typeparam name="ColumnMemberType">The CLR type of the member in the object which corresponds to the given SQLite columnn</typeparam>
@@ -3424,18 +3454,15 @@ namespace SQLite
 		/// <returns>A strongly-typed delegate</returns>
 		private static Action<ObjectType, Sqlite3Statement, int> CreateTypedSetterDelegate<ObjectType, ColumnMemberType> (TableMapping.Column column, Func<Sqlite3Statement, int, ColumnMemberType> getColumnValue)
 		{
-			Action<ObjectType, Sqlite3Statement, int> fastSetter;
-
-			// Create a delegate that points to the Set accessor of the destination object property
 			var setProperty = (Action<ObjectType, ColumnMemberType>)Delegate.CreateDelegate (
 					typeof (Action<ObjectType, ColumnMemberType>), null,
 					column.PropertyInfo.GetSetMethod ());
 
-			// Wrapping the setter delegate allows us to maintain strong typing for these dynamic methods
-			fastSetter = (o, stmt, i) => {
-				setProperty.Invoke (o, getColumnValue.Invoke(stmt, i));
+			return (o, stmt, i) => {
+				var colType = SQLite3.ColumnType (stmt, i);
+				if (colType != SQLite3.ColType.Null)
+					setProperty.Invoke (o, getColumnValue.Invoke (stmt, i));
 			};
-			return fastSetter;
 		}
 	}
 


### PR DESCRIPTION
This PR changes the way that we do column lookups to be once-per-query rather than once-per row.  By doing this, we can speed up large query retrieval by ~500%.  

We have to do some funky stuff re: creating dynamic strongly-typed setter delegates, but other libraries have already gone this way (such as Protobuf), so we can follow in their footsteps a bit.

## Detailed explanation: Simple Syntax vs. Fast Speed

SQLite.net is very easy to use, and has great facility for mapping from SQLite tables into object properties.  However, for very large queries, response times can be a bit on the slow side:

	// *** Method 1 ***
	var orders = conn.Query<OrderDetail>("select * from [OrderDetail]");


If OrderDetail is 1 million records or so, then performance is very poor:

```Retrieved 1000000 records in 14852 ms```

Why does it take 15 seconds to query from a local database?  This should be FAST!

Traditionally this can be overcome by doing some low-level work and stepping through a SQLite query on your own:

	// *** Method 2 ***
	var stmt = SQLite3.Prepare2(conn.Handle, "select * from [OrderDetail]");
	var orders = new List<OrderDetail>();
	
	while (SQLite3.Step(stmt) == SQLite3.Result.Row)
	{
	    var id = SQLite3.ColumnInt(stmt, 0);
	    var orderId = SQLite3.ColumnInt(stmt, 1);
	    var productId = SQLite3.ColumnInt(stmt, 2);
	    var quantity = SQLite3.ColumnInt(stmt, 3);
	    var name = SQLite3.ColumnString(stmt, 4);
	
	    var orderDetail = new OrderDetail()
	    {
	        Id = id,
	        OrderId = orderId,
	        ProductId = productId,
	        Quantity = quantity,
	        Name = name
	    };
	    orders.Add(orderDetail);
	}

uuuugh.  It's much more cumbersome syntax, but the performance boost is undeniable:
```Retrieved 1000000 records in 1350 ms.```

That's more like it!  It runs in a tenth of the time!  Both are using SQLite.net with the same query on the same database -- so why is Method 1 so slow?

## In-Loop Reflection as the Root of Evil

The core of the problem lies in the fact that the inside of SQLite.net's `ExecuteDeferredQuery` loop makes a call to `PropertyInfo.SetValue ()`.  This is a rather heavy-weight call that uses Reflection every time it's called to make sure that the generic `object` being passed into it is compatible with the type held by that particular PropertyInfo.

So how do we fix this?  Is there a way to have the syntactic sugar of Method 1 with the speed of Method 2?

The good news is yes -- there are two alternatives that people have used to approach this problem.

### Fast-Member
The fastest method is to emit dynamic IL and link into that at runtime.  This is the method used by the [excellent Fast-Member library](https://github.com/mgravell/fast-member).

However, there are .NET platforms (such as Xamarin.iOS and Unity IL2CPP) that don't support such shenanigans, so I'd rather not go down that road.

### Strongly-Typed Delegates
The second method isn't quite as fast as dynamic IL, but it's still reasonably fast.  It involves doing all of the type-checking reflection _outside_ of the query loop, and creating strongly-typed delegates to set property values.  

Jon Skeet wrote [a blog post](https://codeblog.jonskeet.uk/2008/08/09/making-reflection-fly-and-exploring-delegates/) that explains this technique, as well as [a Stack Overflow answer that summarizes nicely](https://stackoverflow.com/a/1028058/12481680).  This is the same technique used to add [this same speed-boost to Google's Protobuf library](https://github.com/protocolbuffers/protobuf/blob/master/csharp/src/Google.Protobuf/Reflection/ReflectionUtil.cs).

I'm not doing everything quite the same way as he is (to be honest, I had a hard time following all of it), but I think the version I created is hopefully easy enough to read, and similarly zippy at runtime.

Note that we avoid quite a bit of confusion by simply skipping the Enum case, and falling back to the original method of simply calling Column.Set() on every row.  For enumerated types, then my pull request will simply fall back on the old (and slow) method of calling `PropertyInfo.SetValue()` on every row.  Yes, it's slow -- but at least it's not going to be any slower than it was before this change (and maybe someone else can help figure out the black-magic voodoo to make strongly-typed delegates for enums function).  

## Measuring Performance
So what does this all boil down to?  Well, let's check the performance.

Prior to my pull request:

	Method 1: Retrieved 1000000 records in 15009 ms.
	Method 2: Retrieved 1000000 records in 1419 ms.

After FastColumnSet:

	Method 1: Retrieved 1000000 records in 3087 ms.
	Method 2: Retrieved 1000000 records in 1426 ms.

Still not nearly as good as the hand-created mappings, but 15 seconds down to 3 seconds is still an impressive boost!

There's a lot of junk I needed to put in there to make Nullable types work properly (ugh).  If I skip Nullable checks and defer nullable types back to the legacy method, then it makes things a tad bit simpler, but I don't think the speed increase is that significant -- it shaves off maybe 500ms or so.

## Feedback?
What do you all think?  Is this clean enough / general-purpose enough to make it into the main trunk?  

I'm certainly open to input on how to make this all cleaner -- it was a bear getting this all to work properly, but I'm very very thankful for a comprehensive unit test suite in SQLite-net. Kudos for that. :)