### PR TITLE
ReadmeTest.cs were failing if run in parallel execution or continuosly

### DIFF
--- a/tests/ReadmeTest.cs
+++ b/tests/ReadmeTest.cs
@@ -64,9 +64,8 @@ namespace SQLite.Tests
 		[Test]
 		public void Synchronous ()
 		{
-			var databasePath = Path.Combine (Environment.GetFolderPath (Environment.SpecialFolder.MyDocuments), "SynchronousMyData.db");
-			File.Delete (databasePath);
-
+			var databasePath = Path.Combine (Path.GetTempPath(), "SynchronousMyData"+ Guid.NewGuid() +".db");
+			File.Delete(databasePath);
 			var db = new SQLiteConnection (databasePath);
 			try
 			{
@@ -100,7 +99,7 @@ namespace SQLite.Tests
 		public async Task Asynchronous()
 		{
 			// Get an absolute path to the database file
-			var databasePath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), "AsynchronousMyData.db");
+			var databasePath = Path.Combine(Path.GetTempPath(), "AsynchronousMyData" + Guid.NewGuid() + ".db");
 			File.Delete(databasePath);
 			var db = new SQLiteAsyncConnection(databasePath);
 			try
@@ -143,7 +142,7 @@ namespace SQLite.Tests
 		[Test]
 		public async Task Cipher()
 		{
-			var databasePath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), "CipherMyData.db");
+			var databasePath = Path.Combine(Path.GetTempPath(), "CipherMyData" + Guid.NewGuid() + ".db");
 			File.Delete(databasePath);
 
 			var options = new SQLiteConnectionString(databasePath, true, key: "password");

--- a/tests/ReadmeTest.cs
+++ b/tests/ReadmeTest.cs
@@ -64,95 +64,125 @@ namespace SQLite.Tests
 		[Test]
 		public void Synchronous ()
 		{
-			var databasePath = Path.Combine (Environment.GetFolderPath (Environment.SpecialFolder.MyDocuments), "MyData.db");
+			var databasePath = Path.Combine (Environment.GetFolderPath (Environment.SpecialFolder.MyDocuments), "SynchronousMyData.db");
 			File.Delete (databasePath);
 
 			var db = new SQLiteConnection (databasePath);
-			db.CreateTable<Stock> ();
-			db.CreateTable<Valuation> ();
+			try
+			{
+				db.CreateTable<Stock>();
+				db.CreateTable<Valuation>();
 
-			AddStock (db, "A1");
-			AddStock (db, "A2");
-			AddStock (db, "A3");
-			AddStock (db, "B1");
-			AddStock (db, "B2");
-			AddStock (db, "B3");
+				AddStock(db, "A1");
+				AddStock(db, "A2");
+				AddStock(db, "A3");
+				AddStock(db, "B1");
+				AddStock(db, "B2");
+				AddStock(db, "B3");
 
-			var query = db.Table<Stock> ().Where (v => v.Symbol.StartsWith ("A"));
+				var query = db.Table<Stock>().Where(v => v.Symbol.StartsWith("A"));
 
-			foreach (var stock in query)
-				Console.WriteLine ("Stock: " + stock.Symbol);
+				foreach (var stock in query)
+					Console.WriteLine("Stock: " + stock.Symbol);
 
-			Assert.AreEqual (3, query.ToList ().Count);
+				Assert.AreEqual(3, query.ToList().Count);
+			}
+			finally
+			{
+				db.Close();
+				File.Delete(databasePath);
+			}
+
 
 		}
 
 		[Test]
-		public async Task Asynchronous ()
+		public async Task Asynchronous()
 		{
-			await Task.Delay (1).ConfigureAwait (false);
-
 			// Get an absolute path to the database file
-			var databasePath = Path.Combine (Environment.GetFolderPath (Environment.SpecialFolder.MyDocuments), "MyData.db");
-			File.Delete (databasePath);
+			var databasePath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), "AsynchronousMyData.db");
+			File.Delete(databasePath);
+			var db = new SQLiteAsyncConnection(databasePath);
+			try
+			{
+				await db.CreateTableAsync<Stock>();
 
-			var db = new SQLiteAsyncConnection (databasePath);
+				Console.WriteLine("Table created!");
 
-			await db.CreateTableAsync<Stock> ();
+				var stock = new Stock()
+				{
+					Symbol = "AAPL"
+				};
 
-			Console.WriteLine ("Table created!");
+				await db.InsertAsync(stock);
 
-			var stock = new Stock () {
-				Symbol = "AAPL"
-			};
+				Console.WriteLine("New sti ID: {0}", stock.Id);
 
-			await db.InsertAsync (stock);
+				var query = db.Table<Stock>().Where(s => s.Symbol.StartsWith("A"));
 
-			Console.WriteLine ("New sti ID: {0}", stock.Id);
+				var result = await query.ToListAsync();
 
-			var query = db.Table<Stock> ().Where (s => s.Symbol.StartsWith ("A"));
+				foreach (var s in result)
+					Console.WriteLine("Stock: " + s.Symbol);
 
-			var result = await query.ToListAsync ();
+				Assert.AreEqual(1, result.Count);
 
-			foreach (var s in result)
-				Console.WriteLine ("Stock: " + s.Symbol);
+				var count = await db.ExecuteScalarAsync<int>("select count(*) from Stock");
 
-			Assert.AreEqual (1, result.Count);
+				Console.WriteLine(string.Format("Found '{0}' stock items.", count));
 
-			var count = await db.ExecuteScalarAsync<int> ("select count(*) from Stock");
-
-			Console.WriteLine (string.Format ("Found '{0}' stock items.", count));
-
-			Assert.AreEqual (1, count);
+				Assert.AreEqual(1, count);
+			}
+			finally
+			{
+				await db.CloseAsync();
+				File.Delete(databasePath);
+			}
 		}
 
 		[Test]
-		public void Cipher ()
+		public async Task Cipher()
 		{
-			var databasePath = Path.Combine (Environment.GetFolderPath (Environment.SpecialFolder.MyDocuments), "MyData.db");
-			File.Delete (databasePath);
+			var databasePath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), "CipherMyData.db");
+			File.Delete(databasePath);
 
-			var options = new SQLiteConnectionString (databasePath, true, key: "password");
-			var encryptedDb = new SQLiteAsyncConnection (options);
+			var options = new SQLiteConnectionString(databasePath, true, key: "password");
+			var encryptedDb = new SQLiteAsyncConnection(options);
 
-			var options2 = new SQLiteConnectionString (databasePath, true,
+			var options2 = new SQLiteConnectionString(databasePath, true,
 				key: "password",
 				preKeyAction: db => db.Execute("PRAGMA cipher_default_use_hmac = OFF;"),
-				postKeyAction: db => db.Execute ("PRAGMA kdf_iter = 128000;"));
-			var encryptedDb2 = new SQLiteAsyncConnection (options2);
+				postKeyAction: db => db.Execute("PRAGMA kdf_iter = 128000;"));
+			SQLiteAsyncConnection encryptedDb2 = null;
+			try
+			{
+				encryptedDb2 = new SQLiteAsyncConnection(options2);
+			}
+			finally
+			{
+				await encryptedDb2?.CloseAsync();
+				File.Delete(databasePath);
+			}
 		}
 
 		[Test]
 		public void Manual()
 		{
 			var db = new SQLiteConnection (":memory:");
+			try
+			{
 
-			db.Execute ("create table Stock(Symbol varchar(100) not null)");
-			db.Execute ("insert into Stock(Symbol) values (?)", "MSFT");
-			var stocks = db.Query<Stock> ("select * from Stock");
+				db.Execute("create table Stock(Symbol varchar(100) not null)");
+				db.Execute("insert into Stock(Symbol) values (?)", "MSFT");
+				var stocks = db.Query<Stock>("select * from Stock");
 
-			Assert.AreEqual (1, stocks.Count);
-			Assert.AreEqual ("MSFT", stocks[0].Symbol);
+				Assert.AreEqual(1, stocks.Count);
+				Assert.AreEqual("MSFT", stocks[0].Symbol);
+			}
+			finally
+			{
+				db.Close();
+			}
 		}
 	}
 }


### PR DESCRIPTION
I personally use "NCrunch" as nunit test runner. among the other things it supports parallel execution of tests (which should work because tests are supposed to be able to run in total isolation among each other) and a "churn mode" which actually runs tests continuosly, totally non-stop, until they break.

The tests in this source file:

1.  couldn't be run in parallel because they were trying to delete and reuse the same file. When run in parallel they were breaking because they were trying to delete a database file being used by another test.
2. couldn't be run continuosly because they weren't doing any proper database.close() operation, so if the garbage collector hasn't been run yet, the file resulted still in use and couldn't be deleted (this doesn't apply obviously to the test using a :memory: database... but still..

P.S: I have similar issues with the other tests, but I will submit separate pull requests for each files to make it easier for you to evaluate them... there's a 1-month trial version of NCrunch if you want to experience it by yourelf. (it is not just a test runner... it runs tests as you type on the code you are typing: you break something, you know it whithin 10 seconds after having broken it) 
p.s. I don't work for ncrunch, I am just a happy user of it.
