### PR TITLE
Implemented Fluent Api based on @RoyGoode's code

### DIFF
--- a/src/SQLiteAsync.cs
+++ b/src/SQLiteAsync.cs
@@ -383,6 +383,20 @@ namespace SQLite
 		}
 
 		/// <summary>
+		/// Executes a "create table if not exists" on the database. It also
+		/// creates any specified indexes on the columns of the table. 
+		/// </summary>
+		/// <param name="map">The table mapping to create the table from.</param>
+		/// <param name="createFlags">Optional flags allowing implicit PK and indexes based on naming conventions.</param>  
+		/// <returns>
+		/// Whether the table was created or migrated.
+		/// </returns>
+		public Task<CreateTableResult> CreateTableAsync (TableMapping map, CreateFlags createFlags = CreateFlags.None)
+		{
+			return WriteAsync (conn => conn.CreateTable (map, createFlags));
+		}
+
+		/// <summary>
 		/// Executes a "create table if not exists" on the database for each type. It also
 		/// creates any specified indexes on the columns of the table. It uses
 		/// a schema automatically generated from the specified type. You can
@@ -464,6 +478,18 @@ namespace SQLite
 		public Task<CreateTablesResult> CreateTablesAsync (CreateFlags createFlags = CreateFlags.None, params Type[] types)
 		{
 			return WriteAsync (conn => conn.CreateTables (createFlags, types));
+		}
+
+		/// <summary>
+		/// Executes a "create table if not exists" on the database for each type. It also
+		/// creates any specified indexes on the columns of the table.
+		/// </summary>
+		/// <returns>
+		/// Whether the table was created or migrated for each type.
+		/// </returns>
+		public Task<CreateTablesResult> CreateTablesAsync (CreateFlags createFlags = CreateFlags.None, params TableMapping[] mappings)
+		{
+			return WriteAsync (conn => conn.CreateTables (createFlags, mappings));
 		}
 
 		/// <summary>


### PR DESCRIPTION
I have noticed that there's been a few attempt to implement fluent api for sqlite-net in the past. The prominent one being from @RoyGoode. 

This is my attempt to implement fluent API that is based on @RoyGoode's [code](https://github.com/RoyGoode/sqlite-net/tree/FluentAPI2). I also took to consideration the author's (@praeclarum) comment in #533. This should get rid of the requirement to use the attribute for table and columns. 

**Usage** 
```
    var mapping = TableMapping.Builder<SomeTable>()
        .TableName("some_table")
        .ColumnName(s => s.Name, "some_name")
        .AutoIncrement(s => s.MyId)
        .PrimaryKey(s => s.MyId)
        .Unique(s => s.MyId)
	.Build();
    								
    connection.UseMapping(mapping);
    connection.CreateTable<SomeTable>();

    // or 

   connection.CreateTable<SomeTable>(mapping); 

   // this also supports CreateTables(map1, map2, map3, ... ); 
```

I'm open to any comments and suggestions. 