### PR TITLE
Support source code integration of sqlite3 for Unity IL2CPP

### DIFF
--- a/src/SQLite.cs
+++ b/src/SQLite.cs
@@ -3018,7 +3018,7 @@ namespace SQLite
 								BindingFlags.NonPublic | BindingFlags.Static).MakeGenericMethod (map.MappedType);
 					}
 
-					for (int i = 0; i < cols.Length; i++) {						
+					for (int i = 0; i < cols.Length; i++) {
 						var name = SQLite3.ColumnName16 (stmt, i);
 						cols[i] = map.FindColumn (name);
 						if (cols[i] != null)
@@ -4442,7 +4442,11 @@ namespace SQLite
 			Serialized = 3
 		}
 
+#if ENABLE_IL2CPP
+		const string LibraryPath = "__Internal";
+#else
 		const string LibraryPath = "sqlite3";
+#endif
 
 #if !USE_CSHARP_SQLITE && !USE_WP8_NATIVE_SQLITE && !USE_SQLITEPCL_RAW
 		[DllImport(LibraryPath, EntryPoint = "sqlite3_threadsafe", CallingConvention=CallingConvention.Cdecl)]
@@ -4478,8 +4482,10 @@ namespace SQLite
 		[DllImport(LibraryPath, EntryPoint = "sqlite3_config", CallingConvention=CallingConvention.Cdecl)]
 		public static extern Result Config (ConfigOption option);
 
+#if NETFX_CORE
 		[DllImport(LibraryPath, EntryPoint = "sqlite3_win32_set_directory", CallingConvention=CallingConvention.Cdecl, CharSet=CharSet.Unicode)]
 		public static extern int SetDirectory (uint directoryType, string directoryPath);
+#endif
 
 		[DllImport(LibraryPath, EntryPoint = "sqlite3_busy_timeout", CallingConvention=CallingConvention.Cdecl)]
 		public static extern Result BusyTimeout (IntPtr db, int milliseconds);


### PR DESCRIPTION
This PR adds some preprocessor directives that enables integrating `sqlite-net` and and `sqlite3` by source in Unity for IL2CPP-enabled build targets. 

Because Unity supports compiling C/C++ sources for IL2CPP builds, importing both amalgamated `SQLite.cs` and `sqlite3.c` source files allows all IL2CPP build targets (iOS, Android, Windows, etc) to share the same version of SQLite statically linked with translated C# code in the same binary, and have better debugging experience. 