### PR TITLE
use ExecuteScalar<string> to handle 'ok' result from PRAGMA key

### DIFF
--- a/src/SQLite.cs
+++ b/src/SQLite.cs
@@ -368,7 +368,7 @@ namespace SQLite
 		{
 			if (key == null) throw new ArgumentNullException (nameof (key));
 			var q = Quote (key);
-			Execute ("pragma key = " + q);
+			ExecuteScalar<string> ("pragma key = " + q);
 		}
 
 		/// <summary>
@@ -383,7 +383,7 @@ namespace SQLite
 			if (key == null) throw new ArgumentNullException (nameof (key));
 			if (key.Length != 32) throw new ArgumentException ("Key must be 32 bytes (256-bit)", nameof(key));
 			var s = String.Join ("", key.Select (x => x.ToString ("X2")));
-			Execute ("pragma key = \"x'" + s + "'\"");
+			ExecuteScalar<string> ("pragma key = \"x'" + s + "'\"");
 		}
 
 		/// <summary>


### PR DESCRIPTION
The SQLitePCL.raw 2.0.5 prerelease (ericsink/SQLitePCL.raw#392) has been updated by @ericsink to include SQLCipher version 4.4.2. As of SQLCipher 4.3.0 the `PRAGMA key` command now returns a scalar value result, `ok`. This change was made to maintain consistency with upstream SQLite. 

As a result, sqlite-net should be updated to call `PRAGMA key` using `ExecuteScalar<string>`. The use of `Execute` on master and in the current 1.7.335 will resulting in a `SQLiteException: not an error` exception. 

This issue is also being tracked under ericsink/SQLitePCL.raw#394.
