### PR TITLE
Pass along "extra" correctly on InsertAll

### DIFF
--- a/src/SQLite.cs
+++ b/src/SQLite.cs
@@ -1558,7 +1558,7 @@ namespace SQLite
 			}
 			else {
 				foreach (var r in objects) {
-					c += Insert (r);
+					c += Insert (r, extra);
 				}
 			}
 			return c;


### PR DESCRIPTION
Seems like "extra" was forgotten in the non-transactional path and only passed along when running in a transaction