### PR TITLE
ISqliteConnection should be derived from IDisposable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -265,3 +265,6 @@ paket-files/
 # CodeRush
 .cr/
 
+# NCrunch
+*.ncrunchsolution
+*.ncrunchproject

--- a/src/SQLite.cs
+++ b/src/SQLite.cs
@@ -159,7 +159,7 @@ namespace SQLite
 		FullTextSearch4 = 0x200
 	}
 
-	public interface ISQLiteConnection
+	public interface ISQLiteConnection : IDisposable
 	{
 		Sqlite3DatabaseHandle Handle { get; }
 		string DatabasePath { get; }
@@ -215,7 +215,6 @@ namespace SQLite
 		int Delete (object primaryKey, TableMapping map);
 		int DeleteAll<T> ();
 		int DeleteAll (TableMapping map);
-		void Dispose ();
 		int DropTable<T> ();
 		int DropTable (TableMapping map);
 		void EnableLoadExtension (bool enabled);


### PR DESCRIPTION
It's a minor fix, but if ISqliteConnection is not declared as a IDisposable interface, It can't be used with the "using" c# pattern.

I mean, this code, before this modification would not compile:

```csharp
using (ISQLiteConnection conn = MyConnectionFactory.GetConnection())
{
    ..... // use conn
}
```

I also added to .gitignore the project configuration files created by ncrunch (see https://www.ncrunch.net/)