### PR TITLE
Add support for ulong

### DIFF
--- a/src/SQLite.cs
+++ b/src/SQLite.cs
@@ -3319,6 +3319,9 @@ namespace SQLite
 				else if (clrType == typeof (Int64)) {
 					return SQLite3.ColumnInt64 (stmt, index);
 				}
+				else if (clrType == typeof (UInt64)) {
+					return (ulong)SQLite3.ColumnInt64 (stmt, index);
+				}
 				else if (clrType == typeof (UInt32)) {
 					return (uint)SQLite3.ColumnInt64 (stmt, index);
 				}

--- a/src/SQLite.cs
+++ b/src/SQLite.cs
@@ -2786,7 +2786,7 @@ namespace SQLite
 		public static string SqlType (TableMapping.Column p, bool storeDateTimeAsTicks, bool storeTimeSpanAsTicks)
 		{
 			var clrType = p.ColumnType;
-			if (clrType == typeof (Boolean) || clrType == typeof (Byte) || clrType == typeof (UInt16) || clrType == typeof (SByte) || clrType == typeof (Int16) || clrType == typeof (Int32) || clrType == typeof (UInt32) || clrType == typeof (Int64) || clrType == typeof (UInt64) {
+			if (clrType == typeof (Boolean) || clrType == typeof (Byte) || clrType == typeof (UInt16) || clrType == typeof (SByte) || clrType == typeof (Int16) || clrType == typeof (Int32) || clrType == typeof (UInt32) || clrType == typeof (Int64) || clrType == typeof (UInt64)) {
 				return "integer";
 			}
 			else if (clrType == typeof (Single) || clrType == typeof (Double) || clrType == typeof (Decimal)) {

--- a/src/SQLite.cs
+++ b/src/SQLite.cs
@@ -2786,7 +2786,7 @@ namespace SQLite
 		public static string SqlType (TableMapping.Column p, bool storeDateTimeAsTicks, bool storeTimeSpanAsTicks)
 		{
 			var clrType = p.ColumnType;
-			if (clrType == typeof (Boolean) || clrType == typeof (Byte) || clrType == typeof (UInt16) || clrType == typeof (SByte) || clrType == typeof (Int16) || clrType == typeof (Int32) || clrType == typeof (UInt32) || clrType == typeof (Int64)) {
+			if (clrType == typeof (Boolean) || clrType == typeof (Byte) || clrType == typeof (UInt16) || clrType == typeof (SByte) || clrType == typeof (Int16) || clrType == typeof (Int32) || clrType == typeof (UInt32) || clrType == typeof (Int64) || clrType == typeof (UInt64) {
 				return "integer";
 			}
 			else if (clrType == typeof (Single) || clrType == typeof (Double) || clrType == typeof (Decimal)) {
@@ -3185,7 +3185,7 @@ namespace SQLite
 				else if (value is Boolean) {
 					SQLite3.BindInt (stmt, index, (bool)value ? 1 : 0);
 				}
-				else if (value is UInt32 || value is Int64) {
+				else if (value is UInt32 || value is Int64 || value is UInt64) {
 					SQLite3.BindInt64 (stmt, index, Convert.ToInt64 (value));
 				}
 				else if (value is Single || value is Double || value is Decimal) {
@@ -3464,6 +3464,12 @@ namespace SQLite
 			else if (clrType == typeof (Int64)) {
 				fastSetter = CreateNullableTypedSetterDelegate<T, Int64> (column, (stmt, index) => {
 					return SQLite3.ColumnInt64 (stmt, index);
+				});
+			}
+			else if (clrType == typeof(UInt64))
+			{
+				fastSetter = CreateNullableTypedSetterDelegate<T, UInt64>(column, (stmt, index) => {
+					return (ulong)SQLite3.ColumnInt64(stmt, index);
 				});
 			}
 			else if (clrType == typeof (UInt32)) {


### PR DESCRIPTION
I know that SQLite3 does not support [unsigned 64-bit integers for columns](https://www.sqlite.org/c3ref/column_blob.html)

but seeing the way `byte` / `sbyte` are supported in this library, I think other integral types should be supported as well.

Resolves #998 