### PR TITLE
Use icon because PackageIconUrl is deprecated

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,7 +3,7 @@
         <VersionPrefix>1.7</VersionPrefix>
         <VersionSuffix>beta</VersionSuffix>
 
-        <PackageIconUrl>https://raw.githubusercontent.com/praeclarum/sqlite-net/master/nuget/Logo-low.png</PackageIconUrl>
+        <PackageIcon>Logo.png</PackageIcon>
         <PackageProjectUrl>https://github.com/praeclarum/sqlite-net</PackageProjectUrl>
         <RepositoryUrl>https://github.com/praeclarum/sqlite-net.git</RepositoryUrl>
         <PackageTags>sqlite-net;sqlite;database;orm</PackageTags>
@@ -13,4 +13,7 @@
 
         <Deterministic>true</Deterministic>
     </PropertyGroup>
+    <ItemGroup>
+        <None Include="$(MSBuildThisFileDirectory)nuget\Logo-low.png" Pack="true" PackagePath="Logo.png"/>
+    </ItemGroup>
 </Project>


### PR DESCRIPTION
See [NuGet Error NU5030 | Microsoft Docs](https://docs.microsoft.com/en-us/nuget/reference/errors-and-warnings/nu5030 )