### PR TITLE
Cancelable queries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -265,3 +265,4 @@ paket-files/
 # CodeRush
 .cr/
 
+*.ncrunchsolution

--- a/.gitignore
+++ b/.gitignore
@@ -266,3 +266,4 @@ paket-files/
 .cr/
 
 *.ncrunchsolution
+*.ncrunchproject

--- a/tests/ApiDiff/ApiDiff.csproj
+++ b/tests/ApiDiff/ApiDiff.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -9,7 +9,8 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>ApiDiff</RootNamespace>
     <AssemblyName>ApiDiff</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -45,6 +46,7 @@
     </Compile>
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />

--- a/tests/ApiDiff/app.config
+++ b/tests/ApiDiff/app.config
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/></startup></configuration>

--- a/tests/SQLite.Tests/CancelableTest.cs
+++ b/tests/SQLite.Tests/CancelableTest.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -7,16 +8,31 @@ using NUnit.Framework;
 
 namespace SQLite.Tests
 {
+	// all these test do run some heavy queries in a background task.
+	// these queries would take quite some time if they would be allowed to be run to complation,
+	// but each test, after having launched the query, it stops it by setting the CancellationToken.
 	public class CancelableTest
 	{
-		[Test]
-		public async Task CancelableQueryQueryScalarsTest()
+		public static ISQLiteConnection CreateSqliteInMemoryDb()
 		{
-			using (var conn = new SQLiteConnection (":memory:") as ISQLiteConnection) {
+			//return new SQLiteConnection (":memory:"); this simpler version would make all tests run using the very same memory database, so test would not run in parallel
+			// this more complex way of creating a memory database allows to give a separate name to different memory databases
+			return new SQLiteConnection ($"file:memdb{Guid.NewGuid ().ToString ("N")}?mode=memory&cache=private");
+		}
+
+
+		[Test]
+		public async Task CancelableQueryQueryScalars_Test()
+		{
+			using (var conn = CreateSqliteInMemoryDb()) {
 				var CancTokSource = new CancellationTokenSource ();
 				var tok = CancTokSource.Token;
-				// here I am launching the query in a separate task.
-				// this query is extremely slow: Its execution time is way beyond my patience limit
+				
+				// notice that this query takes ages before returning the first record. 
+				// here I am actually testing that the execution is stopped at the "server side"
+				// by the sqlite3_interrupt api call, since we never enter in the internal
+				// "fetch next row" c# loop
+				
 				var task = Task.Run (() => {
 					var extremelySlowQuery =
 						@"WITH RECURSIVE qry(n) AS (
@@ -31,9 +47,9 @@ namespace SQLite.Tests
 
 				Exception e = null;
 				try {
-					await Task.Delay (1000); // let the query run for a bit
-					CancTokSource.Cancel (); // and then we ask the query to stop (this will make a OperationCanceledException to be raised in the context of the task)
-					await task; // then we wait the task to be completed 
+					await Task.Delay (300); // wait some time to be sure that the query has started
+					CancTokSource.Cancel (); 
+					await task; 
 				}
 				catch (Exception ex) {
 					e = ex;
@@ -43,13 +59,11 @@ namespace SQLite.Tests
 		}
 
 		[Test]
-		public async Task CancelableQueryTest ()
+		public async Task CancelableQuery_Test ()
 		{
-			using (var conn = new SQLiteConnection (":memory:")) {
+			using (var conn = CreateSqliteInMemoryDb()) {
 				var CancTokSource = new CancellationTokenSource ();
 				var tok = CancTokSource.Token;
-				// here I am launching the query in a separate task.
-				// this query is extremely slow: Its execution time is way beyond my patience limit
 				var task = Task.Run (() => {
 					var extremelySlowQuery =
 						@"WITH RECURSIVE qry(n) AS (
@@ -63,9 +77,9 @@ namespace SQLite.Tests
 
 				Exception e = null;
 				try {
-					await Task.Delay (1000); // let the query run for a bit
-					CancTokSource.Cancel (); // and then we ask the query to stop (this will make a OperationCanceledException to be raised in the context of the task)
-					await task; // then we wait the task to be completed 
+					await Task.Delay (1000); 
+					CancTokSource.Cancel (); 
+					await task; 
 				}
 				catch (Exception ex) {
 					e = ex;
@@ -75,6 +89,21 @@ namespace SQLite.Tests
 		}
 
 
+		/// <summary>
+		///  this view will return millions of records, by using a recursive "with"
+		/// </summary>
+		public const string BIGVIEW_DEFCMD=
+			@"create view BIGVIEW as
+						WITH RECURSIVE qry(n)
+						AS (
+							SELECT 1 as n
+							UNION ALL
+							SELECT n + 1 as n FROM qry WHERE n < 100000000
+						)
+						SELECT n as fld1, n as fld2 FROM qry";
+		
+		// this entity maps bigview
+		[Table("BIGVIEW")]
 	    public class MyRecType
 		{
 			public long fld1 { get; set; }
@@ -82,33 +111,36 @@ namespace SQLite.Tests
 		}
 
 		[Test]
-		public async Task CancelableTableTest ()
+		public async Task CancelableTable_Test ()
 		{
-			using (var conn = new SQLiteConnection (":memory:")) {
+			using (var conn = CreateSqliteInMemoryDb()) {
+				// 
+				conn.Execute (BIGVIEW_DEFCMD);
+
 				var CancTokSource = new CancellationTokenSource ();
 				var tok = CancTokSource.Token;
-				// here I am launching the query in a separate task.
-				// this query is extremely slow: Its execution time is way beyond my patience limit
 
-				conn.CreateTable<MyRecType> ();
-
-				for (var i= 0; i< 1000000; i++)
-					conn.Insert (new MyRecType { fld1 = i, fld2 = i });
-
-				var task = Task.Run (() => {
-					var result = conn.Table<MyRecType>().CancelToken (tok).ToList();
-				});
+				var task = Task.Run(() => {
+					// this query would take forever if we couldn't stop it
+					var result = 
+					  conn.Table<MyRecType>()
+					  .Where(x => x.fld1!=x.fld2)
+					  .CancelToken (tok)
+					  .ToList ();
+				}).ConfigureAwait(false);
 
 				Exception e = null;
 				try {
-					await Task.Delay (10); // let the query run for a bit
-					CancTokSource.Cancel (); // and then we ask the query to stop (this will make a OperationCanceledException to be raised in the context of the task)
-					await task; // then we wait the task to be completed 
+					await Task.Delay (10);
+					CancTokSource.Cancel ();
+					await task;
 				}
 				catch (Exception ex) {
 					e = ex;
 				}
+			
 				Assert.That (e, Is.InstanceOf<OperationCanceledException> ());
+
 			}
 		}
 

--- a/tests/SQLite.Tests/CancelableTest.cs
+++ b/tests/SQLite.Tests/CancelableTest.cs
@@ -1,0 +1,116 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using NUnit.Framework;
+
+namespace SQLite.Tests
+{
+	public class CancelableTest
+	{
+		[Test]
+		public async Task CancelableQueryQueryScalarsTest()
+		{
+			using (var conn = new SQLiteConnection (":memory:") as ISQLiteConnection) {
+				var CancTokSource = new CancellationTokenSource ();
+				var tok = CancTokSource.Token;
+				// here I am launching the query in a separate task.
+				// this query is extremely slow: Its execution time is way beyond my patience limit
+				var task = Task.Run (() => {
+					var extremelySlowQuery =
+						@"WITH RECURSIVE qry(n) AS (
+						  SELECT 1
+						  UNION ALL
+						  SELECT n + 1 FROM qry WHERE n < 10000000
+						)
+						SELECT * FROM qry where n = 100000000";
+
+					var result = conn.QueryScalars<long> (tok, extremelySlowQuery);
+				});
+
+				Exception e = null;
+				try {
+					await Task.Delay (1000); // let the query run for a bit
+					CancTokSource.Cancel (); // and then we ask the query to stop (this will make a OperationCanceledException to be raised in the context of the task)
+					await task; // then we wait the task to be completed 
+				}
+				catch (Exception ex) {
+					e = ex;
+				}
+				Assert.That (e, Is.InstanceOf<OperationCanceledException> ());
+			}
+		}
+
+		[Test]
+		public async Task CancelableQueryTest ()
+		{
+			using (var conn = new SQLiteConnection (":memory:")) {
+				var CancTokSource = new CancellationTokenSource ();
+				var tok = CancTokSource.Token;
+				// here I am launching the query in a separate task.
+				// this query is extremely slow: Its execution time is way beyond my patience limit
+				var task = Task.Run (() => {
+					var extremelySlowQuery =
+						@"WITH RECURSIVE qry(n) AS (
+						  SELECT 1 as n
+						  UNION ALL
+						  SELECT n + 1 as n FROM qry WHERE n < 100000000
+						)
+						SELECT n as fld1, n as fld2 FROM qry where n = 100000";
+					var result = conn.Query<(long fld1,long fld2)>(tok, extremelySlowQuery);
+				});
+
+				Exception e = null;
+				try {
+					await Task.Delay (1000); // let the query run for a bit
+					CancTokSource.Cancel (); // and then we ask the query to stop (this will make a OperationCanceledException to be raised in the context of the task)
+					await task; // then we wait the task to be completed 
+				}
+				catch (Exception ex) {
+					e = ex;
+				}
+				Assert.That (e, Is.InstanceOf<OperationCanceledException> ());
+			}
+		}
+
+
+	    public class MyRecType
+		{
+			public long fld1 { get; set; }
+			public long fld2 { get; set; }
+		}
+
+		[Test]
+		public async Task CancelableTableTest ()
+		{
+			using (var conn = new SQLiteConnection (":memory:")) {
+				var CancTokSource = new CancellationTokenSource ();
+				var tok = CancTokSource.Token;
+				// here I am launching the query in a separate task.
+				// this query is extremely slow: Its execution time is way beyond my patience limit
+
+				conn.CreateTable<MyRecType> ();
+
+				for (var i= 0; i< 1000000; i++)
+					conn.Insert (new MyRecType { fld1 = i, fld2 = i });
+
+				var task = Task.Run (() => {
+					var result = conn.Table<MyRecType>().CancelToken (tok).ToList();
+				});
+
+				Exception e = null;
+				try {
+					await Task.Delay (10); // let the query run for a bit
+					CancTokSource.Cancel (); // and then we ask the query to stop (this will make a OperationCanceledException to be raised in the context of the task)
+					await task; // then we wait the task to be completed 
+				}
+				catch (Exception ex) {
+					e = ex;
+				}
+				Assert.That (e, Is.InstanceOf<OperationCanceledException> ());
+			}
+		}
+
+	}
+}


### PR DESCRIPTION
Hi, I anticipated I was implementing this in Issue #1174 (this code contains also the small fix I proposed in pull request #1175 )

This modification extends SQLiteConnection and SQLiteAsyncConnection with a mechanism that allows to terminate long running queries by the means of setting a cancellation token.
to interrupt "sqlite server side" processing it makes use of the sqlite3_interrupt() api, that I had to map myself, since it wasn't already imported in the source code. to interrupt record fetch loops it checks the cancellation token status for each record fetched.
When an operation is aborted by the cancellation token you always get a OperationCanceledException.

 I added also some tests of this feature.

for connection.Table() access methods I added a specific CancelToken(cancTok) call to be added in the "builder pattern" chain, so a cancellable query would look like this:
```csharp
CancellationTokenSource tokSource= new ();

try
{
    var recs = conn.Table<MyRecType>()
        .Where(x=>....)
        .CancelToken(tokSource.Token) // <<<
        .ToList();
}
catch (OperationCanceledException)
{
   Writelog('execution has been aborted!');
}

```
of course tokSource.Cancel() must be executed by some other task while the query is still executing.

Whenever possible, I added an optional CancellationToken? cancTok=null parameter to existing apis, but for Apis that were expecting a params args[] for the last parameter, this wasn't possible. in such cases I defined an overloaded version that accepts the cancellation token as first parameter.

For example I had to  define a sqliteConnection.Query<T>(CancellationToken tok, string sql, params args[]) overload.

----
background : why I need this?
I have an android application where the end user can type a search criteria and see the results of that search criteria being found immediately every time he changes the search text, even while he is typing (actually the query is re-executed whenever the user stops typing for at least 300 ms). the problem is that, if the table contains a lot of data I really need to be able to cancel the execution of the current query (if it has not finished yet) as soon the user starts typing again.
 it might be useful also in other scenarios, but in the one I need it it would really make the application much more responsive.