### PR TITLE
Implement cancellable queries.

### DIFF
--- a/src/SQLite.cs
+++ b/src/SQLite.cs
@@ -1008,6 +1008,32 @@ namespace SQLite
 		}
 
 		/// <summary>
+		/// Creates a SQLiteCommand given the command text (SQL) with arguments that may be cancelled.
+		/// Place a '?' in the command text for each of the arguments and then executes that command.
+		/// It returns each row of the result using the mapping automatically generated for
+		/// the given type.
+		/// </summary>
+		/// <param name="query">
+		/// The fully escaped SQL.
+		/// </param>
+		/// <param name="cancellationToken">
+		/// A cancellation token that may be used to cancel the query.
+		/// <para/>
+		/// When <see cref="CancellationToken.IsCancellationRequested"/> is true, causes a <see cref="OperationCanceledException"/> to be thrown.
+		/// </param>
+		/// <param name="args">
+		/// Arguments to substitute for the occurences of '?' in the query.
+		/// </param>
+		/// <returns>
+		/// An enumerable with one result for each row returned by the query.
+		/// </returns>
+		public List<T> QueryWithCancellation<T> (string query, CancellationToken cancellationToken, params object[] args) where T : new()
+		{
+			var cmd = CreateCommand (query, args);
+			return cmd.ExecuteQueryWithCancellation<T> (cancellationToken);
+		}
+
+		/// <summary>
 		/// Creates a SQLiteCommand given the command text (SQL) with arguments. Place a '?'
 		/// in the command text for each of the arguments and then executes that command.
 		/// It returns the first column of each row of the result.
@@ -1025,6 +1051,31 @@ namespace SQLite
 		{
 			var cmd = CreateCommand (query, args);
 			return cmd.ExecuteQueryScalars<T> ().ToList ();
+		}
+
+		/// <summary>
+		/// Creates a SQLiteCommand given the command text (SQL) with arguments that may be cancelled.
+		/// Place a '?' in the command text for each of the arguments and then executes that command.
+		/// It returns the first column of each row of the result.
+		/// </summary>
+		/// <param name="query">
+		/// The fully escaped SQL.
+		/// </param>
+		/// <param name="cancellationToken">
+		/// A cancellation token that may be used to cancel the query.
+		/// <para/>
+		/// When <see cref="CancellationToken.IsCancellationRequested"/> is true, causes a <see cref="OperationCanceledException"/> to be thrown.
+		/// </param>
+		/// <param name="args">
+		/// Arguments to substitute for the occurences of '?' in the query.
+		/// </param>
+		/// <returns>
+		/// An enumerable with one result for the first column of each row returned by the query.
+		/// </returns>
+		public List<T> QueryScalarsWithCancellation<T> (string query, CancellationToken cancellationToken, params object[] args)
+		{
+			var cmd = CreateCommand (query, args);
+			return cmd.ExecuteQueryScalarsWithCancellation<T> (cancellationToken).ToList ();
 		}
 
 		/// <summary>
@@ -1049,6 +1100,35 @@ namespace SQLite
 		{
 			var cmd = CreateCommand (query, args);
 			return cmd.ExecuteDeferredQuery<T> ();
+		}
+
+		/// <summary>
+		/// Creates a SQLiteCommand given the command text (SQL) with arguments that may be cancelled.
+		/// Place a '?' in the command text for each of the arguments and then executes that command.
+		/// It returns each row of the result using the mapping automatically generated for
+		/// the given type.
+		/// </summary>
+		/// <param name="query">
+		/// The fully escaped SQL.
+		/// </param>
+		/// <param name="cancellationToken">
+		/// A cancellation token that may be used to cancel the query.
+		/// <para/>
+		/// When <see cref="CancellationToken.IsCancellationRequested"/> is true, causes a <see cref="OperationCanceledException"/> to be thrown.
+		/// </param>
+		/// <param name="args">
+		/// Arguments to substitute for the occurences of '?' in the query.
+		/// </param>
+		/// <returns>
+		/// An enumerable with one result for each row returned by the query.
+		/// The enumerator (retrieved by calling GetEnumerator() on the result of this method)
+		/// will call sqlite3_step on each call to MoveNext, so the database
+		/// connection must remain open for the lifetime of the enumerator.
+		/// </returns>
+		public IEnumerable<T> DeferredQueryWithCancellation<T> (string query, CancellationToken cancellationToken, params object[] args) where T : new()
+		{
+			var cmd = CreateCommand (query, args);
+			return cmd.ExecuteDeferredQueryWithCancellation<T> (cancellationToken);
 		}
 
 		/// <summary>
@@ -1078,6 +1158,37 @@ namespace SQLite
 		}
 
 		/// <summary>
+		/// Creates a SQLiteCommand given the command text (SQL) with arguments that may be cancelled.
+		/// Place a '?' in the command text for each of the arguments and then executes that command.
+		/// It returns each row of the result using the specified mapping. This function is
+		/// only used by libraries in order to query the database via introspection. It is
+		/// normally not used.
+		/// </summary>
+		/// <param name="map">
+		/// A <see cref="TableMapping"/> to use to convert the resulting rows
+		/// into objects.
+		/// </param>
+		/// <param name="query">
+		/// The fully escaped SQL.
+		/// </param>
+		/// <param name="cancellationToken">
+		/// A cancellation token that may be used to cancel the query.
+		/// <para/>
+		/// When <see cref="CancellationToken.IsCancellationRequested"/> is true, causes a <see cref="OperationCanceledException"/> to be thrown.
+		/// </param>
+		/// <param name="args">
+		/// Arguments to substitute for the occurences of '?' in the query.
+		/// </param>
+		/// <returns>
+		/// An enumerable with one result for each row returned by the query.
+		/// </returns>
+		public List<object> QueryWithCancellation (TableMapping map, string query, CancellationToken cancellationToken, params object[] args)
+		{
+			var cmd = CreateCommand (query, args);
+			return cmd.ExecuteQueryWithCancellation<object> (map, cancellationToken);
+		}
+
+		/// <summary>
 		/// Creates a SQLiteCommand given the command text (SQL) with arguments. Place a '?'
 		/// in the command text for each of the arguments and then executes that command.
 		/// It returns each row of the result using the specified mapping. This function is
@@ -1104,6 +1215,40 @@ namespace SQLite
 		{
 			var cmd = CreateCommand (query, args);
 			return cmd.ExecuteDeferredQuery<object> (map);
+		}
+
+		/// <summary>
+		/// Creates a SQLiteCommand given the command text (SQL) with arguments that may be cancelled.
+		/// Place a '?' in the command text for each of the arguments and then executes that command.
+		/// It returns each row of the result using the specified mapping. This function is
+		/// only used by libraries in order to query the database via introspection. It is
+		/// normally not used.
+		/// </summary>
+		/// <param name="map">
+		/// A <see cref="TableMapping"/> to use to convert the resulting rows
+		/// into objects.
+		/// </param>
+		/// <param name="query">
+		/// The fully escaped SQL.
+		/// </param>
+		/// <param name="cancellationToken">
+		/// A cancellation token that may be used to cancel the query.
+		/// <para/>
+		/// When <see cref="CancellationToken.IsCancellationRequested"/> is true, causes a <see cref="OperationCanceledException"/> to be thrown.
+		/// </param>
+		/// <param name="args">
+		/// Arguments to substitute for the occurences of '?' in the query.
+		/// </param>
+		/// <returns>
+		/// An enumerable with one result for each row returned by the query.
+		/// The enumerator (retrieved by calling GetEnumerator() on the result of this method)
+		/// will call sqlite3_step on each call to MoveNext, so the database
+		/// connection must remain open for the lifetime of the enumerator.
+		/// </returns>
+		public IEnumerable<object> DeferredQueryWithCancellation (TableMapping map, string query, CancellationToken cancellationToken, params object[] args)
+		{
+			var cmd = CreateCommand (query, args);
+			return cmd.ExecuteDeferredQueryWithCancellation<object> (map, cancellationToken);
 		}
 
 		/// <summary>
@@ -2970,14 +3115,29 @@ namespace SQLite
 			return ExecuteDeferredQuery<T> (_conn.GetMapping (typeof (T)));
 		}
 
+		public IEnumerable<T> ExecuteDeferredQueryWithCancellation<T> (CancellationToken cancellationToken)
+		{
+			return ExecuteDeferredQueryWithCancellation<T> (_conn.GetMapping (typeof (T)), cancellationToken);
+		}
+
 		public List<T> ExecuteQuery<T> ()
 		{
 			return ExecuteDeferredQuery<T> (_conn.GetMapping (typeof (T))).ToList ();
 		}
 
+		public List<T> ExecuteQueryWithCancellation<T> (CancellationToken cancellationToken)
+		{
+			return ExecuteDeferredQueryWithCancellation<T> (_conn.GetMapping (typeof (T)), cancellationToken).ToList ();
+		}
+
 		public List<T> ExecuteQuery<T> (TableMapping map)
 		{
 			return ExecuteDeferredQuery<T> (map).ToList ();
+		}
+
+		public List<T> ExecuteQueryWithCancellation<T> (TableMapping map, CancellationToken cancellationToken)
+		{
+			return ExecuteDeferredQueryWithCancellation<T> (map, cancellationToken).ToList ();
 		}
 
 		/// <summary>
@@ -2996,6 +3156,11 @@ namespace SQLite
 		}
 
 		public IEnumerable<T> ExecuteDeferredQuery<T> (TableMapping map)
+		{
+			return ExecuteDeferredQueryWithCancellation<T> (map, CancellationToken.None);
+		}
+
+		public IEnumerable<T> ExecuteDeferredQueryWithCancellation<T> (TableMapping map, CancellationToken cancellationToken)
 		{
 			if (_conn.Trace) {
 				_conn.Tracer?.Invoke ("Executing Query: " + this);
@@ -3032,6 +3197,7 @@ namespace SQLite
 				}
 
 				while (SQLite3.Step (stmt) == SQLite3.Result.Row) {
+					cancellationToken.ThrowIfCancellationRequested ();
 					var obj = Activator.CreateInstance (map.MappedType);
 					for (int i = 0; i < cols.Length; i++) {
 						if (cols[i] == null)
@@ -3089,6 +3255,11 @@ namespace SQLite
 
 		public IEnumerable<T> ExecuteQueryScalars<T> ()
 		{
+			return ExecuteQueryScalarsWithCancellation<T> (CancellationToken.None);
+		}
+
+		public IEnumerable<T> ExecuteQueryScalarsWithCancellation<T> (CancellationToken cancellationToken)
+		{
 			if (_conn.Trace) {
 				_conn.Tracer?.Invoke ("Executing Query: " + this);
 			}
@@ -3098,6 +3269,7 @@ namespace SQLite
 					throw new InvalidOperationException ("QueryScalars should return at least one column");
 				}
 				while (SQLite3.Step (stmt) == SQLite3.Result.Row) {
+					cancellationToken.ThrowIfCancellationRequested ();
 					var colType = SQLite3.ColumnType (stmt, 0);
 					var val = ReadCol (stmt, 0, colType, typeof (T));
 					if (val == null) {

--- a/src/SQLiteAsync.cs
+++ b/src/SQLiteAsync.cs
@@ -1084,6 +1084,32 @@ namespace SQLite
 		}
 
 		/// <summary>
+		/// Creates a SQLiteCommand given the command text (SQL) with arguments that may be cancelled.
+		/// Place a '?' in the command text for each of the arguments and then executes that command.
+		/// It returns each row of the result using the mapping automatically generated for
+		/// the given type.
+		/// </summary>
+		/// <param name="query">
+		/// The fully escaped SQL.
+		/// </param>
+		/// <param name="cancellationToken">
+		/// A cancellation token that may be used to cancel the query.
+		/// <para/>
+		/// When <see cref="CancellationToken.IsCancellationRequested"/> is true, causes a <see cref="OperationCanceledException"/> to be thrown.
+		/// </param>
+		/// <param name="args">
+		/// Arguments to substitute for the occurences of '?' in the query.
+		/// </param>
+		/// <returns>
+		/// A list with one result for each row returned by the query.
+		/// </returns>
+		public Task<List<T>> QueryWithCancellationAsync<T> (string query, CancellationToken cancellationToken, params object[] args)
+			where T : new()
+		{
+			return ReadAsync (conn => conn.QueryWithCancellation<T> (query, cancellationToken, args));
+		}
+
+		/// <summary>
 		/// Creates a SQLiteCommand given the command text (SQL) with arguments. Place a '?'
 		/// in the command text for each of the arguments and then executes that command.
 		/// It returns the first column of each row of the result.
@@ -1100,6 +1126,30 @@ namespace SQLite
 		public Task<List<T>> QueryScalarsAsync<T> (string query, params object[] args)
 		{
 			return ReadAsync (conn => conn.QueryScalars<T> (query, args));
+		}
+
+		/// <summary>
+		/// Creates a SQLiteCommand given the command text (SQL) with arguments that may be cancelled.
+		/// Place a '?' in the command text for each of the arguments and then executes that command.
+		/// It returns the first column of each row of the result.
+		/// </summary>
+		/// <param name="query">
+		/// The fully escaped SQL.
+		/// </param>
+		/// <param name="cancellationToken">
+		/// A cancellation token that may be used to cancel the query.
+		/// <para/>
+		/// When <see cref="CancellationToken.IsCancellationRequested"/> is true, causes a <see cref="OperationCanceledException"/> to be thrown.
+		/// </param>
+		/// <param name="args">
+		/// Arguments to substitute for the occurences of '?' in the query.
+		/// </param>
+		/// <returns>
+		/// A list with one result for the first column of each row returned by the query.
+		/// </returns>
+		public Task<List<T>> QueryScalarsWithCancellationAsync<T> (string query, CancellationToken cancellationToken, params object[] args)
+		{
+			return ReadAsync (conn => conn.QueryScalarsWithCancellation<T> (query, cancellationToken, args));
 		}
 
 		/// <summary>
@@ -1128,6 +1178,36 @@ namespace SQLite
 		}
 
 		/// <summary>
+		/// Creates a SQLiteCommand given the command text (SQL) with arguments that may be cancelled.
+		/// Place a '?' in the command text for each of the arguments and then executes that command.
+		/// It returns each row of the result using the specified mapping. This function is
+		/// only used by libraries in order to query the database via introspection. It is
+		/// normally not used.
+		/// </summary>
+		/// <param name="map">
+		/// A <see cref="TableMapping"/> to use to convert the resulting rows
+		/// into objects.
+		/// </param>
+		/// <param name="cancellationToken">
+		/// A cancellation token that may be used to cancel the query.
+		/// <para/>
+		/// When <see cref="CancellationToken.IsCancellationRequested"/> is true, causes a <see cref="OperationCanceledException"/> to be thrown.
+		/// </param>
+		/// <param name="query">
+		/// The fully escaped SQL.
+		/// </param>
+		/// <param name="args">
+		/// Arguments to substitute for the occurences of '?' in the query.
+		/// </param>
+		/// <returns>
+		/// An enumerable with one result for each row returned by the query.
+		/// </returns>
+		public Task<List<object>> QueryWithCancellationAsync (TableMapping map, string query, CancellationToken cancellationToken, params object[] args)
+		{
+			return ReadAsync (conn => conn.QueryWithCancellation (map, query, cancellationToken, args));
+		}
+
+		/// <summary>
 		/// Creates a SQLiteCommand given the command text (SQL) with arguments. Place a '?'
 		/// in the command text for each of the arguments and then executes that command.
 		/// It returns each row of the result using the mapping automatically generated for
@@ -1148,6 +1228,34 @@ namespace SQLite
 			where T : new()
 		{
 			return ReadAsync (conn => (IEnumerable<T>)conn.DeferredQuery<T> (query, args).ToList ());
+		}
+
+		/// <summary>
+		/// Creates a SQLiteCommand given the command text (SQL) with arguments that may be cancelled.
+		/// Place a '?' in the command text for each of the arguments and then executes that command.
+		/// It returns each row of the result using the mapping automatically generated for
+		/// the given type.
+		/// </summary>
+		/// <param name="query">
+		/// The fully escaped SQL.
+		/// </param>
+		/// <param name="cancellationToken">
+		/// A cancellation token that may be used to cancel the query.
+		/// <para/>
+		/// When <see cref="CancellationToken.IsCancellationRequested"/> is true, causes a <see cref="OperationCanceledException"/> to be thrown.
+		/// </param>
+		/// <param name="args">
+		/// Arguments to substitute for the occurences of '?' in the query.
+		/// </param>
+		/// <returns>
+		/// An enumerable with one result for each row returned by the query.
+		/// The enumerator will call sqlite3_step on each call to MoveNext, so the database
+		/// connection must remain open for the lifetime of the enumerator.
+		/// </returns>
+		public Task<IEnumerable<T>> DeferredQueryWithCancellationAsync<T> (string query, CancellationToken cancellationToken, params object[] args)
+			where T : new()
+		{
+			return ReadAsync (conn => (IEnumerable<T>)conn.DeferredQueryWithCancellation<T> (query, cancellationToken, args).ToList ());
 		}
 
 		/// <summary>
@@ -1175,6 +1283,38 @@ namespace SQLite
 		public Task<IEnumerable<object>> DeferredQueryAsync (TableMapping map, string query, params object[] args)
 		{
 			return ReadAsync (conn => (IEnumerable<object>)conn.DeferredQuery (map, query, args).ToList ());
+		}
+
+		/// <summary>
+		/// Creates a SQLiteCommand given the command text (SQL) with arguments that may be cancelled.
+		/// Place a '?' in the command text for each of the arguments and then executes that command.
+		/// It returns each row of the result using the specified mapping. This function is
+		/// only used by libraries in order to query the database via introspection. It is
+		/// normally not used.
+		/// </summary>
+		/// <param name="map">
+		/// A <see cref="TableMapping"/> to use to convert the resulting rows
+		/// into objects.
+		/// </param>
+		/// <param name="cancellationToken">
+		/// A cancellation token that may be used to cancel the query.
+		/// <para/>
+		/// When <see cref="CancellationToken.IsCancellationRequested"/> is true, causes a <see cref="OperationCanceledException"/> to be thrown.
+		/// </param>
+		/// <param name="query">
+		/// The fully escaped SQL.
+		/// </param>
+		/// <param name="args">
+		/// Arguments to substitute for the occurences of '?' in the query.
+		/// </param>
+		/// <returns>
+		/// An enumerable with one result for each row returned by the query.
+		/// The enumerator will call sqlite3_step on each call to MoveNext, so the database
+		/// connection must remain open for the lifetime of the enumerator.
+		/// </returns>
+		public Task<IEnumerable<object>> DeferredQueryWithCancellationAsync (TableMapping map, string query, CancellationToken cancellationToken, params object[] args)
+		{
+			return ReadAsync (conn => (IEnumerable<object>)conn.DeferredQueryWithCancellation (map, query, cancellationToken, args).ToList ());
 		}
 	}
 

--- a/tests/SQLite.Tests/DbCommandTest.cs
+++ b/tests/SQLite.Tests/DbCommandTest.cs
@@ -3,6 +3,7 @@ using System.Text;
 using SQLite;
 using System.Threading.Tasks;
 using System.IO;
+using System.Threading;
 
 #if NETFX_CORE
 using Microsoft.VisualStudio.TestPlatform.UnitTestFramework;

--- a/tests/SQLite.Tests/QueryCancellationTests.cs
+++ b/tests/SQLite.Tests/QueryCancellationTests.cs
@@ -1,0 +1,67 @@
+﻿using System.Linq;
+using System.Text;
+using SQLite;
+using System.Threading.Tasks;
+using System.IO;
+using System.Threading;
+using System;
+
+#if NETFX_CORE
+using Microsoft.VisualStudio.TestPlatform.UnitTestFramework;
+using SetUp = Microsoft.VisualStudio.TestPlatform.UnitTestFramework.TestInitializeAttribute;
+using TestFixture = Microsoft.VisualStudio.TestPlatform.UnitTestFramework.TestClassAttribute;
+using Test = Microsoft.VisualStudio.TestPlatform.UnitTestFramework.TestMethodAttribute;
+#else
+using NUnit.Framework;
+#endif
+
+namespace SQLite.Tests
+{
+	[TestFixture]
+	public class QueryCancellationTests
+	{
+		private readonly SQLiteConnection _db = new SQLiteConnection (Path.GetTempFileName (), true);
+		private readonly (int Value, double Walue)[] _records = new[]
+		{
+			(42, 0.5),
+		};
+
+		public QueryCancellationTests ()
+		{
+			_db.Execute ("create table G(Value integer not null, Walue real not null)");
+
+			for (int i = 0; i < _records.Length; i++) {
+				_db.Execute ("insert into G(Value, Walue) values (?, ?)",
+					_records[i].Value, _records[i].Walue);
+			}
+		}
+
+		class GenericObject
+		{
+			public int Value { get; set; }
+			public double Walue { get; set; }
+		}
+
+		[Test]
+		public void CanCancelScalarQuery ()
+		{
+			var cancellationSource = new CancellationTokenSource ();
+			cancellationSource.Cancel ();
+
+			Assert.Throws<OperationCanceledException> (() => {
+				var r = _db.QueryScalarsWithCancellation<int> ("select Value from G", cancellationSource.Token);
+			});
+		}
+
+		[Test]
+		public void CanCancelQuery ()
+		{
+			var cancellationSource = new CancellationTokenSource ();
+			cancellationSource.Cancel ();
+
+			Assert.Throws<OperationCanceledException> (() => {
+				var r = _db.QueryScalarsWithCancellation<GenericObject> ("select * from G", cancellationSource.Token);
+			});
+		}
+	}
+}


### PR DESCRIPTION
@praeclarum I've opened this as a draft to start discussions about this feature. I'm unable to fully document this right now as I'm about to start my work day but will aim on expanding the description/use case of this PR later today.

* TODO @matthewrdev: Explain new APIs. New methods `WithCancellation` to preserve all existing API compatibility.
* TODO @matthewrdev: Document intended use cases (EG: Debounced searching for queries that may return large data sets).

## Points For Discussion

* Do the new QueryWithCancellation methods make sense and fit into sqlite-net's API design?
* Which other API methods may need cancellation support added?
* Are there any foreseen performance implications to the new query implementations? IE: Using `token.ThrowIfCancellationRequested` every SQLite3 Step.
