### PR TITLE
Updated SQLitePCLRaw NuGet packages to version 2.0.2 (fixes #882)

### DIFF
--- a/nuget/SQLite-net-base/SQLite-net-base.csproj
+++ b/nuget/SQLite-net-base/SQLite-net-base.csproj
@@ -26,7 +26,7 @@
     <DocumentationFile>bin\Debug\netstandard2.0\SQLite-net.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="SQLitePCLRaw.core" Version="2.0.1" />
+    <PackageReference Include="SQLitePCLRaw.core" Version="2.0.2" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\..\src\SQLite.cs">

--- a/nuget/SQLite-net-sqlcipher/SQLite-net-sqlcipher.csproj
+++ b/nuget/SQLite-net-sqlcipher/SQLite-net-sqlcipher.csproj
@@ -26,7 +26,7 @@
     <DocumentationFile>bin\Debug\netstandard2.0\SQLite-net.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlcipher" Version="2.0.1" />
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlcipher" Version="2.0.2" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\..\src\SQLite.cs">

--- a/nuget/SQLite-net-std/SQLite-net-std.csproj
+++ b/nuget/SQLite-net-std/SQLite-net-std.csproj
@@ -26,7 +26,7 @@
     <DocumentationFile>bin\Debug\netstandard2.0\SQLite-net.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="SQLitePCLRaw.bundle_green" Version="2.0.1" />
+    <PackageReference Include="SQLitePCLRaw.bundle_green" Version="2.0.2" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\..\src\SQLite.cs">


### PR DESCRIPTION
In issue #882 there was a problem reported with the current beta 1.7.302-beta when compiling Xamarin.Android projects. -the sqlite-net-pcl package references SQLitePCLRaw packages version 2.0.1, which on Android didn't include the necessary e_sqlite3 library, resulting in errors like
`System.DllNotFoundException:** 'e_sqlite3 assembly:<unknown assembly> type:<unknown type> member:(null)'`
@ericsink fixed this in the 2.0.2 packages. A workaround is to add the SQLitePCLRaw 2.0.2 package to the Xamarin.Android project. If sqlite-net-pcl would update the NuGet package references, this workaround wouldn't be necessary.
This PR therefore updates the package references to the SQLitePCLRaw packages to 2.0.2. This fixes #882. Compiles without errors on my local Visual Studio 2019 version 16.5.1.