### PR TITLE
Add trim/AOT annotations to make code trim/AOT-safe

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.100",
+    "version": "9.0.100",
     "rollForward": "latestFeature"
   }
 }

--- a/global.json
+++ b/global.json
@@ -1,5 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.100"
+    "version": "8.0.100",
+    "rollForward": "latestFeature"
   }
 }

--- a/nuget/SQLite-net-base/SQLite-net-base.csproj
+++ b/nuget/SQLite-net-base/SQLite-net-base.csproj
@@ -15,11 +15,11 @@
 
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DefineConstants>USE_SQLITEPCL_RAW;NO_SQLITEPCL_RAW_BATTERIES;RELEASE</DefineConstants>
-    <DocumentationFile>bin\Release\netstandard2.0\SQLite-net.xml</DocumentationFile>
+    <DocumentationFile>bin\Release\$(TargetFramework)\SQLite-net.xml</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DefineConstants>USE_SQLITEPCL_RAW;NO_SQLITEPCL_RAW_BATTERIES;DEBUG</DefineConstants>
-    <DocumentationFile>bin\Debug\netstandard2.0\SQLite-net.xml</DocumentationFile>
+    <DocumentationFile>bin\Debug\$(TargetFramework)\SQLite-net.xml</DocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/nuget/SQLite-net-base/SQLite-net-base.csproj
+++ b/nuget/SQLite-net-base/SQLite-net-base.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net8.0;net9.0</TargetFrameworks>
     <AssemblyName>SQLite-net</AssemblyName>
     <PackageId>sqlite-net-base</PackageId>
     <AssemblyTitle>SQLite-net .NET Standard Base Library</AssemblyTitle>

--- a/nuget/SQLite-net-base/SQLite-net-base.csproj
+++ b/nuget/SQLite-net-base/SQLite-net-base.csproj
@@ -10,6 +10,7 @@
       It is meant to give you all the power of SQLite-net but with the freedom to choose your own provider.
       Please use the package sqlite-net-pcl if you have no idea what any of this means.
     </Description>
+    <IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">true</IsAotCompatible>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">

--- a/nuget/SQLite-net-base/SQLite-net-base.csproj
+++ b/nuget/SQLite-net-base/SQLite-net-base.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
     <AssemblyName>SQLite-net</AssemblyName>
     <PackageId>sqlite-net-base</PackageId>
     <AssemblyTitle>SQLite-net .NET Standard Base Library</AssemblyTitle>

--- a/nuget/SQLite-net-sqlcipher/SQLite-net-sqlcipher.csproj
+++ b/nuget/SQLite-net-sqlcipher/SQLite-net-sqlcipher.csproj
@@ -16,11 +16,11 @@
 
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DefineConstants>USE_SQLITEPCL_RAW;RELEASE</DefineConstants>
-    <DocumentationFile>bin\Release\netstandard2.0\SQLite-net.xml</DocumentationFile>
+    <DocumentationFile>bin\Release\$(TargetFramework)\SQLite-net.xml</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DefineConstants>USE_SQLITEPCL_RAW;DEBUG</DefineConstants>
-    <DocumentationFile>bin\Debug\netstandard2.0\SQLite-net.xml</DocumentationFile>
+    <DocumentationFile>bin\Debug\$(TargetFramework)\SQLite-net.xml</DocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/nuget/SQLite-net-sqlcipher/SQLite-net-sqlcipher.csproj
+++ b/nuget/SQLite-net-sqlcipher/SQLite-net-sqlcipher.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net8.0;net9.0</TargetFrameworks>
     <AssemblyName>SQLite-net</AssemblyName>
     <PackageId>sqlite-net-sqlcipher</PackageId>
     <AssemblyTitle>SQLite-net SQLCipher .NET Standard Library</AssemblyTitle>

--- a/nuget/SQLite-net-sqlcipher/SQLite-net-sqlcipher.csproj
+++ b/nuget/SQLite-net-sqlcipher/SQLite-net-sqlcipher.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
     <AssemblyName>SQLite-net</AssemblyName>
     <PackageId>sqlite-net-sqlcipher</PackageId>
     <AssemblyTitle>SQLite-net SQLCipher .NET Standard Library</AssemblyTitle>
@@ -11,6 +11,7 @@
       This enables secure access to the database with password (key) access.
     </Description>
     <PackageTags>sqlite-net;sqlite;database;orm;encryption;sqlcipher</PackageTags>
+    <IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">true</IsAotCompatible>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">

--- a/nuget/SQLite-net-static/SQLite-net-static.csproj
+++ b/nuget/SQLite-net-static/SQLite-net-static.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net8.0;net9.0</TargetFrameworks>
     <AssemblyName>SQLite-net</AssemblyName>
     <PackageId>sqlite-net-static</PackageId>
     <AssemblyTitle>SQLite-net .NET Standard P/Invoke Library</AssemblyTitle>

--- a/nuget/SQLite-net-static/SQLite-net-static.csproj
+++ b/nuget/SQLite-net-static/SQLite-net-static.csproj
@@ -15,11 +15,11 @@
 
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DefineConstants>RELEASE</DefineConstants>
-    <DocumentationFile>bin\Release\netstandard2.0\SQLite-net.xml</DocumentationFile>
+    <DocumentationFile>bin\Release\$(TargetFramework)\SQLite-net.xml</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DefineConstants>DEBUG</DefineConstants>
-    <DocumentationFile>bin\Debug\netstandard2.0\SQLite-net.xml</DocumentationFile>
+    <DocumentationFile>bin\Debug\$(TargetFramework)\SQLite-net.xml</DocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/nuget/SQLite-net-static/SQLite-net-static.csproj
+++ b/nuget/SQLite-net-static/SQLite-net-static.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
     <AssemblyName>SQLite-net</AssemblyName>
     <PackageId>sqlite-net-static</PackageId>
     <AssemblyTitle>SQLite-net .NET Standard P/Invoke Library</AssemblyTitle>
@@ -10,6 +10,7 @@
       This version uses P/Invokes to the "sqlite3" native library provided by the operating system.
       This works on Xamarin.iOS, Xamarin.Mac, Wilderness Labs' Meadow, and any other platform that has a "sqlite3" library in the path.
     </Description>
+    <IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">true</IsAotCompatible>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">

--- a/nuget/SQLite-net-std/SQLite-net-std.csproj
+++ b/nuget/SQLite-net-std/SQLite-net-std.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net8.0;net9.0</TargetFrameworks>
     <AssemblyName>SQLite-net</AssemblyName>
     <PackageId>sqlite-net-pcl</PackageId>
     <AssemblyTitle>SQLite-net Official .NET Standard Library</AssemblyTitle>

--- a/nuget/SQLite-net-std/SQLite-net-std.csproj
+++ b/nuget/SQLite-net-std/SQLite-net-std.csproj
@@ -14,11 +14,11 @@
 
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DefineConstants>USE_SQLITEPCL_RAW;RELEASE</DefineConstants>
-    <DocumentationFile>bin\Release\netstandard2.0\SQLite-net.xml</DocumentationFile>
+    <DocumentationFile>bin\Release\$(TargetFramework)\SQLite-net.xml</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DefineConstants>USE_SQLITEPCL_RAW;DEBUG</DefineConstants>
-    <DocumentationFile>bin\Debug\netstandard2.0\SQLite-net.xml</DocumentationFile>
+    <DocumentationFile>bin\Debug\$(TargetFramework)\SQLite-net.xml</DocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/nuget/SQLite-net-std/SQLite-net-std.csproj
+++ b/nuget/SQLite-net-std/SQLite-net-std.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
     <AssemblyName>SQLite-net</AssemblyName>
     <PackageId>sqlite-net-pcl</PackageId>
     <AssemblyTitle>SQLite-net Official .NET Standard Library</AssemblyTitle>
@@ -9,6 +9,7 @@
       SQLite-net is an open source and light weight library providing easy SQLite database storage for .NET, Mono, and Xamarin applications.
       This version uses SQLitePCLRaw to provide platform independent versions of SQLite.
     </Description>
+    <IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">true</IsAotCompatible>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">

--- a/src/SQLite.cs
+++ b/src/SQLite.cs
@@ -65,150 +65,150 @@ using Sqlite3Statement = System.IntPtr;
 
 namespace SQLite
 {
-    public class SQLiteException : Exception
-    {
-        public SQLite3.Result Result { get; private set; }
+	public class SQLiteException : Exception
+	{
+		public SQLite3.Result Result { get; private set; }
 
-        protected SQLiteException (SQLite3.Result r, string message) : base (message)
-        {
-            Result = r;
-        }
+		protected SQLiteException (SQLite3.Result r, string message) : base (message)
+		{
+			Result = r;
+		}
 
-        public static SQLiteException New (SQLite3.Result r, string message)
-        {
-            return new SQLiteException (r, message);
-        }
-    }
+		public static SQLiteException New (SQLite3.Result r, string message)
+		{
+			return new SQLiteException (r, message);
+		}
+	}
 
-    public class NotNullConstraintViolationException : SQLiteException
-    {
-        public IEnumerable<TableMapping.Column> Columns { get; protected set; }
+	public class NotNullConstraintViolationException : SQLiteException
+	{
+		public IEnumerable<TableMapping.Column> Columns { get; protected set; }
 
-        protected NotNullConstraintViolationException (SQLite3.Result r, string message)
-            : this (r, message, null, null)
-        {
+		protected NotNullConstraintViolationException (SQLite3.Result r, string message)
+			: this (r, message, null, null)
+		{
 
-        }
+		}
 
-        protected NotNullConstraintViolationException (SQLite3.Result r, string message, TableMapping mapping, object obj)
-            : base (r, message)
-        {
-            if (mapping != null && obj != null) {
-                this.Columns = from c in mapping.Columns
-                               where c.IsNullable == false && c.GetValue (obj) == null
-                               select c;
-            }
-        }
+		protected NotNullConstraintViolationException (SQLite3.Result r, string message, TableMapping mapping, object obj)
+			: base (r, message)
+		{
+			if (mapping != null && obj != null) {
+				this.Columns = from c in mapping.Columns
+							   where c.IsNullable == false && c.GetValue (obj) == null
+							   select c;
+			}
+		}
 
-        public static new NotNullConstraintViolationException New (SQLite3.Result r, string message)
-        {
-            return new NotNullConstraintViolationException (r, message);
-        }
+		public static new NotNullConstraintViolationException New (SQLite3.Result r, string message)
+		{
+			return new NotNullConstraintViolationException (r, message);
+		}
 
-        public static NotNullConstraintViolationException New (SQLite3.Result r, string message, TableMapping mapping, object obj)
-        {
-            return new NotNullConstraintViolationException (r, message, mapping, obj);
-        }
+		public static NotNullConstraintViolationException New (SQLite3.Result r, string message, TableMapping mapping, object obj)
+		{
+			return new NotNullConstraintViolationException (r, message, mapping, obj);
+		}
 
-        public static NotNullConstraintViolationException New (SQLiteException exception, TableMapping mapping, object obj)
-        {
-            return new NotNullConstraintViolationException (exception.Result, exception.Message, mapping, obj);
-        }
-    }
+		public static NotNullConstraintViolationException New (SQLiteException exception, TableMapping mapping, object obj)
+		{
+			return new NotNullConstraintViolationException (exception.Result, exception.Message, mapping, obj);
+		}
+	}
 
-    [Flags]
-    public enum SQLiteOpenFlags
-    {
-        ReadOnly = 1, ReadWrite = 2, Create = 4,
-        Uri = 0x40, Memory = 0x80,
-        NoMutex = 0x8000, FullMutex = 0x10000,
-        SharedCache = 0x20000, PrivateCache = 0x40000,
-        ProtectionComplete = 0x00100000,
-        ProtectionCompleteUnlessOpen = 0x00200000,
-        ProtectionCompleteUntilFirstUserAuthentication = 0x00300000,
-        ProtectionNone = 0x00400000
-    }
+	[Flags]
+	public enum SQLiteOpenFlags
+	{
+		ReadOnly = 1, ReadWrite = 2, Create = 4,
+		Uri = 0x40, Memory = 0x80,
+		NoMutex = 0x8000, FullMutex = 0x10000,
+		SharedCache = 0x20000, PrivateCache = 0x40000,
+		ProtectionComplete = 0x00100000,
+		ProtectionCompleteUnlessOpen = 0x00200000,
+		ProtectionCompleteUntilFirstUserAuthentication = 0x00300000,
+		ProtectionNone = 0x00400000
+	}
 
-    [Flags]
-    public enum CreateFlags
-    {
-        /// <summary>
-        /// Use the default creation options
-        /// </summary>
-        None = 0x000,
-        /// <summary>
-        /// Create a primary key index for a property called 'Id' (case-insensitive).
-        /// This avoids the need for the [PrimaryKey] attribute.
-        /// </summary>
-        ImplicitPK = 0x001,
-        /// <summary>
-        /// Create indices for properties ending in 'Id' (case-insensitive).
-        /// </summary>
-        ImplicitIndex = 0x002,
-        /// <summary>
-        /// Create a primary key for a property called 'Id' and
-        /// create an indices for properties ending in 'Id' (case-insensitive).
-        /// </summary>
-        AllImplicit = 0x003,
-        /// <summary>
-        /// Force the primary key property to be auto incrementing.
-        /// This avoids the need for the [AutoIncrement] attribute.
-        /// The primary key property on the class should have type int or long.
-        /// </summary>
-        AutoIncPK = 0x004,
-        /// <summary>
-        /// Create virtual table using FTS3
-        /// </summary>
-        FullTextSearch3 = 0x100,
-        /// <summary>
-        /// Create virtual table using FTS4
-        /// </summary>
-        FullTextSearch4 = 0x200
-    }
+	[Flags]
+	public enum CreateFlags
+	{
+		/// <summary>
+		/// Use the default creation options
+		/// </summary>
+		None = 0x000,
+		/// <summary>
+		/// Create a primary key index for a property called 'Id' (case-insensitive).
+		/// This avoids the need for the [PrimaryKey] attribute.
+		/// </summary>
+		ImplicitPK = 0x001,
+		/// <summary>
+		/// Create indices for properties ending in 'Id' (case-insensitive).
+		/// </summary>
+		ImplicitIndex = 0x002,
+		/// <summary>
+		/// Create a primary key for a property called 'Id' and
+		/// create an indices for properties ending in 'Id' (case-insensitive).
+		/// </summary>
+		AllImplicit = 0x003,
+		/// <summary>
+		/// Force the primary key property to be auto incrementing.
+		/// This avoids the need for the [AutoIncrement] attribute.
+		/// The primary key property on the class should have type int or long.
+		/// </summary>
+		AutoIncPK = 0x004,
+		/// <summary>
+		/// Create virtual table using FTS3
+		/// </summary>
+		FullTextSearch3 = 0x100,
+		/// <summary>
+		/// Create virtual table using FTS4
+		/// </summary>
+		FullTextSearch4 = 0x200
+	}
 
-    public interface ISQLiteConnection : IDisposable
-    {
-        Sqlite3DatabaseHandle Handle { get; }
-        string DatabasePath { get; }
-        int LibVersionNumber { get; }
-        bool TimeExecution { get; set; }
-        bool Trace { get; set; }
-        Action<string> Tracer { get; set; }
-        bool StoreDateTimeAsTicks { get; }
-        bool StoreTimeSpanAsTicks { get; }
-        string DateTimeStringFormat { get; }
-        TimeSpan BusyTimeout { get; set; }
-        IEnumerable<TableMapping> TableMappings { get; }
-        bool IsInTransaction { get; }
+	public interface ISQLiteConnection : IDisposable
+	{
+		Sqlite3DatabaseHandle Handle { get; }
+		string DatabasePath { get; }
+		int LibVersionNumber { get; }
+		bool TimeExecution { get; set; }
+		bool Trace { get; set; }
+		Action<string> Tracer { get; set; }
+		bool StoreDateTimeAsTicks { get; }
+		bool StoreTimeSpanAsTicks { get; }
+		string DateTimeStringFormat { get; }
+		TimeSpan BusyTimeout { get; set; }
+		IEnumerable<TableMapping> TableMappings { get; }
+		bool IsInTransaction { get; }
 
-        event EventHandler<NotifyTableChangedEventArgs> TableChanged;
+		event EventHandler<NotifyTableChangedEventArgs> TableChanged;
 
-        void Backup (string destinationDatabasePath, string databaseName = "main");
-        void BeginTransaction ();
-        void Close ();
-        void Commit ();
-        SQLiteCommand CreateCommand (string cmdText, params object[] ps);
-        SQLiteCommand CreateCommand (string cmdText, Dictionary<string, object> args);
-        int CreateIndex (string indexName, string tableName, string[] columnNames, bool unique = false);
-        int CreateIndex (string indexName, string tableName, string columnName, bool unique = false);
-        int CreateIndex (string tableName, string columnName, bool unique = false);
-        int CreateIndex (string tableName, string[] columnNames, bool unique = false);
-        int CreateIndex<
+		void Backup (string destinationDatabasePath, string databaseName = "main");
+		void BeginTransaction ();
+		void Close ();
+		void Commit ();
+		SQLiteCommand CreateCommand (string cmdText, params object[] ps);
+		SQLiteCommand CreateCommand (string cmdText, Dictionary<string, object> args);
+		int CreateIndex (string indexName, string tableName, string[] columnNames, bool unique = false);
+		int CreateIndex (string indexName, string tableName, string columnName, bool unique = false);
+		int CreateIndex (string tableName, string columnName, bool unique = false);
+		int CreateIndex (string tableName, string[] columnNames, bool unique = false);
+		int CreateIndex<
 #if NET8_0_OR_GREATER
 			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
 #endif
 			T> (Expression<Func<T, object>> property, bool unique = false);
-        CreateTableResult CreateTable<
+		CreateTableResult CreateTable<
 #if NET8_0_OR_GREATER
 			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
 #endif
 			T> (CreateFlags createFlags = CreateFlags.None);
-        CreateTableResult CreateTable (
+		CreateTableResult CreateTable (
 #if NET8_0_OR_GREATER
 			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
 #endif
 			Type ty, CreateFlags createFlags = CreateFlags.None);
-        CreateTablesResult CreateTables<
+		CreateTablesResult CreateTables<
 #if NET8_0_OR_GREATER
 			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
 #endif
@@ -217,9 +217,9 @@ namespace SQLite
 			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
 #endif
 			T2> (CreateFlags createFlags = CreateFlags.None)
-            where T : new()
-            where T2 : new();
-        CreateTablesResult CreateTables<
+			where T : new()
+			where T2 : new();
+		CreateTablesResult CreateTables<
 #if NET8_0_OR_GREATER
 			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
 #endif
@@ -232,10 +232,10 @@ namespace SQLite
 			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
 #endif
 			T3> (CreateFlags createFlags = CreateFlags.None)
-            where T : new()
-            where T2 : new()
-            where T3 : new();
-        CreateTablesResult CreateTables<
+			where T : new()
+			where T2 : new()
+			where T3 : new();
+		CreateTablesResult CreateTables<
 #if NET8_0_OR_GREATER
 			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
 #endif
@@ -252,11 +252,11 @@ namespace SQLite
 			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
 #endif
 			T4> (CreateFlags createFlags = CreateFlags.None)
-            where T : new()
-            where T2 : new()
-            where T3 : new()
-            where T4 : new();
-        CreateTablesResult CreateTables<
+			where T : new()
+			where T2 : new()
+			where T3 : new()
+			where T4 : new();
+		CreateTablesResult CreateTables<
 #if NET8_0_OR_GREATER
 			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
 #endif
@@ -277,91 +277,91 @@ namespace SQLite
 			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
 #endif
 			T5> (CreateFlags createFlags = CreateFlags.None)
-            where T : new()
-            where T2 : new()
-            where T3 : new()
-            where T4 : new()
-            where T5 : new();
+			where T : new()
+			where T2 : new()
+			where T3 : new()
+			where T4 : new()
+			where T5 : new();
 #if NET
 		[RequiresUnreferencedCode ("This method requires 'DynamicallyAccessedMemberTypes.All' on each input 'Type' instance.")]
 #endif
 		CreateTablesResult CreateTables (CreateFlags createFlags = CreateFlags.None, params Type[] types);
-        IEnumerable<T> DeferredQuery<
+		IEnumerable<T> DeferredQuery<
 #if NET8_0_OR_GREATER
 			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
 #endif
 			T> (string query, params object[] args) where T : new();
-        IEnumerable<object> DeferredQuery (TableMapping map, string query, params object[] args);
+		IEnumerable<object> DeferredQuery (TableMapping map, string query, params object[] args);
 #if NET8_0_OR_GREATER
 		[RequiresUnreferencedCode ("This method requires ''DynamicallyAccessedMemberTypes.All' on the runtime type of 'objectToDelete'.")]
 #endif
 		int Delete (object objectToDelete);
-        int Delete<
+		int Delete<
 #if NET8_0_OR_GREATER
 			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
 #endif
 			T> (object primaryKey);
-        int Delete (object primaryKey, TableMapping map);
-        int DeleteAll<
+		int Delete (object primaryKey, TableMapping map);
+		int DeleteAll<
 #if NET8_0_OR_GREATER
 			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
 #endif
 			T> ();
-        int DeleteAll (TableMapping map);
-        int DropTable<
+		int DeleteAll (TableMapping map);
+		int DropTable<
 #if NET8_0_OR_GREATER
 			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
 #endif
 			T> ();
-        int DropTable (TableMapping map);
-        void EnableLoadExtension (bool enabled);
-        void EnableWriteAheadLogging ();
-        int Execute (string query, params object[] args);
-        T ExecuteScalar<T> (string query, params object[] args);
-        T Find<
+		int DropTable (TableMapping map);
+		void EnableLoadExtension (bool enabled);
+		void EnableWriteAheadLogging ();
+		int Execute (string query, params object[] args);
+		T ExecuteScalar<T> (string query, params object[] args);
+		T Find<
 #if NET8_0_OR_GREATER
 			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
 #endif
 			T> (object pk) where T : new();
-        object Find (object pk, TableMapping map);
-        T Find<
+		object Find (object pk, TableMapping map);
+		T Find<
 #if NET8_0_OR_GREATER
 			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
 #endif
 			T> (Expression<Func<T, bool>> predicate) where T : new();
-        T FindWithQuery<
+		T FindWithQuery<
 #if NET8_0_OR_GREATER
 			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
 #endif
 			T> (string query, params object[] args) where T : new();
-        object FindWithQuery (TableMapping map, string query, params object[] args);
-        T Get<
+		object FindWithQuery (TableMapping map, string query, params object[] args);
+		T Get<
 #if NET8_0_OR_GREATER
 			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
 #endif
 			T> (object pk) where T : new();
-        object Get (object pk, TableMapping map);
-        T Get<
+		object Get (object pk, TableMapping map);
+		T Get<
 #if NET8_0_OR_GREATER
 			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
 #endif
 			T> (Expression<Func<T, bool>> predicate) where T : new();
-        TableMapping GetMapping (
+		TableMapping GetMapping (
 #if NET8_0_OR_GREATER
 			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
 #endif
 			Type type, CreateFlags createFlags = CreateFlags.None);
-        TableMapping GetMapping<
+		TableMapping GetMapping<
 #if NET8_0_OR_GREATER
 			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
 #endif
 			T> (CreateFlags createFlags = CreateFlags.None);
-        List<SQLiteConnection.ColumnInfo> GetTableInfo (string tableName);
+		List<SQLiteConnection.ColumnInfo> GetTableInfo (string tableName);
 #if NET8_0_OR_GREATER
 		[RequiresUnreferencedCode ("This method requires ''DynamicallyAccessedMemberTypes.All' on the runtime type of 'obj'.")]
 #endif
 		int Insert (object obj);
-        int Insert (
+		int Insert (
 			object obj,
 #if NET8_0_OR_GREATER
 			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
@@ -371,7 +371,7 @@ namespace SQLite
 		[RequiresUnreferencedCode ("This method requires ''DynamicallyAccessedMemberTypes.All' on the runtime type of 'obj'.")]
 #endif
 		int Insert (object obj, string extra);
-        int Insert (
+		int Insert (
 			object obj,
 			string extra,
 #if NET8_0_OR_GREATER
@@ -386,7 +386,7 @@ namespace SQLite
 		[RequiresUnreferencedCode ("This method requires ''DynamicallyAccessedMemberTypes.All' on the runtime type of all objects in 'objects'.")]
 #endif
 		int InsertAll (IEnumerable objects, string extra, bool runInTransaction = true);
-        int InsertAll (
+		int InsertAll (
 			IEnumerable objects,
 #if NET8_0_OR_GREATER
 			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
@@ -397,27 +397,27 @@ namespace SQLite
 		[RequiresUnreferencedCode ("This method requires ''DynamicallyAccessedMemberTypes.All' on the runtime type of 'obj'.")]
 #endif
 		int InsertOrReplace (object obj);
-        int InsertOrReplace (
+		int InsertOrReplace (
 			object obj,
 #if NET8_0_OR_GREATER
 			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
 #endif
 			Type objType);
-        List<T> Query<
+		List<T> Query<
 #if NET8_0_OR_GREATER
 			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
 #endif
 			T> (string query, params object[] args) where T : new();
-        List<object> Query (TableMapping map, string query, params object[] args);
-        List<T> QueryScalars<T> (string query, params object[] args);
-        void ReKey (string key);
-        void ReKey (byte[] key);
-        void Release (string savepoint);
-        void Rollback ();
-        void RollbackTo (string savepoint);
-        void RunInTransaction (Action action);
-        string SaveTransactionPoint ();
-        TableQuery<T> Table<
+		List<object> Query (TableMapping map, string query, params object[] args);
+		List<T> QueryScalars<T> (string query, params object[] args);
+		void ReKey (string key);
+		void ReKey (byte[] key);
+		void Release (string savepoint);
+		void Rollback ();
+		void RollbackTo (string savepoint);
+		void RunInTransaction (Action action);
+		string SaveTransactionPoint ();
+		TableQuery<T> Table<
 #if NET8_0_OR_GREATER
 			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
 #endif
@@ -426,7 +426,7 @@ namespace SQLite
 		[RequiresUnreferencedCode ("This method requires ''DynamicallyAccessedMemberTypes.All' on the runtime type of 'obj'.")]
 #endif
 		int Update (object obj);
-        int Update (
+		int Update (
 			object obj,
 #if NET8_0_OR_GREATER
 			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
@@ -436,513 +436,513 @@ namespace SQLite
 		[RequiresUnreferencedCode ("This method requires ''DynamicallyAccessedMemberTypes.All' on the runtime type of all objects in 'objects'.")]
 #endif
 		int UpdateAll (IEnumerable objects, bool runInTransaction = true);
-    }
+	}
 
-    /// <summary>
-    /// An open connection to a SQLite database.
-    /// </summary>
-    [Preserve (AllMembers = true)]
-    public partial class SQLiteConnection : ISQLiteConnection
-    {
-        private bool _open;
-        private TimeSpan _busyTimeout;
-        readonly static Dictionary<string, TableMapping> _mappings = new Dictionary<string, TableMapping> ();
-        private System.Diagnostics.Stopwatch _sw;
-        private long _elapsedMilliseconds = 0;
+	/// <summary>
+	/// An open connection to a SQLite database.
+	/// </summary>
+	[Preserve (AllMembers = true)]
+	public partial class SQLiteConnection : ISQLiteConnection
+	{
+		private bool _open;
+		private TimeSpan _busyTimeout;
+		readonly static Dictionary<string, TableMapping> _mappings = new Dictionary<string, TableMapping> ();
+		private System.Diagnostics.Stopwatch _sw;
+		private long _elapsedMilliseconds = 0;
 
-        private int _transactionDepth = 0;
-        private Random _rand = new Random ();
+		private int _transactionDepth = 0;
+		private Random _rand = new Random ();
 
-        public Sqlite3DatabaseHandle Handle { get; private set; }
-        static readonly Sqlite3DatabaseHandle NullHandle = default (Sqlite3DatabaseHandle);
-        static readonly Sqlite3BackupHandle NullBackupHandle = default (Sqlite3BackupHandle);
+		public Sqlite3DatabaseHandle Handle { get; private set; }
+		static readonly Sqlite3DatabaseHandle NullHandle = default (Sqlite3DatabaseHandle);
+		static readonly Sqlite3BackupHandle NullBackupHandle = default (Sqlite3BackupHandle);
 
-        /// <summary>
-        /// Gets the database path used by this connection.
-        /// </summary>
-        public string DatabasePath { get; private set; }
+		/// <summary>
+		/// Gets the database path used by this connection.
+		/// </summary>
+		public string DatabasePath { get; private set; }
 
-        /// <summary>
-        /// Gets the SQLite library version number. 3007014 would be v3.7.14
-        /// </summary>
-        public int LibVersionNumber { get; private set; }
+		/// <summary>
+		/// Gets the SQLite library version number. 3007014 would be v3.7.14
+		/// </summary>
+		public int LibVersionNumber { get; private set; }
 
-        /// <summary>
-        /// Whether Trace lines should be written that show the execution time of queries.
-        /// </summary>
-        public bool TimeExecution { get; set; }
+		/// <summary>
+		/// Whether Trace lines should be written that show the execution time of queries.
+		/// </summary>
+		public bool TimeExecution { get; set; }
 
-        /// <summary>
-        /// Whether to write queries to <see cref="Tracer"/> during execution.
-        /// </summary>
-        public bool Trace { get; set; }
+		/// <summary>
+		/// Whether to write queries to <see cref="Tracer"/> during execution.
+		/// </summary>
+		public bool Trace { get; set; }
 
-        /// <summary>
-        /// The delegate responsible for writing trace lines.
-        /// </summary>
-        /// <value>The tracer.</value>
-        public Action<string> Tracer { get; set; }
+		/// <summary>
+		/// The delegate responsible for writing trace lines.
+		/// </summary>
+		/// <value>The tracer.</value>
+		public Action<string> Tracer { get; set; }
 
-        /// <summary>
-        /// Whether to store DateTime properties as ticks (true) or strings (false).
-        /// </summary>
-        public bool StoreDateTimeAsTicks { get; private set; }
+		/// <summary>
+		/// Whether to store DateTime properties as ticks (true) or strings (false).
+		/// </summary>
+		public bool StoreDateTimeAsTicks { get; private set; }
 
-        /// <summary>
-        /// Whether to store TimeSpan properties as ticks (true) or strings (false).
-        /// </summary>
-        public bool StoreTimeSpanAsTicks { get; private set; }
+		/// <summary>
+		/// Whether to store TimeSpan properties as ticks (true) or strings (false).
+		/// </summary>
+		public bool StoreTimeSpanAsTicks { get; private set; }
 
-        /// <summary>
-        /// The format to use when storing DateTime properties as strings. Ignored if StoreDateTimeAsTicks is true.
-        /// </summary>
-        /// <value>The date time string format.</value>
-        public string DateTimeStringFormat { get; private set; }
+		/// <summary>
+		/// The format to use when storing DateTime properties as strings. Ignored if StoreDateTimeAsTicks is true.
+		/// </summary>
+		/// <value>The date time string format.</value>
+		public string DateTimeStringFormat { get; private set; }
 
-        /// <summary>
-        /// The DateTimeStyles value to use when parsing a DateTime property string.
-        /// </summary>
-        /// <value>The date time style.</value>
-        internal System.Globalization.DateTimeStyles DateTimeStyle { get; private set; }
+		/// <summary>
+		/// The DateTimeStyles value to use when parsing a DateTime property string.
+		/// </summary>
+		/// <value>The date time style.</value>
+		internal System.Globalization.DateTimeStyles DateTimeStyle { get; private set; }
 
 #if USE_SQLITEPCL_RAW && !NO_SQLITEPCL_RAW_BATTERIES
-        static SQLiteConnection ()
-        {
-            SQLitePCL.Batteries_V2.Init ();
-        }
+		static SQLiteConnection ()
+		{
+			SQLitePCL.Batteries_V2.Init ();
+		}
 #endif
 
-        /// <summary>
-        /// Constructs a new SQLiteConnection and opens a SQLite database specified by databasePath.
-        /// </summary>
-        /// <param name="databasePath">
-        /// Specifies the path to the database file.
-        /// </param>
-        /// <param name="storeDateTimeAsTicks">
-        /// Specifies whether to store DateTime properties as ticks (true) or strings (false). You
-        /// absolutely do want to store them as Ticks in all new projects. The value of false is
-        /// only here for backwards compatibility. There is a *significant* speed advantage, with no
-        /// down sides, when setting storeDateTimeAsTicks = true.
-        /// If you use DateTimeOffset properties, it will be always stored as ticks regardingless
-        /// the storeDateTimeAsTicks parameter.
-        /// </param>
-        public SQLiteConnection (string databasePath, bool storeDateTimeAsTicks = true)
-            : this (new SQLiteConnectionString (databasePath, SQLiteOpenFlags.ReadWrite | SQLiteOpenFlags.Create, storeDateTimeAsTicks))
-        {
-        }
+		/// <summary>
+		/// Constructs a new SQLiteConnection and opens a SQLite database specified by databasePath.
+		/// </summary>
+		/// <param name="databasePath">
+		/// Specifies the path to the database file.
+		/// </param>
+		/// <param name="storeDateTimeAsTicks">
+		/// Specifies whether to store DateTime properties as ticks (true) or strings (false). You
+		/// absolutely do want to store them as Ticks in all new projects. The value of false is
+		/// only here for backwards compatibility. There is a *significant* speed advantage, with no
+		/// down sides, when setting storeDateTimeAsTicks = true.
+		/// If you use DateTimeOffset properties, it will be always stored as ticks regardingless
+		/// the storeDateTimeAsTicks parameter.
+		/// </param>
+		public SQLiteConnection (string databasePath, bool storeDateTimeAsTicks = true)
+			: this (new SQLiteConnectionString (databasePath, SQLiteOpenFlags.ReadWrite | SQLiteOpenFlags.Create, storeDateTimeAsTicks))
+		{
+		}
 
-        /// <summary>
-        /// Constructs a new SQLiteConnection and opens a SQLite database specified by databasePath.
-        /// </summary>
-        /// <param name="databasePath">
-        /// Specifies the path to the database file.
-        /// </param>
-        /// <param name="openFlags">
-        /// Flags controlling how the connection should be opened.
-        /// </param>
-        /// <param name="storeDateTimeAsTicks">
-        /// Specifies whether to store DateTime properties as ticks (true) or strings (false). You
-        /// absolutely do want to store them as Ticks in all new projects. The value of false is
-        /// only here for backwards compatibility. There is a *significant* speed advantage, with no
-        /// down sides, when setting storeDateTimeAsTicks = true.
-        /// If you use DateTimeOffset properties, it will be always stored as ticks regardingless
-        /// the storeDateTimeAsTicks parameter.
-        /// </param>
-        public SQLiteConnection (string databasePath, SQLiteOpenFlags openFlags, bool storeDateTimeAsTicks = true)
-            : this (new SQLiteConnectionString (databasePath, openFlags, storeDateTimeAsTicks))
-        {
-        }
+		/// <summary>
+		/// Constructs a new SQLiteConnection and opens a SQLite database specified by databasePath.
+		/// </summary>
+		/// <param name="databasePath">
+		/// Specifies the path to the database file.
+		/// </param>
+		/// <param name="openFlags">
+		/// Flags controlling how the connection should be opened.
+		/// </param>
+		/// <param name="storeDateTimeAsTicks">
+		/// Specifies whether to store DateTime properties as ticks (true) or strings (false). You
+		/// absolutely do want to store them as Ticks in all new projects. The value of false is
+		/// only here for backwards compatibility. There is a *significant* speed advantage, with no
+		/// down sides, when setting storeDateTimeAsTicks = true.
+		/// If you use DateTimeOffset properties, it will be always stored as ticks regardingless
+		/// the storeDateTimeAsTicks parameter.
+		/// </param>
+		public SQLiteConnection (string databasePath, SQLiteOpenFlags openFlags, bool storeDateTimeAsTicks = true)
+			: this (new SQLiteConnectionString (databasePath, openFlags, storeDateTimeAsTicks))
+		{
+		}
 
-        /// <summary>
-        /// Constructs a new SQLiteConnection and opens a SQLite database specified by databasePath.
-        /// </summary>
-        /// <param name="connectionString">
-        /// Details on how to find and open the database.
-        /// </param>
-        public SQLiteConnection (SQLiteConnectionString connectionString)
-        {
-            if (connectionString == null)
-                throw new ArgumentNullException (nameof (connectionString));
-            if (connectionString.DatabasePath == null)
-                throw new InvalidOperationException ("DatabasePath must be specified");
+		/// <summary>
+		/// Constructs a new SQLiteConnection and opens a SQLite database specified by databasePath.
+		/// </summary>
+		/// <param name="connectionString">
+		/// Details on how to find and open the database.
+		/// </param>
+		public SQLiteConnection (SQLiteConnectionString connectionString)
+		{
+			if (connectionString == null)
+				throw new ArgumentNullException (nameof (connectionString));
+			if (connectionString.DatabasePath == null)
+				throw new InvalidOperationException ("DatabasePath must be specified");
 
-            DatabasePath = connectionString.DatabasePath;
+			DatabasePath = connectionString.DatabasePath;
 
-            LibVersionNumber = SQLite3.LibVersionNumber ();
+			LibVersionNumber = SQLite3.LibVersionNumber ();
 
 #if NETFX_CORE
-            SQLite3.SetDirectory(/*temp directory type*/2, Windows.Storage.ApplicationData.Current.TemporaryFolder.Path);
+			SQLite3.SetDirectory(/*temp directory type*/2, Windows.Storage.ApplicationData.Current.TemporaryFolder.Path);
 #endif
 
-            Sqlite3DatabaseHandle handle;
+			Sqlite3DatabaseHandle handle;
 
 #if SILVERLIGHT || USE_CSHARP_SQLITE || USE_SQLITEPCL_RAW
-            var r = SQLite3.Open (connectionString.DatabasePath, out handle, (int)connectionString.OpenFlags, connectionString.VfsName);
+			var r = SQLite3.Open (connectionString.DatabasePath, out handle, (int)connectionString.OpenFlags, connectionString.VfsName);
 #else
-            // open using the byte[]
-            // in the case where the path may include Unicode
-            // force open to using UTF-8 using sqlite3_open_v2
-            var databasePathAsBytes = GetNullTerminatedUtf8 (connectionString.DatabasePath);
-            var r = SQLite3.Open (databasePathAsBytes, out handle, (int)connectionString.OpenFlags, connectionString.VfsName);
+			// open using the byte[]
+			// in the case where the path may include Unicode
+			// force open to using UTF-8 using sqlite3_open_v2
+			var databasePathAsBytes = GetNullTerminatedUtf8 (connectionString.DatabasePath);
+			var r = SQLite3.Open (databasePathAsBytes, out handle, (int)connectionString.OpenFlags, connectionString.VfsName);
 #endif
 
-            Handle = handle;
-            if (r != SQLite3.Result.OK) {
-                throw SQLiteException.New (r, String.Format ("Could not open database file: {0} ({1})", DatabasePath, r));
-            }
-            _open = true;
+			Handle = handle;
+			if (r != SQLite3.Result.OK) {
+				throw SQLiteException.New (r, String.Format ("Could not open database file: {0} ({1})", DatabasePath, r));
+			}
+			_open = true;
 
-            StoreDateTimeAsTicks = connectionString.StoreDateTimeAsTicks;
-            StoreTimeSpanAsTicks = connectionString.StoreTimeSpanAsTicks;
-            DateTimeStringFormat = connectionString.DateTimeStringFormat;
-            DateTimeStyle = connectionString.DateTimeStyle;
+			StoreDateTimeAsTicks = connectionString.StoreDateTimeAsTicks;
+			StoreTimeSpanAsTicks = connectionString.StoreTimeSpanAsTicks;
+			DateTimeStringFormat = connectionString.DateTimeStringFormat;
+			DateTimeStyle = connectionString.DateTimeStyle;
 
-            BusyTimeout = TimeSpan.FromSeconds (1.0);
-            Tracer = line => Debug.WriteLine (line);
+			BusyTimeout = TimeSpan.FromSeconds (1.0);
+			Tracer = line => Debug.WriteLine (line);
 
-            connectionString.PreKeyAction?.Invoke (this);
-            if (connectionString.Key is string stringKey) {
-                SetKey (stringKey);
-            }
-            else if (connectionString.Key is byte[] bytesKey) {
-                SetKey (bytesKey);
-            }
-            else if (connectionString.Key != null) {
-                throw new InvalidOperationException ("Encryption keys must be strings or byte arrays");
-            }
-            connectionString.PostKeyAction?.Invoke (this);
-        }
+			connectionString.PreKeyAction?.Invoke (this);
+			if (connectionString.Key is string stringKey) {
+				SetKey (stringKey);
+			}
+			else if (connectionString.Key is byte[] bytesKey) {
+				SetKey (bytesKey);
+			}
+			else if (connectionString.Key != null) {
+				throw new InvalidOperationException ("Encryption keys must be strings or byte arrays");
+			}
+			connectionString.PostKeyAction?.Invoke (this);
+		}
 
-        /// <summary>
-        /// Enables the write ahead logging. WAL is significantly faster in most scenarios
-        /// by providing better concurrency and better disk IO performance than the normal
-        /// journal mode. You only need to call this function once in the lifetime of the database.
-        /// </summary>
-        public void EnableWriteAheadLogging ()
-        {
-            ExecuteScalar<string> ("PRAGMA journal_mode=WAL");
-        }
+		/// <summary>
+		/// Enables the write ahead logging. WAL is significantly faster in most scenarios
+		/// by providing better concurrency and better disk IO performance than the normal
+		/// journal mode. You only need to call this function once in the lifetime of the database.
+		/// </summary>
+		public void EnableWriteAheadLogging ()
+		{
+			ExecuteScalar<string> ("PRAGMA journal_mode=WAL");
+		}
 
-        /// <summary>
-        /// Convert an input string to a quoted SQL string that can be safely used in queries.
-        /// </summary>
-        /// <returns>The quoted string.</returns>
-        /// <param name="unsafeString">The unsafe string to quote.</param>
-        static string Quote (string unsafeString)
-        {
-            // TODO: Doesn't call sqlite3_mprintf("%Q", u) because we're waiting on https://github.com/ericsink/SQLitePCL.raw/issues/153
-            if (unsafeString == null)
-                return "NULL";
-            var safe = unsafeString.Replace ("'", "''");
-            return "'" + safe + "'";
-        }
+		/// <summary>
+		/// Convert an input string to a quoted SQL string that can be safely used in queries.
+		/// </summary>
+		/// <returns>The quoted string.</returns>
+		/// <param name="unsafeString">The unsafe string to quote.</param>
+		static string Quote (string unsafeString)
+		{
+			// TODO: Doesn't call sqlite3_mprintf("%Q", u) because we're waiting on https://github.com/ericsink/SQLitePCL.raw/issues/153
+			if (unsafeString == null)
+				return "NULL";
+			var safe = unsafeString.Replace ("'", "''");
+			return "'" + safe + "'";
+		}
 
-        /// <summary>
-        /// Sets the key used to encrypt/decrypt the database with "pragma key = ...".
-        /// This must be the first thing you call before doing anything else with this connection
-        /// if your database is encrypted.
-        /// This only has an effect if you are using the SQLCipher nuget package.
-        /// </summary>
-        /// <param name="key">Encryption key plain text that is converted to the real encryption key using PBKDF2 key derivation</param>
-        void SetKey (string key)
-        {
-            if (key == null)
-                throw new ArgumentNullException (nameof (key));
-            var q = Quote (key);
-            ExecuteScalar<string> ("pragma key = " + q);
-        }
+		/// <summary>
+		/// Sets the key used to encrypt/decrypt the database with "pragma key = ...".
+		/// This must be the first thing you call before doing anything else with this connection
+		/// if your database is encrypted.
+		/// This only has an effect if you are using the SQLCipher nuget package.
+		/// </summary>
+		/// <param name="key">Encryption key plain text that is converted to the real encryption key using PBKDF2 key derivation</param>
+		void SetKey (string key)
+		{
+			if (key == null)
+				throw new ArgumentNullException (nameof (key));
+			var q = Quote (key);
+			ExecuteScalar<string> ("pragma key = " + q);
+		}
 
-        /// <summary>
-        /// Sets the key used to encrypt/decrypt the database.
-        /// This must be the first thing you call before doing anything else with this connection
-        /// if your database is encrypted.
-        /// This only has an effect if you are using the SQLCipher nuget package.
-        /// </summary>
-        /// <param name="key">256-bit (32 byte) encryption key data</param>
-        void SetKey (byte[] key)
-        {
-            if (key == null)
-                throw new ArgumentNullException (nameof (key));
-            if (key.Length != 32 && key.Length != 48)
-                throw new ArgumentException ("Key must be 32 bytes (256-bit) or 48 bytes (384-bit)", nameof (key));
-            var s = String.Join ("", key.Select (x => x.ToString ("X2")));
-            ExecuteScalar<string> ("pragma key = \"x'" + s + "'\"");
-        }
+		/// <summary>
+		/// Sets the key used to encrypt/decrypt the database.
+		/// This must be the first thing you call before doing anything else with this connection
+		/// if your database is encrypted.
+		/// This only has an effect if you are using the SQLCipher nuget package.
+		/// </summary>
+		/// <param name="key">256-bit (32 byte) encryption key data</param>
+		void SetKey (byte[] key)
+		{
+			if (key == null)
+				throw new ArgumentNullException (nameof (key));
+			if (key.Length != 32 && key.Length != 48)
+				throw new ArgumentException ("Key must be 32 bytes (256-bit) or 48 bytes (384-bit)", nameof (key));
+			var s = String.Join ("", key.Select (x => x.ToString ("X2")));
+			ExecuteScalar<string> ("pragma key = \"x'" + s + "'\"");
+		}
 
-        /// <summary>
-        /// Change the encryption key for a SQLCipher database with "pragma rekey = ...".
-        /// </summary>
-        /// <param name="key">Encryption key plain text that is converted to the real encryption key using PBKDF2 key derivation</param>
-        public void ReKey (string key)
-        {
-            if (key == null)
-                throw new ArgumentNullException(nameof(key));
-            var q = Quote(key);
-            ExecuteScalar<string>("pragma rekey = " + q);
-        }
+		/// <summary>
+		/// Change the encryption key for a SQLCipher database with "pragma rekey = ...".
+		/// </summary>
+		/// <param name="key">Encryption key plain text that is converted to the real encryption key using PBKDF2 key derivation</param>
+		public void ReKey (string key)
+		{
+			if (key == null)
+				throw new ArgumentNullException(nameof(key));
+			var q = Quote(key);
+			ExecuteScalar<string>("pragma rekey = " + q);
+		}
 
-        /// <summary>
-        /// Change the encryption key for a SQLCipher database.
-        /// </summary>
-        /// <param name="key">256-bit (32 byte) or 384-bit (48 bytes) encryption key data</param>
-        public void ReKey (byte[] key)
-        {
-            if (key == null)
-                throw new ArgumentNullException(nameof(key));
-            if (key.Length != 32 && key.Length != 48)
-                throw new ArgumentException ("Key must be 32 bytes (256-bit) or 48 bytes (384-bit)", nameof (key));
-            var s = String.Join("", key.Select(x => x.ToString("X2")));
-            ExecuteScalar<string>("pragma rekey = \"x'" + s + "'\"");
-        }
+		/// <summary>
+		/// Change the encryption key for a SQLCipher database.
+		/// </summary>
+		/// <param name="key">256-bit (32 byte) or 384-bit (48 bytes) encryption key data</param>
+		public void ReKey (byte[] key)
+		{
+			if (key == null)
+				throw new ArgumentNullException(nameof(key));
+			if (key.Length != 32 && key.Length != 48)
+				throw new ArgumentException ("Key must be 32 bytes (256-bit) or 48 bytes (384-bit)", nameof (key));
+			var s = String.Join("", key.Select(x => x.ToString("X2")));
+			ExecuteScalar<string>("pragma rekey = \"x'" + s + "'\"");
+		}
 
-        /// <summary>
-        /// Enable or disable extension loading.
-        /// </summary>
-        public void EnableLoadExtension (bool enabled)
-        {
-            SQLite3.Result r = SQLite3.EnableLoadExtension (Handle, enabled ? 1 : 0);
-            if (r != SQLite3.Result.OK) {
-                string msg = SQLite3.GetErrmsg (Handle);
-                throw SQLiteException.New (r, msg);
-            }
-        }
+		/// <summary>
+		/// Enable or disable extension loading.
+		/// </summary>
+		public void EnableLoadExtension (bool enabled)
+		{
+			SQLite3.Result r = SQLite3.EnableLoadExtension (Handle, enabled ? 1 : 0);
+			if (r != SQLite3.Result.OK) {
+				string msg = SQLite3.GetErrmsg (Handle);
+				throw SQLiteException.New (r, msg);
+			}
+		}
 
 #if !USE_SQLITEPCL_RAW
-        static byte[] GetNullTerminatedUtf8 (string s)
-        {
-            var utf8Length = System.Text.Encoding.UTF8.GetByteCount (s);
-            var bytes = new byte [utf8Length + 1];
-            utf8Length = System.Text.Encoding.UTF8.GetBytes(s, 0, s.Length, bytes, 0);
-            return bytes;
-        }
+		static byte[] GetNullTerminatedUtf8 (string s)
+		{
+			var utf8Length = System.Text.Encoding.UTF8.GetByteCount (s);
+			var bytes = new byte [utf8Length + 1];
+			utf8Length = System.Text.Encoding.UTF8.GetBytes(s, 0, s.Length, bytes, 0);
+			return bytes;
+		}
 #endif
 
-        /// <summary>
-        /// Sets a busy handler to sleep the specified amount of time when a table is locked.
-        /// The handler will sleep multiple times until a total time of <see cref="BusyTimeout"/> has accumulated.
-        /// </summary>
-        public TimeSpan BusyTimeout {
-            get { return _busyTimeout; }
-            set {
-                _busyTimeout = value;
-                if (Handle != NullHandle) {
-                    SQLite3.BusyTimeout (Handle, (int)_busyTimeout.TotalMilliseconds);
-                }
-            }
-        }
+		/// <summary>
+		/// Sets a busy handler to sleep the specified amount of time when a table is locked.
+		/// The handler will sleep multiple times until a total time of <see cref="BusyTimeout"/> has accumulated.
+		/// </summary>
+		public TimeSpan BusyTimeout {
+			get { return _busyTimeout; }
+			set {
+				_busyTimeout = value;
+				if (Handle != NullHandle) {
+					SQLite3.BusyTimeout (Handle, (int)_busyTimeout.TotalMilliseconds);
+				}
+			}
+		}
 
-        /// <summary>
-        /// Returns the mappings from types to tables that the connection
-        /// currently understands.
-        /// </summary>
-        public IEnumerable<TableMapping> TableMappings {
-            get {
-                lock (_mappings) {
-                    return new List<TableMapping> (_mappings.Values);
-                }
-            }
-        }
+		/// <summary>
+		/// Returns the mappings from types to tables that the connection
+		/// currently understands.
+		/// </summary>
+		public IEnumerable<TableMapping> TableMappings {
+			get {
+				lock (_mappings) {
+					return new List<TableMapping> (_mappings.Values);
+				}
+			}
+		}
 
-        /// <summary>
-        /// Retrieves the mapping that is automatically generated for the given type.
-        /// </summary>
-        /// <param name="type">
-        /// The type whose mapping to the database is returned.
-        /// </param>
-        /// <param name="createFlags">
-        /// Optional flags allowing implicit PK and indexes based on naming conventions
-        /// </param>
-        /// <returns>
-        /// The mapping represents the schema of the columns of the database and contains
-        /// methods to set and get properties of objects.
-        /// </returns>
-        public TableMapping GetMapping (
+		/// <summary>
+		/// Retrieves the mapping that is automatically generated for the given type.
+		/// </summary>
+		/// <param name="type">
+		/// The type whose mapping to the database is returned.
+		/// </param>
+		/// <param name="createFlags">
+		/// Optional flags allowing implicit PK and indexes based on naming conventions
+		/// </param>
+		/// <returns>
+		/// The mapping represents the schema of the columns of the database and contains
+		/// methods to set and get properties of objects.
+		/// </returns>
+		public TableMapping GetMapping (
 #if NET8_0_OR_GREATER
 			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
 #endif
 			Type type,
 			CreateFlags createFlags = CreateFlags.None)
-        {
-            TableMapping map;
-            var key = type.FullName;
-            lock (_mappings) {
-                if (_mappings.TryGetValue (key, out map)) {
-                    if (createFlags != CreateFlags.None && createFlags != map.CreateFlags) {
-                        map = new TableMapping (type, createFlags);
-                        _mappings[key] = map;
-                    }
-                }
-                else {
-                    map = new TableMapping (type, createFlags);
-                    _mappings.Add (key, map);
-                }
-            }
-            return map;
-        }
+		{
+			TableMapping map;
+			var key = type.FullName;
+			lock (_mappings) {
+				if (_mappings.TryGetValue (key, out map)) {
+					if (createFlags != CreateFlags.None && createFlags != map.CreateFlags) {
+						map = new TableMapping (type, createFlags);
+						_mappings[key] = map;
+					}
+				}
+				else {
+					map = new TableMapping (type, createFlags);
+					_mappings.Add (key, map);
+				}
+			}
+			return map;
+		}
 
-        /// <summary>
-        /// Retrieves the mapping that is automatically generated for the given type.
-        /// </summary>
-        /// <param name="createFlags">
-        /// Optional flags allowing implicit PK and indexes based on naming conventions
-        /// </param>
-        /// <returns>
-        /// The mapping represents the schema of the columns of the database and contains
-        /// methods to set and get properties of objects.
-        /// </returns>
-        public TableMapping GetMapping<
+		/// <summary>
+		/// Retrieves the mapping that is automatically generated for the given type.
+		/// </summary>
+		/// <param name="createFlags">
+		/// Optional flags allowing implicit PK and indexes based on naming conventions
+		/// </param>
+		/// <returns>
+		/// The mapping represents the schema of the columns of the database and contains
+		/// methods to set and get properties of objects.
+		/// </returns>
+		public TableMapping GetMapping<
 #if NET8_0_OR_GREATER
 			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
 #endif
 			T> (CreateFlags createFlags = CreateFlags.None)
-        {
-            return GetMapping (typeof (T), createFlags);
-        }
+		{
+			return GetMapping (typeof (T), createFlags);
+		}
 
-        private struct IndexedColumn
-        {
-            public int Order;
-            public string ColumnName;
-        }
+		private struct IndexedColumn
+		{
+			public int Order;
+			public string ColumnName;
+		}
 
-        private struct IndexInfo
-        {
-            public string IndexName;
-            public string TableName;
-            public bool Unique;
-            public List<IndexedColumn> Columns;
-        }
+		private struct IndexInfo
+		{
+			public string IndexName;
+			public string TableName;
+			public bool Unique;
+			public List<IndexedColumn> Columns;
+		}
 
-        /// <summary>
-        /// Executes a "drop table" on the database.  This is non-recoverable.
-        /// </summary>
-        public int DropTable<
+		/// <summary>
+		/// Executes a "drop table" on the database.  This is non-recoverable.
+		/// </summary>
+		public int DropTable<
 #if NET8_0_OR_GREATER
 			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
 #endif
 			T> ()
-        {
-            return DropTable (GetMapping (typeof (T)));
-        }
+		{
+			return DropTable (GetMapping (typeof (T)));
+		}
 
-        /// <summary>
-        /// Executes a "drop table" on the database.  This is non-recoverable.
-        /// </summary>
-        /// <param name="map">
-        /// The TableMapping used to identify the table.
-        /// </param>
-        public int DropTable (TableMapping map)
-        {
-            var query = string.Format ("drop table if exists \"{0}\"", map.TableName);
-            return Execute (query);
-        }
+		/// <summary>
+		/// Executes a "drop table" on the database.  This is non-recoverable.
+		/// </summary>
+		/// <param name="map">
+		/// The TableMapping used to identify the table.
+		/// </param>
+		public int DropTable (TableMapping map)
+		{
+			var query = string.Format ("drop table if exists \"{0}\"", map.TableName);
+			return Execute (query);
+		}
 
-        /// <summary>
-        /// Executes a "create table if not exists" on the database. It also
-        /// creates any specified indexes on the columns of the table. It uses
-        /// a schema automatically generated from the specified type. You can
-        /// later access this schema by calling GetMapping.
-        /// </summary>
-        /// <returns>
-        /// Whether the table was created or migrated.
-        /// </returns>
-        public CreateTableResult CreateTable<
+		/// <summary>
+		/// Executes a "create table if not exists" on the database. It also
+		/// creates any specified indexes on the columns of the table. It uses
+		/// a schema automatically generated from the specified type. You can
+		/// later access this schema by calling GetMapping.
+		/// </summary>
+		/// <returns>
+		/// Whether the table was created or migrated.
+		/// </returns>
+		public CreateTableResult CreateTable<
 #if NET8_0_OR_GREATER
 			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
 #endif
 			T> (CreateFlags createFlags = CreateFlags.None)
-        {
-            return CreateTable (typeof (T), createFlags);
-        }
+		{
+			return CreateTable (typeof (T), createFlags);
+		}
 
-        /// <summary>
-        /// Executes a "create table if not exists" on the database. It also
-        /// creates any specified indexes on the columns of the table. It uses
-        /// a schema automatically generated from the specified type. You can
-        /// later access this schema by calling GetMapping.
-        /// </summary>
-        /// <param name="ty">Type to reflect to a database table.</param>
-        /// <param name="createFlags">Optional flags allowing implicit PK and indexes based on naming conventions.</param>
-        /// <returns>
-        /// Whether the table was created or migrated.
-        /// </returns>
-        public CreateTableResult CreateTable (
+		/// <summary>
+		/// Executes a "create table if not exists" on the database. It also
+		/// creates any specified indexes on the columns of the table. It uses
+		/// a schema automatically generated from the specified type. You can
+		/// later access this schema by calling GetMapping.
+		/// </summary>
+		/// <param name="ty">Type to reflect to a database table.</param>
+		/// <param name="createFlags">Optional flags allowing implicit PK and indexes based on naming conventions.</param>
+		/// <returns>
+		/// Whether the table was created or migrated.
+		/// </returns>
+		public CreateTableResult CreateTable (
 #if NET8_0_OR_GREATER
 			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
 #endif
 			Type ty, CreateFlags createFlags = CreateFlags.None)
-        {
-            var map = GetMapping (ty, createFlags);
+		{
+			var map = GetMapping (ty, createFlags);
 
-            // Present a nice error if no columns specified
-            if (map.Columns.Length == 0) {
-                throw new Exception (string.Format ("Cannot create a table without columns (does '{0}' have public properties?)", ty.FullName));
-            }
+			// Present a nice error if no columns specified
+			if (map.Columns.Length == 0) {
+				throw new Exception (string.Format ("Cannot create a table without columns (does '{0}' have public properties?)", ty.FullName));
+			}
 
-            // Check if the table exists
-            var result = CreateTableResult.Created;
-            var existingCols = GetTableInfo (map.TableName);
+			// Check if the table exists
+			var result = CreateTableResult.Created;
+			var existingCols = GetTableInfo (map.TableName);
 
-            // Create or migrate it
-            if (existingCols.Count == 0) {
+			// Create or migrate it
+			if (existingCols.Count == 0) {
 
-                // Facilitate virtual tables a.k.a. full-text search.
-                bool fts3 = (createFlags & CreateFlags.FullTextSearch3) != 0;
-                bool fts4 = (createFlags & CreateFlags.FullTextSearch4) != 0;
-                bool fts = fts3 || fts4;
-                var @virtual = fts ? "virtual " : string.Empty;
-                var @using = fts3 ? "using fts3 " : fts4 ? "using fts4 " : string.Empty;
+				// Facilitate virtual tables a.k.a. full-text search.
+				bool fts3 = (createFlags & CreateFlags.FullTextSearch3) != 0;
+				bool fts4 = (createFlags & CreateFlags.FullTextSearch4) != 0;
+				bool fts = fts3 || fts4;
+				var @virtual = fts ? "virtual " : string.Empty;
+				var @using = fts3 ? "using fts3 " : fts4 ? "using fts4 " : string.Empty;
 
-                // Build query.
-                var query = "create " + @virtual + "table if not exists \"" + map.TableName + "\" " + @using + "(\n";
-                var decls = map.Columns.Select (p => Orm.SqlDecl (p, StoreDateTimeAsTicks, StoreTimeSpanAsTicks));
-                var decl = string.Join (",\n", decls.ToArray ());
-                query += decl;
-                query += ")";
-                if (map.WithoutRowId) {
-                    query += " without rowid";
-                }
+				// Build query.
+				var query = "create " + @virtual + "table if not exists \"" + map.TableName + "\" " + @using + "(\n";
+				var decls = map.Columns.Select (p => Orm.SqlDecl (p, StoreDateTimeAsTicks, StoreTimeSpanAsTicks));
+				var decl = string.Join (",\n", decls.ToArray ());
+				query += decl;
+				query += ")";
+				if (map.WithoutRowId) {
+					query += " without rowid";
+				}
 
-                Execute (query);
-            }
-            else {
-                result = CreateTableResult.Migrated;
-                MigrateTable (map, existingCols);
-            }
+				Execute (query);
+			}
+			else {
+				result = CreateTableResult.Migrated;
+				MigrateTable (map, existingCols);
+			}
 
-            var indexes = new Dictionary<string, IndexInfo> ();
-            foreach (var c in map.Columns) {
-                foreach (var i in c.Indices) {
-                    var iname = i.Name ?? map.TableName + "_" + c.Name;
-                    IndexInfo iinfo;
-                    if (!indexes.TryGetValue (iname, out iinfo)) {
-                        iinfo = new IndexInfo {
-                            IndexName = iname,
-                            TableName = map.TableName,
-                            Unique = i.Unique,
-                            Columns = new List<IndexedColumn> ()
-                        };
-                        indexes.Add (iname, iinfo);
-                    }
+			var indexes = new Dictionary<string, IndexInfo> ();
+			foreach (var c in map.Columns) {
+				foreach (var i in c.Indices) {
+					var iname = i.Name ?? map.TableName + "_" + c.Name;
+					IndexInfo iinfo;
+					if (!indexes.TryGetValue (iname, out iinfo)) {
+						iinfo = new IndexInfo {
+							IndexName = iname,
+							TableName = map.TableName,
+							Unique = i.Unique,
+							Columns = new List<IndexedColumn> ()
+						};
+						indexes.Add (iname, iinfo);
+					}
 
-                    if (i.Unique != iinfo.Unique)
-                        throw new Exception ("All the columns in an index must have the same value for their Unique property");
+					if (i.Unique != iinfo.Unique)
+						throw new Exception ("All the columns in an index must have the same value for their Unique property");
 
-                    iinfo.Columns.Add (new IndexedColumn {
-                        Order = i.Order,
-                        ColumnName = c.Name
-                    });
-                }
-            }
+					iinfo.Columns.Add (new IndexedColumn {
+						Order = i.Order,
+						ColumnName = c.Name
+					});
+				}
+			}
 
-            foreach (var indexName in indexes.Keys) {
-                var index = indexes[indexName];
-                var columns = index.Columns.OrderBy (i => i.Order).Select (i => i.ColumnName).ToArray ();
-                CreateIndex (indexName, index.TableName, columns, index.Unique);
-            }
+			foreach (var indexName in indexes.Keys) {
+				var index = indexes[indexName];
+				var columns = index.Columns.OrderBy (i => i.Order).Select (i => i.ColumnName).ToArray ();
+				CreateIndex (indexName, index.TableName, columns, index.Unique);
+			}
 
-            return result;
-        }
+			return result;
+		}
 
 		/// <summary>
 		/// Executes a "create table if not exists" on the database for each type. It also
@@ -965,11 +965,11 @@ namespace SQLite
 			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
 #endif
 			T2> (CreateFlags createFlags = CreateFlags.None)
-            where T : new()
-            where T2 : new()
-        {
-            return CreateTables (createFlags, typeof (T), typeof (T2));
-        }
+			where T : new()
+			where T2 : new()
+		{
+			return CreateTables (createFlags, typeof (T), typeof (T2));
+		}
 
 		/// <summary>
 		/// Executes a "create table if not exists" on the database for each type. It also
@@ -997,11 +997,11 @@ namespace SQLite
 #endif
 			T3> (CreateFlags createFlags = CreateFlags.None)
 			where T : new()
-            where T2 : new()
-            where T3 : new()
-        {
-            return CreateTables (createFlags, typeof (T), typeof (T2), typeof (T3));
-        }
+			where T2 : new()
+			where T3 : new()
+		{
+			return CreateTables (createFlags, typeof (T), typeof (T2), typeof (T3));
+		}
 
 		/// <summary>
 		/// Executes a "create table if not exists" on the database for each type. It also
@@ -1033,12 +1033,12 @@ namespace SQLite
 # endif
 			T4> (CreateFlags createFlags = CreateFlags.None)
 			where T : new()
-            where T2 : new()
-            where T3 : new()
-            where T4 : new()
-        {
-            return CreateTables (createFlags, typeof (T), typeof (T2), typeof (T3), typeof (T4));
-        }
+			where T2 : new()
+			where T3 : new()
+			where T4 : new()
+		{
+			return CreateTables (createFlags, typeof (T), typeof (T2), typeof (T3), typeof (T4));
+		}
 
 		/// <summary>
 		/// Executes a "create table if not exists" on the database for each type. It also
@@ -1074,13 +1074,13 @@ namespace SQLite
 # endif
 			T5> (CreateFlags createFlags = CreateFlags.None)
 			where T : new()
-            where T2 : new()
-            where T3 : new()
-            where T4 : new()
-            where T5 : new()
-        {
-            return CreateTables (createFlags, typeof (T), typeof (T2), typeof (T3), typeof (T4), typeof (T5));
-        }
+			where T2 : new()
+			where T3 : new()
+			where T4 : new()
+			where T5 : new()
+		{
+			return CreateTables (createFlags, typeof (T), typeof (T2), typeof (T3), typeof (T4), typeof (T5));
+		}
 
 		/// <summary>
 		/// Executes a "create table if not exists" on the database for each type. It also
@@ -1095,854 +1095,854 @@ namespace SQLite
 		[RequiresUnreferencedCode("This method requires 'DynamicallyAccessedMemberTypes.All' on each input 'Type' instance.")]
 #endif
 		public CreateTablesResult CreateTables (CreateFlags createFlags = CreateFlags.None, params Type[] types)
-        {
-            var result = new CreateTablesResult ();
-            foreach (Type type in types) {
-                var aResult = CreateTable (type, createFlags);
-                result.Results[type] = aResult;
-            }
-            return result;
-        }
+		{
+			var result = new CreateTablesResult ();
+			foreach (Type type in types) {
+				var aResult = CreateTable (type, createFlags);
+				result.Results[type] = aResult;
+			}
+			return result;
+		}
 
-        /// <summary>
-        /// Creates an index for the specified table and columns.
-        /// </summary>
-        /// <param name="indexName">Name of the index to create</param>
-        /// <param name="tableName">Name of the database table</param>
-        /// <param name="columnNames">An array of column names to index</param>
-        /// <param name="unique">Whether the index should be unique</param>
-        /// <returns>Zero on success.</returns>
-        public int CreateIndex (string indexName, string tableName, string[] columnNames, bool unique = false)
-        {
-            const string sqlFormat = "create {2} index if not exists \"{3}\" on \"{0}\"(\"{1}\")";
-            var sql = String.Format (sqlFormat, tableName, string.Join ("\", \"", columnNames), unique ? "unique" : "", indexName);
-            return Execute (sql);
-        }
+		/// <summary>
+		/// Creates an index for the specified table and columns.
+		/// </summary>
+		/// <param name="indexName">Name of the index to create</param>
+		/// <param name="tableName">Name of the database table</param>
+		/// <param name="columnNames">An array of column names to index</param>
+		/// <param name="unique">Whether the index should be unique</param>
+		/// <returns>Zero on success.</returns>
+		public int CreateIndex (string indexName, string tableName, string[] columnNames, bool unique = false)
+		{
+			const string sqlFormat = "create {2} index if not exists \"{3}\" on \"{0}\"(\"{1}\")";
+			var sql = String.Format (sqlFormat, tableName, string.Join ("\", \"", columnNames), unique ? "unique" : "", indexName);
+			return Execute (sql);
+		}
 
-        /// <summary>
-        /// Creates an index for the specified table and column.
-        /// </summary>
-        /// <param name="indexName">Name of the index to create</param>
-        /// <param name="tableName">Name of the database table</param>
-        /// <param name="columnName">Name of the column to index</param>
-        /// <param name="unique">Whether the index should be unique</param>
-        /// <returns>Zero on success.</returns>
-        public int CreateIndex (string indexName, string tableName, string columnName, bool unique = false)
-        {
-            return CreateIndex (indexName, tableName, new string[] { columnName }, unique);
-        }
+		/// <summary>
+		/// Creates an index for the specified table and column.
+		/// </summary>
+		/// <param name="indexName">Name of the index to create</param>
+		/// <param name="tableName">Name of the database table</param>
+		/// <param name="columnName">Name of the column to index</param>
+		/// <param name="unique">Whether the index should be unique</param>
+		/// <returns>Zero on success.</returns>
+		public int CreateIndex (string indexName, string tableName, string columnName, bool unique = false)
+		{
+			return CreateIndex (indexName, tableName, new string[] { columnName }, unique);
+		}
 
-        /// <summary>
-        /// Creates an index for the specified table and column.
-        /// </summary>
-        /// <param name="tableName">Name of the database table</param>
-        /// <param name="columnName">Name of the column to index</param>
-        /// <param name="unique">Whether the index should be unique</param>
-        /// <returns>Zero on success.</returns>
-        public int CreateIndex (string tableName, string columnName, bool unique = false)
-        {
-            return CreateIndex (tableName + "_" + columnName, tableName, columnName, unique);
-        }
+		/// <summary>
+		/// Creates an index for the specified table and column.
+		/// </summary>
+		/// <param name="tableName">Name of the database table</param>
+		/// <param name="columnName">Name of the column to index</param>
+		/// <param name="unique">Whether the index should be unique</param>
+		/// <returns>Zero on success.</returns>
+		public int CreateIndex (string tableName, string columnName, bool unique = false)
+		{
+			return CreateIndex (tableName + "_" + columnName, tableName, columnName, unique);
+		}
 
-        /// <summary>
-        /// Creates an index for the specified table and columns.
-        /// </summary>
-        /// <param name="tableName">Name of the database table</param>
-        /// <param name="columnNames">An array of column names to index</param>
-        /// <param name="unique">Whether the index should be unique</param>
-        /// <returns>Zero on success.</returns>
-        public int CreateIndex (string tableName, string[] columnNames, bool unique = false)
-        {
-            return CreateIndex (tableName + "_" + string.Join ("_", columnNames), tableName, columnNames, unique);
-        }
+		/// <summary>
+		/// Creates an index for the specified table and columns.
+		/// </summary>
+		/// <param name="tableName">Name of the database table</param>
+		/// <param name="columnNames">An array of column names to index</param>
+		/// <param name="unique">Whether the index should be unique</param>
+		/// <returns>Zero on success.</returns>
+		public int CreateIndex (string tableName, string[] columnNames, bool unique = false)
+		{
+			return CreateIndex (tableName + "_" + string.Join ("_", columnNames), tableName, columnNames, unique);
+		}
 
-        /// <summary>
-        /// Creates an index for the specified object property.
-        /// e.g. CreateIndex&lt;Client&gt;(c => c.Name);
-        /// </summary>
-        /// <typeparam name="T">Type to reflect to a database table.</typeparam>
-        /// <param name="property">Property to index</param>
-        /// <param name="unique">Whether the index should be unique</param>
-        /// <returns>Zero on success.</returns>
-        public int CreateIndex<
+		/// <summary>
+		/// Creates an index for the specified object property.
+		/// e.g. CreateIndex&lt;Client&gt;(c => c.Name);
+		/// </summary>
+		/// <typeparam name="T">Type to reflect to a database table.</typeparam>
+		/// <param name="property">Property to index</param>
+		/// <param name="unique">Whether the index should be unique</param>
+		/// <returns>Zero on success.</returns>
+		public int CreateIndex<
 #if NET8_0_OR_GREATER
 			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
 #endif
 			T> (Expression<Func<T, object>> property, bool unique = false)
-        {
-            MemberExpression mx;
-            if (property.Body.NodeType == ExpressionType.Convert) {
-                mx = ((UnaryExpression)property.Body).Operand as MemberExpression;
-            }
-            else {
-                mx = (property.Body as MemberExpression);
-            }
-            var propertyInfo = mx.Member as PropertyInfo;
-            if (propertyInfo == null) {
-                throw new ArgumentException ("The lambda expression 'property' should point to a valid Property");
-            }
+		{
+			MemberExpression mx;
+			if (property.Body.NodeType == ExpressionType.Convert) {
+				mx = ((UnaryExpression)property.Body).Operand as MemberExpression;
+			}
+			else {
+				mx = (property.Body as MemberExpression);
+			}
+			var propertyInfo = mx.Member as PropertyInfo;
+			if (propertyInfo == null) {
+				throw new ArgumentException ("The lambda expression 'property' should point to a valid Property");
+			}
 
-            var propName = propertyInfo.Name;
+			var propName = propertyInfo.Name;
 
-            var map = GetMapping<T> ();
-            var colName = map.FindColumnWithPropertyName (propName).Name;
+			var map = GetMapping<T> ();
+			var colName = map.FindColumnWithPropertyName (propName).Name;
 
-            return CreateIndex (map.TableName, colName, unique);
-        }
+			return CreateIndex (map.TableName, colName, unique);
+		}
 
-        [Preserve (AllMembers = true)]
-        public class ColumnInfo
-        {
-            //			public int cid { get; set; }
+		[Preserve (AllMembers = true)]
+		public class ColumnInfo
+		{
+			//			public int cid { get; set; }
 
-            [Column ("name")]
-            public string Name { get; set; }
+			[Column ("name")]
+			public string Name { get; set; }
 
-            //			[Column ("type")]
-            //			public string ColumnType { get; set; }
+			//			[Column ("type")]
+			//			public string ColumnType { get; set; }
 
-            public int notnull { get; set; }
+			public int notnull { get; set; }
 
-            //			public string dflt_value { get; set; }
+			//			public string dflt_value { get; set; }
 
-            //			public int pk { get; set; }
+			//			public int pk { get; set; }
 
-            public override string ToString ()
-            {
-                return Name;
-            }
-        }
+			public override string ToString ()
+			{
+				return Name;
+			}
+		}
 
-        /// <summary>
-        /// Query the built-in sqlite table_info table for a specific tables columns.
-        /// </summary>
-        /// <returns>The columns contains in the table.</returns>
-        /// <param name="tableName">Table name.</param>
-        public List<ColumnInfo> GetTableInfo (string tableName)
-        {
-            var query = "pragma table_info(\"" + tableName + "\")";
-            return Query<ColumnInfo> (query);
-        }
+		/// <summary>
+		/// Query the built-in sqlite table_info table for a specific tables columns.
+		/// </summary>
+		/// <returns>The columns contains in the table.</returns>
+		/// <param name="tableName">Table name.</param>
+		public List<ColumnInfo> GetTableInfo (string tableName)
+		{
+			var query = "pragma table_info(\"" + tableName + "\")";
+			return Query<ColumnInfo> (query);
+		}
 
-        void MigrateTable (TableMapping map, List<ColumnInfo> existingCols)
-        {
-            var toBeAdded = new List<TableMapping.Column> ();
+		void MigrateTable (TableMapping map, List<ColumnInfo> existingCols)
+		{
+			var toBeAdded = new List<TableMapping.Column> ();
 
-            foreach (var p in map.Columns) {
-                var found = false;
-                foreach (var c in existingCols) {
-                    found = (string.Compare (p.Name, c.Name, StringComparison.OrdinalIgnoreCase) == 0);
-                    if (found)
-                        break;
-                }
-                if (!found) {
-                    toBeAdded.Add (p);
-                }
-            }
+			foreach (var p in map.Columns) {
+				var found = false;
+				foreach (var c in existingCols) {
+					found = (string.Compare (p.Name, c.Name, StringComparison.OrdinalIgnoreCase) == 0);
+					if (found)
+						break;
+				}
+				if (!found) {
+					toBeAdded.Add (p);
+				}
+			}
 
-            foreach (var p in toBeAdded) {
-                var addCol = "alter table \"" + map.TableName + "\" add column " + Orm.SqlDecl (p, StoreDateTimeAsTicks, StoreTimeSpanAsTicks);
-                Execute (addCol);
-            }
-        }
+			foreach (var p in toBeAdded) {
+				var addCol = "alter table \"" + map.TableName + "\" add column " + Orm.SqlDecl (p, StoreDateTimeAsTicks, StoreTimeSpanAsTicks);
+				Execute (addCol);
+			}
+		}
 
-        /// <summary>
-        /// Creates a new SQLiteCommand. Can be overridden to provide a sub-class.
-        /// </summary>
-        /// <seealso cref="SQLiteCommand.OnInstanceCreated"/>
-        protected virtual SQLiteCommand NewCommand ()
-        {
-            return new SQLiteCommand (this);
-        }
+		/// <summary>
+		/// Creates a new SQLiteCommand. Can be overridden to provide a sub-class.
+		/// </summary>
+		/// <seealso cref="SQLiteCommand.OnInstanceCreated"/>
+		protected virtual SQLiteCommand NewCommand ()
+		{
+			return new SQLiteCommand (this);
+		}
 
-        /// <summary>
-        /// Creates a new SQLiteCommand given the command text with arguments. Place a '?'
-        /// in the command text for each of the arguments.
-        /// </summary>
-        /// <param name="cmdText">
-        /// The fully escaped SQL.
-        /// </param>
-        /// <param name="ps">
-        /// Arguments to substitute for the occurences of '?' in the command text.
-        /// </param>
-        /// <returns>
-        /// A <see cref="SQLiteCommand"/>
-        /// </returns>
-        public SQLiteCommand CreateCommand (string cmdText, params object[] ps)
-        {
-            if (!_open)
-                throw SQLiteException.New (SQLite3.Result.Error, "Cannot create commands from unopened database");
+		/// <summary>
+		/// Creates a new SQLiteCommand given the command text with arguments. Place a '?'
+		/// in the command text for each of the arguments.
+		/// </summary>
+		/// <param name="cmdText">
+		/// The fully escaped SQL.
+		/// </param>
+		/// <param name="ps">
+		/// Arguments to substitute for the occurences of '?' in the command text.
+		/// </param>
+		/// <returns>
+		/// A <see cref="SQLiteCommand"/>
+		/// </returns>
+		public SQLiteCommand CreateCommand (string cmdText, params object[] ps)
+		{
+			if (!_open)
+				throw SQLiteException.New (SQLite3.Result.Error, "Cannot create commands from unopened database");
 
-            var cmd = NewCommand ();
-            cmd.CommandText = cmdText;
-            foreach (var o in ps) {
-                cmd.Bind (o);
-            }
-            return cmd;
-        }
+			var cmd = NewCommand ();
+			cmd.CommandText = cmdText;
+			foreach (var o in ps) {
+				cmd.Bind (o);
+			}
+			return cmd;
+		}
 
-        /// <summary>
-        /// Creates a new SQLiteCommand given the command text with named arguments. Place a "[@:$]VVV"
-        /// in the command text for each of the arguments. VVV represents an alphanumeric identifier.
-        /// For example, @name :name and $name can all be used in the query.
-        /// </summary>
-        /// <param name="cmdText">
-        /// The fully escaped SQL.
-        /// </param>
-        /// <param name="args">
-        /// Arguments to substitute for the occurences of "[@:$]VVV" in the command text.
-        /// </param>
-        /// <returns>
-        /// A <see cref="SQLiteCommand" />
-        /// </returns>
-        public SQLiteCommand CreateCommand (string cmdText, Dictionary<string, object> args)
-        {
-            if (!_open)
-                throw SQLiteException.New (SQLite3.Result.Error, "Cannot create commands from unopened database");
+		/// <summary>
+		/// Creates a new SQLiteCommand given the command text with named arguments. Place a "[@:$]VVV"
+		/// in the command text for each of the arguments. VVV represents an alphanumeric identifier.
+		/// For example, @name :name and $name can all be used in the query.
+		/// </summary>
+		/// <param name="cmdText">
+		/// The fully escaped SQL.
+		/// </param>
+		/// <param name="args">
+		/// Arguments to substitute for the occurences of "[@:$]VVV" in the command text.
+		/// </param>
+		/// <returns>
+		/// A <see cref="SQLiteCommand" />
+		/// </returns>
+		public SQLiteCommand CreateCommand (string cmdText, Dictionary<string, object> args)
+		{
+			if (!_open)
+				throw SQLiteException.New (SQLite3.Result.Error, "Cannot create commands from unopened database");
 
-            SQLiteCommand cmd = NewCommand ();
-            cmd.CommandText = cmdText;
-            foreach (var kv in args) {
-                cmd.Bind (kv.Key, kv.Value);
-            }
-            return cmd;
-        }
+			SQLiteCommand cmd = NewCommand ();
+			cmd.CommandText = cmdText;
+			foreach (var kv in args) {
+				cmd.Bind (kv.Key, kv.Value);
+			}
+			return cmd;
+		}
 
-        /// <summary>
-        /// Creates a SQLiteCommand given the command text (SQL) with arguments. Place a '?'
-        /// in the command text for each of the arguments and then executes that command.
-        /// Use this method instead of Query when you don't expect rows back. Such cases include
-        /// INSERTs, UPDATEs, and DELETEs.
-        /// You can set the Trace or TimeExecution properties of the connection
-        /// to profile execution.
-        /// </summary>
-        /// <param name="query">
-        /// The fully escaped SQL.
-        /// </param>
-        /// <param name="args">
-        /// Arguments to substitute for the occurences of '?' in the query.
-        /// </param>
-        /// <returns>
-        /// The number of rows modified in the database as a result of this execution.
-        /// </returns>
-        public int Execute (string query, params object[] args)
-        {
-            var cmd = CreateCommand (query, args);
+		/// <summary>
+		/// Creates a SQLiteCommand given the command text (SQL) with arguments. Place a '?'
+		/// in the command text for each of the arguments and then executes that command.
+		/// Use this method instead of Query when you don't expect rows back. Such cases include
+		/// INSERTs, UPDATEs, and DELETEs.
+		/// You can set the Trace or TimeExecution properties of the connection
+		/// to profile execution.
+		/// </summary>
+		/// <param name="query">
+		/// The fully escaped SQL.
+		/// </param>
+		/// <param name="args">
+		/// Arguments to substitute for the occurences of '?' in the query.
+		/// </param>
+		/// <returns>
+		/// The number of rows modified in the database as a result of this execution.
+		/// </returns>
+		public int Execute (string query, params object[] args)
+		{
+			var cmd = CreateCommand (query, args);
 
-            if (TimeExecution) {
-                if (_sw == null) {
-                    _sw = new Stopwatch ();
-                }
-                _sw.Reset ();
-                _sw.Start ();
-            }
+			if (TimeExecution) {
+				if (_sw == null) {
+					_sw = new Stopwatch ();
+				}
+				_sw.Reset ();
+				_sw.Start ();
+			}
 
-            var r = cmd.ExecuteNonQuery ();
+			var r = cmd.ExecuteNonQuery ();
 
-            if (TimeExecution) {
-                _sw.Stop ();
-                _elapsedMilliseconds += _sw.ElapsedMilliseconds;
-                Tracer?.Invoke (string.Format ("Finished in {0} ms ({1:0.0} s total)", _sw.ElapsedMilliseconds, _elapsedMilliseconds / 1000.0));
-            }
+			if (TimeExecution) {
+				_sw.Stop ();
+				_elapsedMilliseconds += _sw.ElapsedMilliseconds;
+				Tracer?.Invoke (string.Format ("Finished in {0} ms ({1:0.0} s total)", _sw.ElapsedMilliseconds, _elapsedMilliseconds / 1000.0));
+			}
 
-            return r;
-        }
+			return r;
+		}
 
-        /// <summary>
-        /// Creates a SQLiteCommand given the command text (SQL) with arguments. Place a '?'
-        /// in the command text for each of the arguments and then executes that command.
-        /// Use this method when return primitive values.
-        /// You can set the Trace or TimeExecution properties of the connection
-        /// to profile execution.
-        /// </summary>
-        /// <param name="query">
-        /// The fully escaped SQL.
-        /// </param>
-        /// <param name="args">
-        /// Arguments to substitute for the occurences of '?' in the query.
-        /// </param>
-        /// <returns>
-        /// The number of rows modified in the database as a result of this execution.
-        /// </returns>
-        public T ExecuteScalar<T> (string query, params object[] args)
-        {
-            var cmd = CreateCommand (query, args);
+		/// <summary>
+		/// Creates a SQLiteCommand given the command text (SQL) with arguments. Place a '?'
+		/// in the command text for each of the arguments and then executes that command.
+		/// Use this method when return primitive values.
+		/// You can set the Trace or TimeExecution properties of the connection
+		/// to profile execution.
+		/// </summary>
+		/// <param name="query">
+		/// The fully escaped SQL.
+		/// </param>
+		/// <param name="args">
+		/// Arguments to substitute for the occurences of '?' in the query.
+		/// </param>
+		/// <returns>
+		/// The number of rows modified in the database as a result of this execution.
+		/// </returns>
+		public T ExecuteScalar<T> (string query, params object[] args)
+		{
+			var cmd = CreateCommand (query, args);
 
-            if (TimeExecution) {
-                if (_sw == null) {
-                    _sw = new Stopwatch ();
-                }
-                _sw.Reset ();
-                _sw.Start ();
-            }
+			if (TimeExecution) {
+				if (_sw == null) {
+					_sw = new Stopwatch ();
+				}
+				_sw.Reset ();
+				_sw.Start ();
+			}
 
-            var r = cmd.ExecuteScalar<T> ();
+			var r = cmd.ExecuteScalar<T> ();
 
-            if (TimeExecution) {
-                _sw.Stop ();
-                _elapsedMilliseconds += _sw.ElapsedMilliseconds;
-                Tracer?.Invoke (string.Format ("Finished in {0} ms ({1:0.0} s total)", _sw.ElapsedMilliseconds, _elapsedMilliseconds / 1000.0));
-            }
+			if (TimeExecution) {
+				_sw.Stop ();
+				_elapsedMilliseconds += _sw.ElapsedMilliseconds;
+				Tracer?.Invoke (string.Format ("Finished in {0} ms ({1:0.0} s total)", _sw.ElapsedMilliseconds, _elapsedMilliseconds / 1000.0));
+			}
 
-            return r;
-        }
+			return r;
+		}
 
-        /// <summary>
-        /// Creates a SQLiteCommand given the command text (SQL) with arguments. Place a '?'
-        /// in the command text for each of the arguments and then executes that command.
-        /// It returns each row of the result using the mapping automatically generated for
-        /// the given type.
-        /// </summary>
-        /// <param name="query">
-        /// The fully escaped SQL.
-        /// </param>
-        /// <param name="args">
-        /// Arguments to substitute for the occurences of '?' in the query.
-        /// </param>
-        /// <returns>
-        /// An enumerable with one result for each row returned by the query.
-        /// </returns>
-        public List<T> Query<
+		/// <summary>
+		/// Creates a SQLiteCommand given the command text (SQL) with arguments. Place a '?'
+		/// in the command text for each of the arguments and then executes that command.
+		/// It returns each row of the result using the mapping automatically generated for
+		/// the given type.
+		/// </summary>
+		/// <param name="query">
+		/// The fully escaped SQL.
+		/// </param>
+		/// <param name="args">
+		/// Arguments to substitute for the occurences of '?' in the query.
+		/// </param>
+		/// <returns>
+		/// An enumerable with one result for each row returned by the query.
+		/// </returns>
+		public List<T> Query<
 #if NET8_0_OR_GREATER
 			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
 #endif
 			T> (string query, params object[] args) where T : new()
-        {
-            var cmd = CreateCommand (query, args);
-            return cmd.ExecuteQuery<T> ();
-        }
+		{
+			var cmd = CreateCommand (query, args);
+			return cmd.ExecuteQuery<T> ();
+		}
 
-        /// <summary>
-        /// Creates a SQLiteCommand given the command text (SQL) with arguments. Place a '?'
-        /// in the command text for each of the arguments and then executes that command.
-        /// It returns the first column of each row of the result.
-        /// </summary>
-        /// <param name="query">
-        /// The fully escaped SQL.
-        /// </param>
-        /// <param name="args">
-        /// Arguments to substitute for the occurences of '?' in the query.
-        /// </param>
-        /// <returns>
-        /// An enumerable with one result for the first column of each row returned by the query.
-        /// </returns>
-        public List<T> QueryScalars<T> (string query, params object[] args)
-        {
-            var cmd = CreateCommand (query, args);
-            return cmd.ExecuteQueryScalars<T> ().ToList ();
-        }
+		/// <summary>
+		/// Creates a SQLiteCommand given the command text (SQL) with arguments. Place a '?'
+		/// in the command text for each of the arguments and then executes that command.
+		/// It returns the first column of each row of the result.
+		/// </summary>
+		/// <param name="query">
+		/// The fully escaped SQL.
+		/// </param>
+		/// <param name="args">
+		/// Arguments to substitute for the occurences of '?' in the query.
+		/// </param>
+		/// <returns>
+		/// An enumerable with one result for the first column of each row returned by the query.
+		/// </returns>
+		public List<T> QueryScalars<T> (string query, params object[] args)
+		{
+			var cmd = CreateCommand (query, args);
+			return cmd.ExecuteQueryScalars<T> ().ToList ();
+		}
 
-        /// <summary>
-        /// Creates a SQLiteCommand given the command text (SQL) with arguments. Place a '?'
-        /// in the command text for each of the arguments and then executes that command.
-        /// It returns each row of the result using the mapping automatically generated for
-        /// the given type.
-        /// </summary>
-        /// <param name="query">
-        /// The fully escaped SQL.
-        /// </param>
-        /// <param name="args">
-        /// Arguments to substitute for the occurences of '?' in the query.
-        /// </param>
-        /// <returns>
-        /// An enumerable with one result for each row returned by the query.
-        /// The enumerator (retrieved by calling GetEnumerator() on the result of this method)
-        /// will call sqlite3_step on each call to MoveNext, so the database
-        /// connection must remain open for the lifetime of the enumerator.
-        /// </returns>
-        public IEnumerable<T> DeferredQuery<
+		/// <summary>
+		/// Creates a SQLiteCommand given the command text (SQL) with arguments. Place a '?'
+		/// in the command text for each of the arguments and then executes that command.
+		/// It returns each row of the result using the mapping automatically generated for
+		/// the given type.
+		/// </summary>
+		/// <param name="query">
+		/// The fully escaped SQL.
+		/// </param>
+		/// <param name="args">
+		/// Arguments to substitute for the occurences of '?' in the query.
+		/// </param>
+		/// <returns>
+		/// An enumerable with one result for each row returned by the query.
+		/// The enumerator (retrieved by calling GetEnumerator() on the result of this method)
+		/// will call sqlite3_step on each call to MoveNext, so the database
+		/// connection must remain open for the lifetime of the enumerator.
+		/// </returns>
+		public IEnumerable<T> DeferredQuery<
 #if NET8_0_OR_GREATER
 			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
 #endif
 			T> (string query, params object[] args) where T : new()
-        {
-            var cmd = CreateCommand (query, args);
-            return cmd.ExecuteDeferredQuery<T> ();
-        }
+		{
+			var cmd = CreateCommand (query, args);
+			return cmd.ExecuteDeferredQuery<T> ();
+		}
 
-        /// <summary>
-        /// Creates a SQLiteCommand given the command text (SQL) with arguments. Place a '?'
-        /// in the command text for each of the arguments and then executes that command.
-        /// It returns each row of the result using the specified mapping. This function is
-        /// only used by libraries in order to query the database via introspection. It is
-        /// normally not used.
-        /// </summary>
-        /// <param name="map">
-        /// A <see cref="TableMapping"/> to use to convert the resulting rows
-        /// into objects.
-        /// </param>
-        /// <param name="query">
-        /// The fully escaped SQL.
-        /// </param>
-        /// <param name="args">
-        /// Arguments to substitute for the occurences of '?' in the query.
-        /// </param>
-        /// <returns>
-        /// An enumerable with one result for each row returned by the query.
-        /// </returns>
-        public List<object> Query (TableMapping map, string query, params object[] args)
-        {
-            var cmd = CreateCommand (query, args);
-            return cmd.ExecuteQuery<object> (map);
-        }
+		/// <summary>
+		/// Creates a SQLiteCommand given the command text (SQL) with arguments. Place a '?'
+		/// in the command text for each of the arguments and then executes that command.
+		/// It returns each row of the result using the specified mapping. This function is
+		/// only used by libraries in order to query the database via introspection. It is
+		/// normally not used.
+		/// </summary>
+		/// <param name="map">
+		/// A <see cref="TableMapping"/> to use to convert the resulting rows
+		/// into objects.
+		/// </param>
+		/// <param name="query">
+		/// The fully escaped SQL.
+		/// </param>
+		/// <param name="args">
+		/// Arguments to substitute for the occurences of '?' in the query.
+		/// </param>
+		/// <returns>
+		/// An enumerable with one result for each row returned by the query.
+		/// </returns>
+		public List<object> Query (TableMapping map, string query, params object[] args)
+		{
+			var cmd = CreateCommand (query, args);
+			return cmd.ExecuteQuery<object> (map);
+		}
 
-        /// <summary>
-        /// Creates a SQLiteCommand given the command text (SQL) with arguments. Place a '?'
-        /// in the command text for each of the arguments and then executes that command.
-        /// It returns each row of the result using the specified mapping. This function is
-        /// only used by libraries in order to query the database via introspection. It is
-        /// normally not used.
-        /// </summary>
-        /// <param name="map">
-        /// A <see cref="TableMapping"/> to use to convert the resulting rows
-        /// into objects.
-        /// </param>
-        /// <param name="query">
-        /// The fully escaped SQL.
-        /// </param>
-        /// <param name="args">
-        /// Arguments to substitute for the occurences of '?' in the query.
-        /// </param>
-        /// <returns>
-        /// An enumerable with one result for each row returned by the query.
-        /// The enumerator (retrieved by calling GetEnumerator() on the result of this method)
-        /// will call sqlite3_step on each call to MoveNext, so the database
-        /// connection must remain open for the lifetime of the enumerator.
-        /// </returns>
-        public IEnumerable<object> DeferredQuery (TableMapping map, string query, params object[] args)
-        {
-            var cmd = CreateCommand (query, args);
-            return cmd.ExecuteDeferredQuery<object> (map);
-        }
+		/// <summary>
+		/// Creates a SQLiteCommand given the command text (SQL) with arguments. Place a '?'
+		/// in the command text for each of the arguments and then executes that command.
+		/// It returns each row of the result using the specified mapping. This function is
+		/// only used by libraries in order to query the database via introspection. It is
+		/// normally not used.
+		/// </summary>
+		/// <param name="map">
+		/// A <see cref="TableMapping"/> to use to convert the resulting rows
+		/// into objects.
+		/// </param>
+		/// <param name="query">
+		/// The fully escaped SQL.
+		/// </param>
+		/// <param name="args">
+		/// Arguments to substitute for the occurences of '?' in the query.
+		/// </param>
+		/// <returns>
+		/// An enumerable with one result for each row returned by the query.
+		/// The enumerator (retrieved by calling GetEnumerator() on the result of this method)
+		/// will call sqlite3_step on each call to MoveNext, so the database
+		/// connection must remain open for the lifetime of the enumerator.
+		/// </returns>
+		public IEnumerable<object> DeferredQuery (TableMapping map, string query, params object[] args)
+		{
+			var cmd = CreateCommand (query, args);
+			return cmd.ExecuteDeferredQuery<object> (map);
+		}
 
-        /// <summary>
-        /// Returns a queryable interface to the table represented by the given type.
-        /// </summary>
-        /// <returns>
-        /// A queryable object that is able to translate Where, OrderBy, and Take
-        /// queries into native SQL.
-        /// </returns>
-        public TableQuery<T> Table<
+		/// <summary>
+		/// Returns a queryable interface to the table represented by the given type.
+		/// </summary>
+		/// <returns>
+		/// A queryable object that is able to translate Where, OrderBy, and Take
+		/// queries into native SQL.
+		/// </returns>
+		public TableQuery<T> Table<
 #if NET8_0_OR_GREATER
 			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
 #endif
 			T> () where T : new()
-        {
-            return new TableQuery<T> (this);
-        }
+		{
+			return new TableQuery<T> (this);
+		}
 
-        /// <summary>
-        /// Attempts to retrieve an object with the given primary key from the table
-        /// associated with the specified type. Use of this method requires that
-        /// the given type have a designated PrimaryKey (using the PrimaryKeyAttribute).
-        /// </summary>
-        /// <param name="pk">
-        /// The primary key.
-        /// </param>
-        /// <returns>
-        /// The object with the given primary key. Throws a not found exception
-        /// if the object is not found.
-        /// </returns>
-        public T Get<
+		/// <summary>
+		/// Attempts to retrieve an object with the given primary key from the table
+		/// associated with the specified type. Use of this method requires that
+		/// the given type have a designated PrimaryKey (using the PrimaryKeyAttribute).
+		/// </summary>
+		/// <param name="pk">
+		/// The primary key.
+		/// </param>
+		/// <returns>
+		/// The object with the given primary key. Throws a not found exception
+		/// if the object is not found.
+		/// </returns>
+		public T Get<
 #if NET8_0_OR_GREATER
 			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
 #endif
 			T> (object pk) where T : new()
-        {
-            var map = GetMapping (typeof (T));
-            return Query<T> (map.GetByPrimaryKeySql, pk).First ();
-        }
+		{
+			var map = GetMapping (typeof (T));
+			return Query<T> (map.GetByPrimaryKeySql, pk).First ();
+		}
 
-        /// <summary>
-        /// Attempts to retrieve an object with the given primary key from the table
-        /// associated with the specified type. Use of this method requires that
-        /// the given type have a designated PrimaryKey (using the PrimaryKeyAttribute).
-        /// </summary>
-        /// <param name="pk">
-        /// The primary key.
-        /// </param>
-        /// <param name="map">
-        /// The TableMapping used to identify the table.
-        /// </param>
-        /// <returns>
-        /// The object with the given primary key. Throws a not found exception
-        /// if the object is not found.
-        /// </returns>
-        public object Get (object pk, TableMapping map)
-        {
-            return Query (map, map.GetByPrimaryKeySql, pk).First ();
-        }
+		/// <summary>
+		/// Attempts to retrieve an object with the given primary key from the table
+		/// associated with the specified type. Use of this method requires that
+		/// the given type have a designated PrimaryKey (using the PrimaryKeyAttribute).
+		/// </summary>
+		/// <param name="pk">
+		/// The primary key.
+		/// </param>
+		/// <param name="map">
+		/// The TableMapping used to identify the table.
+		/// </param>
+		/// <returns>
+		/// The object with the given primary key. Throws a not found exception
+		/// if the object is not found.
+		/// </returns>
+		public object Get (object pk, TableMapping map)
+		{
+			return Query (map, map.GetByPrimaryKeySql, pk).First ();
+		}
 
-        /// <summary>
-        /// Attempts to retrieve the first object that matches the predicate from the table
-        /// associated with the specified type.
-        /// </summary>
-        /// <param name="predicate">
-        /// A predicate for which object to find.
-        /// </param>
-        /// <returns>
-        /// The object that matches the given predicate. Throws a not found exception
-        /// if the object is not found.
-        /// </returns>
-        public T Get<
+		/// <summary>
+		/// Attempts to retrieve the first object that matches the predicate from the table
+		/// associated with the specified type.
+		/// </summary>
+		/// <param name="predicate">
+		/// A predicate for which object to find.
+		/// </param>
+		/// <returns>
+		/// The object that matches the given predicate. Throws a not found exception
+		/// if the object is not found.
+		/// </returns>
+		public T Get<
 #if NET8_0_OR_GREATER
 			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
 #endif
 			T> (Expression<Func<T, bool>> predicate) where T : new()
-        {
-            return Table<T> ().Where (predicate).First ();
-        }
+		{
+			return Table<T> ().Where (predicate).First ();
+		}
 
-        /// <summary>
-        /// Attempts to retrieve an object with the given primary key from the table
-        /// associated with the specified type. Use of this method requires that
-        /// the given type have a designated PrimaryKey (using the PrimaryKeyAttribute).
-        /// </summary>
-        /// <param name="pk">
-        /// The primary key.
-        /// </param>
-        /// <returns>
-        /// The object with the given primary key or null
-        /// if the object is not found.
-        /// </returns>
-        public T Find<
+		/// <summary>
+		/// Attempts to retrieve an object with the given primary key from the table
+		/// associated with the specified type. Use of this method requires that
+		/// the given type have a designated PrimaryKey (using the PrimaryKeyAttribute).
+		/// </summary>
+		/// <param name="pk">
+		/// The primary key.
+		/// </param>
+		/// <returns>
+		/// The object with the given primary key or null
+		/// if the object is not found.
+		/// </returns>
+		public T Find<
 #if NET8_0_OR_GREATER
 			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
 #endif
 			T> (object pk) where T : new()
-        {
-            var map = GetMapping (typeof (T));
-            return Query<T> (map.GetByPrimaryKeySql, pk).FirstOrDefault ();
-        }
+		{
+			var map = GetMapping (typeof (T));
+			return Query<T> (map.GetByPrimaryKeySql, pk).FirstOrDefault ();
+		}
 
-        /// <summary>
-        /// Attempts to retrieve an object with the given primary key from the table
-        /// associated with the specified type. Use of this method requires that
-        /// the given type have a designated PrimaryKey (using the PrimaryKeyAttribute).
-        /// </summary>
-        /// <param name="pk">
-        /// The primary key.
-        /// </param>
-        /// <param name="map">
-        /// The TableMapping used to identify the table.
-        /// </param>
-        /// <returns>
-        /// The object with the given primary key or null
-        /// if the object is not found.
-        /// </returns>
-        public object Find (object pk, TableMapping map)
-        {
-            return Query (map, map.GetByPrimaryKeySql, pk).FirstOrDefault ();
-        }
+		/// <summary>
+		/// Attempts to retrieve an object with the given primary key from the table
+		/// associated with the specified type. Use of this method requires that
+		/// the given type have a designated PrimaryKey (using the PrimaryKeyAttribute).
+		/// </summary>
+		/// <param name="pk">
+		/// The primary key.
+		/// </param>
+		/// <param name="map">
+		/// The TableMapping used to identify the table.
+		/// </param>
+		/// <returns>
+		/// The object with the given primary key or null
+		/// if the object is not found.
+		/// </returns>
+		public object Find (object pk, TableMapping map)
+		{
+			return Query (map, map.GetByPrimaryKeySql, pk).FirstOrDefault ();
+		}
 
-        /// <summary>
-        /// Attempts to retrieve the first object that matches the predicate from the table
-        /// associated with the specified type.
-        /// </summary>
-        /// <param name="predicate">
-        /// A predicate for which object to find.
-        /// </param>
-        /// <returns>
-        /// The object that matches the given predicate or null
-        /// if the object is not found.
-        /// </returns>
-        public T Find<
+		/// <summary>
+		/// Attempts to retrieve the first object that matches the predicate from the table
+		/// associated with the specified type.
+		/// </summary>
+		/// <param name="predicate">
+		/// A predicate for which object to find.
+		/// </param>
+		/// <returns>
+		/// The object that matches the given predicate or null
+		/// if the object is not found.
+		/// </returns>
+		public T Find<
 #if NET8_0_OR_GREATER
 			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
 #endif
 			T> (Expression<Func<T, bool>> predicate) where T : new()
-        {
-            return Table<T> ().Where (predicate).FirstOrDefault ();
-        }
+		{
+			return Table<T> ().Where (predicate).FirstOrDefault ();
+		}
 
-        /// <summary>
-        /// Attempts to retrieve the first object that matches the query from the table
-        /// associated with the specified type.
-        /// </summary>
-        /// <param name="query">
-        /// The fully escaped SQL.
-        /// </param>
-        /// <param name="args">
-        /// Arguments to substitute for the occurences of '?' in the query.
-        /// </param>
-        /// <returns>
-        /// The object that matches the given predicate or null
-        /// if the object is not found.
-        /// </returns>
-        public T FindWithQuery<
+		/// <summary>
+		/// Attempts to retrieve the first object that matches the query from the table
+		/// associated with the specified type.
+		/// </summary>
+		/// <param name="query">
+		/// The fully escaped SQL.
+		/// </param>
+		/// <param name="args">
+		/// Arguments to substitute for the occurences of '?' in the query.
+		/// </param>
+		/// <returns>
+		/// The object that matches the given predicate or null
+		/// if the object is not found.
+		/// </returns>
+		public T FindWithQuery<
 #if NET8_0_OR_GREATER
 			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
 #endif
 			T> (string query, params object[] args) where T : new()
-        {
-            return Query<T> (query, args).FirstOrDefault ();
-        }
+		{
+			return Query<T> (query, args).FirstOrDefault ();
+		}
 
-        /// <summary>
-        /// Attempts to retrieve the first object that matches the query from the table
-        /// associated with the specified type.
-        /// </summary>
-        /// <param name="map">
-        /// The TableMapping used to identify the table.
-        /// </param>
-        /// <param name="query">
-        /// The fully escaped SQL.
-        /// </param>
-        /// <param name="args">
-        /// Arguments to substitute for the occurences of '?' in the query.
-        /// </param>
-        /// <returns>
-        /// The object that matches the given predicate or null
-        /// if the object is not found.
-        /// </returns>
-        public object FindWithQuery (TableMapping map, string query, params object[] args)
-        {
-            return Query (map, query, args).FirstOrDefault ();
-        }
+		/// <summary>
+		/// Attempts to retrieve the first object that matches the query from the table
+		/// associated with the specified type.
+		/// </summary>
+		/// <param name="map">
+		/// The TableMapping used to identify the table.
+		/// </param>
+		/// <param name="query">
+		/// The fully escaped SQL.
+		/// </param>
+		/// <param name="args">
+		/// Arguments to substitute for the occurences of '?' in the query.
+		/// </param>
+		/// <returns>
+		/// The object that matches the given predicate or null
+		/// if the object is not found.
+		/// </returns>
+		public object FindWithQuery (TableMapping map, string query, params object[] args)
+		{
+			return Query (map, query, args).FirstOrDefault ();
+		}
 
-        /// <summary>
-        /// Whether <see cref="BeginTransaction"/> has been called and the database is waiting for a <see cref="Commit"/>.
-        /// </summary>
-        public bool IsInTransaction {
-            get { return _transactionDepth > 0; }
-        }
+		/// <summary>
+		/// Whether <see cref="BeginTransaction"/> has been called and the database is waiting for a <see cref="Commit"/>.
+		/// </summary>
+		public bool IsInTransaction {
+			get { return _transactionDepth > 0; }
+		}
 
-        /// <summary>
-        /// Begins a new transaction. Call <see cref="Commit"/> to end the transaction.
-        /// </summary>
-        /// <example cref="System.InvalidOperationException">Throws if a transaction has already begun.</example>
-        public void BeginTransaction ()
-        {
-            // The BEGIN command only works if the transaction stack is empty,
-            //    or in other words if there are no pending transactions.
-            // If the transaction stack is not empty when the BEGIN command is invoked,
-            //    then the command fails with an error.
-            // Rather than crash with an error, we will just ignore calls to BeginTransaction
-            //    that would result in an error.
-            if (Interlocked.CompareExchange (ref _transactionDepth, 1, 0) == 0) {
-                try {
-                    Execute ("begin transaction");
-                }
-                catch (Exception ex) {
-                    var sqlExp = ex as SQLiteException;
-                    if (sqlExp != null) {
-                        // It is recommended that applications respond to the errors listed below
-                        //    by explicitly issuing a ROLLBACK command.
-                        // TODO: This rollback failsafe should be localized to all throw sites.
-                        switch (sqlExp.Result) {
-                            case SQLite3.Result.IOError:
-                            case SQLite3.Result.Full:
-                            case SQLite3.Result.Busy:
-                            case SQLite3.Result.NoMem:
-                            case SQLite3.Result.Interrupt:
-                                RollbackTo (null, true);
-                                break;
-                        }
-                    }
-                    else {
-                        // Call decrement and not VolatileWrite in case we've already
-                        //    created a transaction point in SaveTransactionPoint since the catch.
-                        Interlocked.Decrement (ref _transactionDepth);
-                    }
+		/// <summary>
+		/// Begins a new transaction. Call <see cref="Commit"/> to end the transaction.
+		/// </summary>
+		/// <example cref="System.InvalidOperationException">Throws if a transaction has already begun.</example>
+		public void BeginTransaction ()
+		{
+			// The BEGIN command only works if the transaction stack is empty,
+			//    or in other words if there are no pending transactions.
+			// If the transaction stack is not empty when the BEGIN command is invoked,
+			//    then the command fails with an error.
+			// Rather than crash with an error, we will just ignore calls to BeginTransaction
+			//    that would result in an error.
+			if (Interlocked.CompareExchange (ref _transactionDepth, 1, 0) == 0) {
+				try {
+					Execute ("begin transaction");
+				}
+				catch (Exception ex) {
+					var sqlExp = ex as SQLiteException;
+					if (sqlExp != null) {
+						// It is recommended that applications respond to the errors listed below
+						//    by explicitly issuing a ROLLBACK command.
+						// TODO: This rollback failsafe should be localized to all throw sites.
+						switch (sqlExp.Result) {
+							case SQLite3.Result.IOError:
+							case SQLite3.Result.Full:
+							case SQLite3.Result.Busy:
+							case SQLite3.Result.NoMem:
+							case SQLite3.Result.Interrupt:
+								RollbackTo (null, true);
+								break;
+						}
+					}
+					else {
+						// Call decrement and not VolatileWrite in case we've already
+						//    created a transaction point in SaveTransactionPoint since the catch.
+						Interlocked.Decrement (ref _transactionDepth);
+					}
 
-                    throw;
-                }
-            }
-            else {
-                // Calling BeginTransaction on an already open transaction is invalid
-                throw new InvalidOperationException ("Cannot begin a transaction while already in a transaction.");
-            }
-        }
+					throw;
+				}
+			}
+			else {
+				// Calling BeginTransaction on an already open transaction is invalid
+				throw new InvalidOperationException ("Cannot begin a transaction while already in a transaction.");
+			}
+		}
 
-        /// <summary>
-        /// Creates a savepoint in the database at the current point in the transaction timeline.
-        /// Begins a new transaction if one is not in progress.
-        ///
-        /// Call <see cref="RollbackTo(string)"/> to undo transactions since the returned savepoint.
-        /// Call <see cref="Release"/> to commit transactions after the savepoint returned here.
-        /// Call <see cref="Commit"/> to end the transaction, committing all changes.
-        /// </summary>
-        /// <returns>A string naming the savepoint.</returns>
-        public string SaveTransactionPoint ()
-        {
-            int depth = Interlocked.Increment (ref _transactionDepth) - 1;
-            string retVal = "S" + _rand.Next (short.MaxValue) + "D" + depth;
+		/// <summary>
+		/// Creates a savepoint in the database at the current point in the transaction timeline.
+		/// Begins a new transaction if one is not in progress.
+		///
+		/// Call <see cref="RollbackTo(string)"/> to undo transactions since the returned savepoint.
+		/// Call <see cref="Release"/> to commit transactions after the savepoint returned here.
+		/// Call <see cref="Commit"/> to end the transaction, committing all changes.
+		/// </summary>
+		/// <returns>A string naming the savepoint.</returns>
+		public string SaveTransactionPoint ()
+		{
+			int depth = Interlocked.Increment (ref _transactionDepth) - 1;
+			string retVal = "S" + _rand.Next (short.MaxValue) + "D" + depth;
 
-            try {
-                Execute ("savepoint " + retVal);
-            }
-            catch (Exception ex) {
-                var sqlExp = ex as SQLiteException;
-                if (sqlExp != null) {
-                    // It is recommended that applications respond to the errors listed below
-                    //    by explicitly issuing a ROLLBACK command.
-                    // TODO: This rollback failsafe should be localized to all throw sites.
-                    switch (sqlExp.Result) {
-                        case SQLite3.Result.IOError:
-                        case SQLite3.Result.Full:
-                        case SQLite3.Result.Busy:
-                        case SQLite3.Result.NoMem:
-                        case SQLite3.Result.Interrupt:
-                            RollbackTo (null, true);
-                            break;
-                    }
-                }
-                else {
-                    Interlocked.Decrement (ref _transactionDepth);
-                }
+			try {
+				Execute ("savepoint " + retVal);
+			}
+			catch (Exception ex) {
+				var sqlExp = ex as SQLiteException;
+				if (sqlExp != null) {
+					// It is recommended that applications respond to the errors listed below
+					//    by explicitly issuing a ROLLBACK command.
+					// TODO: This rollback failsafe should be localized to all throw sites.
+					switch (sqlExp.Result) {
+						case SQLite3.Result.IOError:
+						case SQLite3.Result.Full:
+						case SQLite3.Result.Busy:
+						case SQLite3.Result.NoMem:
+						case SQLite3.Result.Interrupt:
+							RollbackTo (null, true);
+							break;
+					}
+				}
+				else {
+					Interlocked.Decrement (ref _transactionDepth);
+				}
 
-                throw;
-            }
+				throw;
+			}
 
-            return retVal;
-        }
+			return retVal;
+		}
 
-        /// <summary>
-        /// Rolls back the transaction that was begun by <see cref="BeginTransaction"/> or <see cref="SaveTransactionPoint"/>.
-        /// </summary>
-        public void Rollback ()
-        {
-            RollbackTo (null, false);
-        }
+		/// <summary>
+		/// Rolls back the transaction that was begun by <see cref="BeginTransaction"/> or <see cref="SaveTransactionPoint"/>.
+		/// </summary>
+		public void Rollback ()
+		{
+			RollbackTo (null, false);
+		}
 
-        /// <summary>
-        /// Rolls back the savepoint created by <see cref="BeginTransaction"/> or SaveTransactionPoint.
-        /// </summary>
-        /// <param name="savepoint">The name of the savepoint to roll back to, as returned by <see cref="SaveTransactionPoint"/>.  If savepoint is null or empty, this method is equivalent to a call to <see cref="Rollback"/></param>
-        public void RollbackTo (string savepoint)
-        {
-            RollbackTo (savepoint, false);
-        }
+		/// <summary>
+		/// Rolls back the savepoint created by <see cref="BeginTransaction"/> or SaveTransactionPoint.
+		/// </summary>
+		/// <param name="savepoint">The name of the savepoint to roll back to, as returned by <see cref="SaveTransactionPoint"/>.  If savepoint is null or empty, this method is equivalent to a call to <see cref="Rollback"/></param>
+		public void RollbackTo (string savepoint)
+		{
+			RollbackTo (savepoint, false);
+		}
 
-        /// <summary>
-        /// Rolls back the transaction that was begun by <see cref="BeginTransaction"/>.
-        /// </summary>
-        /// <param name="savepoint">The name of the savepoint to roll back to, as returned by <see cref="SaveTransactionPoint"/>.  If savepoint is null or empty, this method is equivalent to a call to <see cref="Rollback"/></param>
-        /// <param name="noThrow">true to avoid throwing exceptions, false otherwise</param>
-        void RollbackTo (string savepoint, bool noThrow)
-        {
-            // Rolling back without a TO clause rolls backs all transactions
-            //    and leaves the transaction stack empty.
-            try {
-                if (String.IsNullOrEmpty (savepoint)) {
-                    if (Interlocked.Exchange (ref _transactionDepth, 0) > 0) {
-                        Execute ("rollback");
-                    }
-                }
-                else {
-                    DoSavePointExecute (savepoint, "rollback to ");
-                }
-            }
-            catch (SQLiteException) {
-                if (!noThrow)
-                    throw;
+		/// <summary>
+		/// Rolls back the transaction that was begun by <see cref="BeginTransaction"/>.
+		/// </summary>
+		/// <param name="savepoint">The name of the savepoint to roll back to, as returned by <see cref="SaveTransactionPoint"/>.  If savepoint is null or empty, this method is equivalent to a call to <see cref="Rollback"/></param>
+		/// <param name="noThrow">true to avoid throwing exceptions, false otherwise</param>
+		void RollbackTo (string savepoint, bool noThrow)
+		{
+			// Rolling back without a TO clause rolls backs all transactions
+			//    and leaves the transaction stack empty.
+			try {
+				if (String.IsNullOrEmpty (savepoint)) {
+					if (Interlocked.Exchange (ref _transactionDepth, 0) > 0) {
+						Execute ("rollback");
+					}
+				}
+				else {
+					DoSavePointExecute (savepoint, "rollback to ");
+				}
+			}
+			catch (SQLiteException) {
+				if (!noThrow)
+					throw;
 
-            }
-            // No need to rollback if there are no transactions open.
-        }
+			}
+			// No need to rollback if there are no transactions open.
+		}
 
-        /// <summary>
-        /// Releases a savepoint returned from <see cref="SaveTransactionPoint"/>.  Releasing a savepoint
-        ///    makes changes since that savepoint permanent if the savepoint began the transaction,
-        ///    or otherwise the changes are permanent pending a call to <see cref="Commit"/>.
-        ///
-        /// The RELEASE command is like a COMMIT for a SAVEPOINT.
-        /// </summary>
-        /// <param name="savepoint">The name of the savepoint to release.  The string should be the result of a call to <see cref="SaveTransactionPoint"/></param>
-        public void Release (string savepoint)
-        {
-            try {
-                DoSavePointExecute (savepoint, "release ");
-            }
-            catch (SQLiteException ex) {
-                if (ex.Result == SQLite3.Result.Busy) {
-                    // Force a rollback since most people don't know this function can fail
-                    // Don't call Rollback() since the _transactionDepth is 0 and it won't try
-                    // Calling rollback makes our _transactionDepth variable correct.
-                    // Writes to the database only happen at depth=0, so this failure will only happen then.
-                    try {
-                        Execute ("rollback");
-                    }
-                    catch {
-                        // rollback can fail in all sorts of wonderful version-dependent ways. Let's just hope for the best
-                    }
-                }
-                throw;
-            }
-        }
+		/// <summary>
+		/// Releases a savepoint returned from <see cref="SaveTransactionPoint"/>.  Releasing a savepoint
+		///    makes changes since that savepoint permanent if the savepoint began the transaction,
+		///    or otherwise the changes are permanent pending a call to <see cref="Commit"/>.
+		///
+		/// The RELEASE command is like a COMMIT for a SAVEPOINT.
+		/// </summary>
+		/// <param name="savepoint">The name of the savepoint to release.  The string should be the result of a call to <see cref="SaveTransactionPoint"/></param>
+		public void Release (string savepoint)
+		{
+			try {
+				DoSavePointExecute (savepoint, "release ");
+			}
+			catch (SQLiteException ex) {
+				if (ex.Result == SQLite3.Result.Busy) {
+					// Force a rollback since most people don't know this function can fail
+					// Don't call Rollback() since the _transactionDepth is 0 and it won't try
+					// Calling rollback makes our _transactionDepth variable correct.
+					// Writes to the database only happen at depth=0, so this failure will only happen then.
+					try {
+						Execute ("rollback");
+					}
+					catch {
+						// rollback can fail in all sorts of wonderful version-dependent ways. Let's just hope for the best
+					}
+				}
+				throw;
+			}
+		}
 
-        void DoSavePointExecute (string savepoint, string cmd)
-        {
-            // Validate the savepoint
-            int firstLen = savepoint.IndexOf ('D');
-            if (firstLen >= 2 && savepoint.Length > firstLen + 1) {
-                int depth;
-                if (Int32.TryParse (savepoint.Substring (firstLen + 1), out depth)) {
-                    // TODO: Mild race here, but inescapable without locking almost everywhere.
-                    if (0 <= depth && depth < _transactionDepth) {
+		void DoSavePointExecute (string savepoint, string cmd)
+		{
+			// Validate the savepoint
+			int firstLen = savepoint.IndexOf ('D');
+			if (firstLen >= 2 && savepoint.Length > firstLen + 1) {
+				int depth;
+				if (Int32.TryParse (savepoint.Substring (firstLen + 1), out depth)) {
+					// TODO: Mild race here, but inescapable without locking almost everywhere.
+					if (0 <= depth && depth < _transactionDepth) {
 #if NETFX_CORE || USE_SQLITEPCL_RAW || NETCORE
-                        Volatile.Write (ref _transactionDepth, depth);
+						Volatile.Write (ref _transactionDepth, depth);
 #elif SILVERLIGHT
-                        _transactionDepth = depth;
+						_transactionDepth = depth;
 #else
-                        Thread.VolatileWrite (ref _transactionDepth, depth);
+						Thread.VolatileWrite (ref _transactionDepth, depth);
 #endif
-                        Execute (cmd + savepoint);
-                        return;
-                    }
-                }
-            }
+						Execute (cmd + savepoint);
+						return;
+					}
+				}
+			}
 
-            throw new ArgumentException ("savePoint is not valid, and should be the result of a call to SaveTransactionPoint.", "savePoint");
-        }
+			throw new ArgumentException ("savePoint is not valid, and should be the result of a call to SaveTransactionPoint.", "savePoint");
+		}
 
-        /// <summary>
-        /// Commits the transaction that was begun by <see cref="BeginTransaction"/>.
-        /// </summary>
-        public void Commit ()
-        {
-            if (Interlocked.Exchange (ref _transactionDepth, 0) != 0) {
-                try {
-                    Execute ("commit");
-                }
-                catch {
-                    // Force a rollback since most people don't know this function can fail
-                    // Don't call Rollback() since the _transactionDepth is 0 and it won't try
-                    // Calling rollback makes our _transactionDepth variable correct.
-                    try {
-                        Execute ("rollback");
-                    }
-                    catch {
-                        // rollback can fail in all sorts of wonderful version-dependent ways. Let's just hope for the best
-                    }
-                    throw;
-                }
-            }
-            // Do nothing on a commit with no open transaction
-        }
+		/// <summary>
+		/// Commits the transaction that was begun by <see cref="BeginTransaction"/>.
+		/// </summary>
+		public void Commit ()
+		{
+			if (Interlocked.Exchange (ref _transactionDepth, 0) != 0) {
+				try {
+					Execute ("commit");
+				}
+				catch {
+					// Force a rollback since most people don't know this function can fail
+					// Don't call Rollback() since the _transactionDepth is 0 and it won't try
+					// Calling rollback makes our _transactionDepth variable correct.
+					try {
+						Execute ("rollback");
+					}
+					catch {
+						// rollback can fail in all sorts of wonderful version-dependent ways. Let's just hope for the best
+					}
+					throw;
+				}
+			}
+			// Do nothing on a commit with no open transaction
+		}
 
-        /// <summary>
-        /// Executes <paramref name="action"/> within a (possibly nested) transaction by wrapping it in a SAVEPOINT. If an
-        /// exception occurs the whole transaction is rolled back, not just the current savepoint. The exception
-        /// is rethrown.
-        /// </summary>
-        /// <param name="action">
-        /// The <see cref="Action"/> to perform within a transaction. <paramref name="action"/> can contain any number
-        /// of operations on the connection but should never call <see cref="BeginTransaction"/> or
-        /// <see cref="Commit"/>.
-        /// </param>
-        public void RunInTransaction (Action action)
-        {
-            try {
-                var savePoint = SaveTransactionPoint ();
-                action ();
-                Release (savePoint);
-            }
-            catch (Exception) {
-                Rollback ();
-                throw;
-            }
-        }
+		/// <summary>
+		/// Executes <paramref name="action"/> within a (possibly nested) transaction by wrapping it in a SAVEPOINT. If an
+		/// exception occurs the whole transaction is rolled back, not just the current savepoint. The exception
+		/// is rethrown.
+		/// </summary>
+		/// <param name="action">
+		/// The <see cref="Action"/> to perform within a transaction. <paramref name="action"/> can contain any number
+		/// of operations on the connection but should never call <see cref="BeginTransaction"/> or
+		/// <see cref="Commit"/>.
+		/// </param>
+		public void RunInTransaction (Action action)
+		{
+			try {
+				var savePoint = SaveTransactionPoint ();
+				action ();
+				Release (savePoint);
+			}
+			catch (Exception) {
+				Rollback ();
+				throw;
+			}
+		}
 
 		/// <summary>
 		/// Inserts all specified objects.
@@ -1959,22 +1959,22 @@ namespace SQLite
 		[RequiresUnreferencedCode ("This method requires ''DynamicallyAccessedMemberTypes.All' on the runtime type of all objects in 'objects'.")]
 #endif
 		public int InsertAll (System.Collections.IEnumerable objects, bool runInTransaction = true)
-        {
-            var c = 0;
-            if (runInTransaction) {
-                RunInTransaction (() => {
-                    foreach (var r in objects) {
-                        c += Insert (r);
-                    }
-                });
-            }
-            else {
-                foreach (var r in objects) {
-                    c += Insert (r);
-                }
-            }
-            return c;
-        }
+		{
+			var c = 0;
+			if (runInTransaction) {
+				RunInTransaction (() => {
+					foreach (var r in objects) {
+						c += Insert (r);
+					}
+				});
+			}
+			else {
+				foreach (var r in objects) {
+					c += Insert (r);
+				}
+			}
+			return c;
+		}
 
 		/// <summary>
 		/// Inserts all specified objects.
@@ -1995,61 +1995,61 @@ namespace SQLite
 		[RequiresUnreferencedCode ("This method requires ''DynamicallyAccessedMemberTypes.All' on the runtime type of all objects in 'objects'.")]
 #endif
 		public int InsertAll (System.Collections.IEnumerable objects, string extra, bool runInTransaction = true)
-        {
-            var c = 0;
-            if (runInTransaction) {
-                RunInTransaction (() => {
-                    foreach (var r in objects) {
-                        c += Insert (r, extra);
-                    }
-                });
-            }
-            else {
-                foreach (var r in objects) {
-                    c += Insert (r, extra);
-                }
-            }
-            return c;
-        }
+		{
+			var c = 0;
+			if (runInTransaction) {
+				RunInTransaction (() => {
+					foreach (var r in objects) {
+						c += Insert (r, extra);
+					}
+				});
+			}
+			else {
+				foreach (var r in objects) {
+					c += Insert (r, extra);
+				}
+			}
+			return c;
+		}
 
-        /// <summary>
-        /// Inserts all specified objects.
-        /// </summary>
-        /// <param name="objects">
-        /// An <see cref="IEnumerable"/> of the objects to insert.
-        /// </param>
-        /// <param name="objType">
-        /// The type of object to insert.
-        /// </param>
-        /// <param name="runInTransaction">
-        /// A boolean indicating if the inserts should be wrapped in a transaction.
-        /// </param>
-        /// <returns>
-        /// The number of rows added to the table.
-        /// </returns>
-        public int InsertAll (
+		/// <summary>
+		/// Inserts all specified objects.
+		/// </summary>
+		/// <param name="objects">
+		/// An <see cref="IEnumerable"/> of the objects to insert.
+		/// </param>
+		/// <param name="objType">
+		/// The type of object to insert.
+		/// </param>
+		/// <param name="runInTransaction">
+		/// A boolean indicating if the inserts should be wrapped in a transaction.
+		/// </param>
+		/// <returns>
+		/// The number of rows added to the table.
+		/// </returns>
+		public int InsertAll (
 			System.Collections.IEnumerable objects,
 #if NET8_0_OR_GREATER
 			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
 #endif
 			Type objType,
 			bool runInTransaction = true)
-        {
-            var c = 0;
-            if (runInTransaction) {
-                RunInTransaction (() => {
-                    foreach (var r in objects) {
-                        c += Insert (r, objType);
-                    }
-                });
-            }
-            else {
-                foreach (var r in objects) {
-                    c += Insert (r, objType);
-                }
-            }
-            return c;
-        }
+		{
+			var c = 0;
+			if (runInTransaction) {
+				RunInTransaction (() => {
+					foreach (var r in objects) {
+						c += Insert (r, objType);
+					}
+				});
+			}
+			else {
+				foreach (var r in objects) {
+					c += Insert (r, objType);
+				}
+			}
+			return c;
+		}
 
 		/// <summary>
 		/// Inserts the given object (and updates its
@@ -2066,12 +2066,12 @@ namespace SQLite
 		[RequiresUnreferencedCode("This method requires ''DynamicallyAccessedMemberTypes.All' on the runtime type of 'obj'.")]
 #endif
 		public int Insert (object obj)
-        {
-            if (obj == null) {
-                return 0;
-            }
-            return Insert (obj, "", Orm.GetType (obj));
-        }
+		{
+			if (obj == null) {
+				return 0;
+			}
+			return Insert (obj, "", Orm.GetType (obj));
+		}
 
 		/// <summary>
 		/// Inserts the given object (and updates its
@@ -2091,63 +2091,63 @@ namespace SQLite
 		[RequiresUnreferencedCode ("This method requires ''DynamicallyAccessedMemberTypes.All' on the runtime type of 'obj'.")]
 #endif
 		public int InsertOrReplace (object obj)
-        {
-            if (obj == null) {
-                return 0;
-            }
-            return Insert (obj, "OR REPLACE", Orm.GetType (obj));
-        }
+		{
+			if (obj == null) {
+				return 0;
+			}
+			return Insert (obj, "OR REPLACE", Orm.GetType (obj));
+		}
 
-        /// <summary>
-        /// Inserts the given object (and updates its
-        /// auto incremented primary key if it has one).
-        /// The return value is the number of rows added to the table.
-        /// </summary>
-        /// <param name="obj">
-        /// The object to insert.
-        /// </param>
-        /// <param name="objType">
-        /// The type of object to insert.
-        /// </param>
-        /// <returns>
-        /// The number of rows added to the table.
-        /// </returns>
-        public int Insert (
+		/// <summary>
+		/// Inserts the given object (and updates its
+		/// auto incremented primary key if it has one).
+		/// The return value is the number of rows added to the table.
+		/// </summary>
+		/// <param name="obj">
+		/// The object to insert.
+		/// </param>
+		/// <param name="objType">
+		/// The type of object to insert.
+		/// </param>
+		/// <returns>
+		/// The number of rows added to the table.
+		/// </returns>
+		public int Insert (
 			object obj,
 #if NET8_0_OR_GREATER
 			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
 #endif
 			Type objType)
-        {
-            return Insert (obj, "", objType);
-        }
+		{
+			return Insert (obj, "", objType);
+		}
 
-        /// <summary>
-        /// Inserts the given object (and updates its
-        /// auto incremented primary key if it has one).
-        /// The return value is the number of rows added to the table.
-        /// If a UNIQUE constraint violation occurs with
-        /// some pre-existing object, this function deletes
-        /// the old object.
-        /// </summary>
-        /// <param name="obj">
-        /// The object to insert.
-        /// </param>
-        /// <param name="objType">
-        /// The type of object to insert.
-        /// </param>
-        /// <returns>
-        /// The number of rows modified.
-        /// </returns>
-        public int InsertOrReplace (
+		/// <summary>
+		/// Inserts the given object (and updates its
+		/// auto incremented primary key if it has one).
+		/// The return value is the number of rows added to the table.
+		/// If a UNIQUE constraint violation occurs with
+		/// some pre-existing object, this function deletes
+		/// the old object.
+		/// </summary>
+		/// <param name="obj">
+		/// The object to insert.
+		/// </param>
+		/// <param name="objType">
+		/// The type of object to insert.
+		/// </param>
+		/// <returns>
+		/// The number of rows modified.
+		/// </returns>
+		public int InsertOrReplace (
 			object obj,
 #if NET8_0_OR_GREATER
 			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
 #endif
 			Type objType)
-        {
-            return Insert (obj, "OR REPLACE", objType);
-        }
+		{
+			return Insert (obj, "OR REPLACE", objType);
+		}
 
 		/// <summary>
 		/// Inserts the given object (and updates its
@@ -2167,138 +2167,138 @@ namespace SQLite
 		[RequiresUnreferencedCode ("This method requires ''DynamicallyAccessedMemberTypes.All' on the runtime type of 'obj'.")]
 #endif
 		public int Insert (object obj, string extra)
-        {
-            if (obj == null) {
-                return 0;
-            }
-            return Insert (obj, extra, Orm.GetType (obj));
-        }
+		{
+			if (obj == null) {
+				return 0;
+			}
+			return Insert (obj, extra, Orm.GetType (obj));
+		}
 
-        /// <summary>
-        /// Inserts the given object (and updates its
-        /// auto incremented primary key if it has one).
-        /// The return value is the number of rows added to the table.
-        /// </summary>
-        /// <param name="obj">
-        /// The object to insert.
-        /// </param>
-        /// <param name="extra">
-        /// Literal SQL code that gets placed into the command. INSERT {extra} INTO ...
-        /// </param>
-        /// <param name="objType">
-        /// The type of object to insert.
-        /// </param>
-        /// <returns>
-        /// The number of rows added to the table.
-        /// </returns>
-        public int Insert (
+		/// <summary>
+		/// Inserts the given object (and updates its
+		/// auto incremented primary key if it has one).
+		/// The return value is the number of rows added to the table.
+		/// </summary>
+		/// <param name="obj">
+		/// The object to insert.
+		/// </param>
+		/// <param name="extra">
+		/// Literal SQL code that gets placed into the command. INSERT {extra} INTO ...
+		/// </param>
+		/// <param name="objType">
+		/// The type of object to insert.
+		/// </param>
+		/// <returns>
+		/// The number of rows added to the table.
+		/// </returns>
+		public int Insert (
 			object obj,
 			string extra,
 #if NET8_0_OR_GREATER
 			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
 #endif
 			Type objType)
-        {
-            if (obj == null || objType == null) {
-                return 0;
-            }
+		{
+			if (obj == null || objType == null) {
+				return 0;
+			}
 
-            var map = GetMapping (objType);
+			var map = GetMapping (objType);
 
-            if (map.PK != null && map.PK.IsAutoGuid) {
-                if (map.PK.GetValue (obj).Equals (Guid.Empty)) {
-                    map.PK.SetValue (obj, Guid.NewGuid ());
-                }
-            }
+			if (map.PK != null && map.PK.IsAutoGuid) {
+				if (map.PK.GetValue (obj).Equals (Guid.Empty)) {
+					map.PK.SetValue (obj, Guid.NewGuid ());
+				}
+			}
 
-            var replacing = string.Compare (extra, "OR REPLACE", StringComparison.OrdinalIgnoreCase) == 0;
+			var replacing = string.Compare (extra, "OR REPLACE", StringComparison.OrdinalIgnoreCase) == 0;
 
-            var cols = replacing ? map.InsertOrReplaceColumns : map.InsertColumns;
-            var vals = new object[cols.Length];
-            for (var i = 0; i < vals.Length; i++) {
-                vals[i] = cols[i].GetValue (obj);
-            }
+			var cols = replacing ? map.InsertOrReplaceColumns : map.InsertColumns;
+			var vals = new object[cols.Length];
+			for (var i = 0; i < vals.Length; i++) {
+				vals[i] = cols[i].GetValue (obj);
+			}
 
-            var insertCmd = GetInsertCommand (map, extra);
-            int count;
+			var insertCmd = GetInsertCommand (map, extra);
+			int count;
 
-            lock (insertCmd) {
-                // We lock here to protect the prepared statement returned via GetInsertCommand.
-                // A SQLite prepared statement can be bound for only one operation at a time.
-                try {
-                    count = insertCmd.ExecuteNonQuery (vals);
-                }
-                catch (SQLiteException ex) {
-                    if (SQLite3.ExtendedErrCode (this.Handle) == SQLite3.ExtendedResult.ConstraintNotNull) {
-                        throw NotNullConstraintViolationException.New (ex.Result, ex.Message, map, obj);
-                    }
-                    throw;
-                }
+			lock (insertCmd) {
+				// We lock here to protect the prepared statement returned via GetInsertCommand.
+				// A SQLite prepared statement can be bound for only one operation at a time.
+				try {
+					count = insertCmd.ExecuteNonQuery (vals);
+				}
+				catch (SQLiteException ex) {
+					if (SQLite3.ExtendedErrCode (this.Handle) == SQLite3.ExtendedResult.ConstraintNotNull) {
+						throw NotNullConstraintViolationException.New (ex.Result, ex.Message, map, obj);
+					}
+					throw;
+				}
 
-                if (map.HasAutoIncPK) {
-                    var id = SQLite3.LastInsertRowid (Handle);
-                    map.SetAutoIncPK (obj, id);
-                }
-            }
-            if (count > 0)
-                OnTableChanged (map, NotifyTableChangedAction.Insert);
+				if (map.HasAutoIncPK) {
+					var id = SQLite3.LastInsertRowid (Handle);
+					map.SetAutoIncPK (obj, id);
+				}
+			}
+			if (count > 0)
+				OnTableChanged (map, NotifyTableChangedAction.Insert);
 
-            return count;
-        }
+			return count;
+		}
 
-        readonly Dictionary<Tuple<string, string>, PreparedSqlLiteInsertCommand> _insertCommandMap = new Dictionary<Tuple<string, string>, PreparedSqlLiteInsertCommand> ();
+		readonly Dictionary<Tuple<string, string>, PreparedSqlLiteInsertCommand> _insertCommandMap = new Dictionary<Tuple<string, string>, PreparedSqlLiteInsertCommand> ();
 
-        PreparedSqlLiteInsertCommand GetInsertCommand (TableMapping map, string extra)
-        {
-            PreparedSqlLiteInsertCommand prepCmd;
+		PreparedSqlLiteInsertCommand GetInsertCommand (TableMapping map, string extra)
+		{
+			PreparedSqlLiteInsertCommand prepCmd;
 
-            var key = Tuple.Create (map.MappedType.FullName, extra);
+			var key = Tuple.Create (map.MappedType.FullName, extra);
 
-            lock (_insertCommandMap) {
-                if (_insertCommandMap.TryGetValue (key, out prepCmd)) {
-                    return prepCmd;
-                }
-            }
+			lock (_insertCommandMap) {
+				if (_insertCommandMap.TryGetValue (key, out prepCmd)) {
+					return prepCmd;
+				}
+			}
 
-            prepCmd = CreateInsertCommand (map, extra);
+			prepCmd = CreateInsertCommand (map, extra);
 
-            lock (_insertCommandMap) {
-                if (_insertCommandMap.TryGetValue (key, out var existing)) {
-                    prepCmd.Dispose ();
-                    return existing;
-                }
+			lock (_insertCommandMap) {
+				if (_insertCommandMap.TryGetValue (key, out var existing)) {
+					prepCmd.Dispose ();
+					return existing;
+				}
 
-                _insertCommandMap.Add (key, prepCmd);
-            }
+				_insertCommandMap.Add (key, prepCmd);
+			}
 
-            return prepCmd;
-        }
+			return prepCmd;
+		}
 
-        PreparedSqlLiteInsertCommand CreateInsertCommand (TableMapping map, string extra)
-        {
-            var cols = map.InsertColumns;
-            string insertSql;
-            if (cols.Length == 0 && map.Columns.Length == 1 && map.Columns[0].IsAutoInc) {
-                insertSql = string.Format ("insert {1} into \"{0}\" default values", map.TableName, extra);
-            }
-            else {
-                var replacing = string.Compare (extra, "OR REPLACE", StringComparison.OrdinalIgnoreCase) == 0;
+		PreparedSqlLiteInsertCommand CreateInsertCommand (TableMapping map, string extra)
+		{
+			var cols = map.InsertColumns;
+			string insertSql;
+			if (cols.Length == 0 && map.Columns.Length == 1 && map.Columns[0].IsAutoInc) {
+				insertSql = string.Format ("insert {1} into \"{0}\" default values", map.TableName, extra);
+			}
+			else {
+				var replacing = string.Compare (extra, "OR REPLACE", StringComparison.OrdinalIgnoreCase) == 0;
 
-                if (replacing) {
-                    cols = map.InsertOrReplaceColumns;
-                }
+				if (replacing) {
+					cols = map.InsertOrReplaceColumns;
+				}
 
-                insertSql = string.Format ("insert {3} into \"{0}\"({1}) values ({2})", map.TableName,
-                                   string.Join (",", (from c in cols
-                                                      select "\"" + c.Name + "\"").ToArray ()),
-                                   string.Join (",", (from c in cols
-                                                      select "?").ToArray ()), extra);
+				insertSql = string.Format ("insert {3} into \"{0}\"({1}) values ({2})", map.TableName,
+								   string.Join (",", (from c in cols
+													  select "\"" + c.Name + "\"").ToArray ()),
+								   string.Join (",", (from c in cols
+													  select "?").ToArray ()), extra);
 
-            }
+			}
 
-            var insertCommand = new PreparedSqlLiteInsertCommand (this, insertSql);
-            return insertCommand;
-        }
+			var insertCommand = new PreparedSqlLiteInsertCommand (this, insertSql);
+			return insertCommand;
+		}
 
 		/// <summary>
 		/// Updates all of the columns of a table using the specified object
@@ -2315,82 +2315,82 @@ namespace SQLite
 		[RequiresUnreferencedCode ("This method requires ''DynamicallyAccessedMemberTypes.All' on the runtime type of 'obj'.")]
 #endif
 		public int Update (object obj)
-        {
-            if (obj == null) {
-                return 0;
-            }
-            return Update (obj, Orm.GetType (obj));
-        }
+		{
+			if (obj == null) {
+				return 0;
+			}
+			return Update (obj, Orm.GetType (obj));
+		}
 
-        /// <summary>
-        /// Updates all of the columns of a table using the specified object
-        /// except for its primary key.
-        /// The object is required to have a primary key.
-        /// </summary>
-        /// <param name="obj">
-        /// The object to update. It must have a primary key designated using the PrimaryKeyAttribute.
-        /// </param>
-        /// <param name="objType">
-        /// The type of object to insert.
-        /// </param>
-        /// <returns>
-        /// The number of rows updated.
-        /// </returns>
-        public int Update (
+		/// <summary>
+		/// Updates all of the columns of a table using the specified object
+		/// except for its primary key.
+		/// The object is required to have a primary key.
+		/// </summary>
+		/// <param name="obj">
+		/// The object to update. It must have a primary key designated using the PrimaryKeyAttribute.
+		/// </param>
+		/// <param name="objType">
+		/// The type of object to insert.
+		/// </param>
+		/// <returns>
+		/// The number of rows updated.
+		/// </returns>
+		public int Update (
 			object obj,
 #if NET8_0_OR_GREATER
 			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
 #endif
 			Type objType)
-        {
-            int rowsAffected = 0;
-            if (obj == null || objType == null) {
-                return 0;
-            }
+		{
+			int rowsAffected = 0;
+			if (obj == null || objType == null) {
+				return 0;
+			}
 
-            var map = GetMapping (objType);
+			var map = GetMapping (objType);
 
-            var pk = map.PK;
+			var pk = map.PK;
 
-            if (pk == null) {
-                throw new NotSupportedException ("Cannot update " + map.TableName + ": it has no PK");
-            }
+			if (pk == null) {
+				throw new NotSupportedException ("Cannot update " + map.TableName + ": it has no PK");
+			}
 
-            var cols = from p in map.Columns
-                       where p != pk
-                       select p;
-            var vals = from c in cols
-                       select c.GetValue (obj);
-            var ps = new List<object> (vals);
-            if (ps.Count == 0) {
-                // There is a PK but no accompanying data,
-                // so reset the PK to make the UPDATE work.
-                cols = map.Columns;
-                vals = from c in cols
-                       select c.GetValue (obj);
-                ps = new List<object> (vals);
-            }
-            ps.Add (pk.GetValue (obj));
-            var q = string.Format ("update \"{0}\" set {1} where \"{2}\" = ? ", map.TableName, string.Join (",", (from c in cols
-                                                                                                                  select "\"" + c.Name + "\" = ? ").ToArray ()), pk.Name);
+			var cols = from p in map.Columns
+					   where p != pk
+					   select p;
+			var vals = from c in cols
+					   select c.GetValue (obj);
+			var ps = new List<object> (vals);
+			if (ps.Count == 0) {
+				// There is a PK but no accompanying data,
+				// so reset the PK to make the UPDATE work.
+				cols = map.Columns;
+				vals = from c in cols
+					   select c.GetValue (obj);
+				ps = new List<object> (vals);
+			}
+			ps.Add (pk.GetValue (obj));
+			var q = string.Format ("update \"{0}\" set {1} where \"{2}\" = ? ", map.TableName, string.Join (",", (from c in cols
+																												  select "\"" + c.Name + "\" = ? ").ToArray ()), pk.Name);
 
-            try {
-                rowsAffected = Execute (q, ps.ToArray ());
-            }
-            catch (SQLiteException ex) {
+			try {
+				rowsAffected = Execute (q, ps.ToArray ());
+			}
+			catch (SQLiteException ex) {
 
-                if (ex.Result == SQLite3.Result.Constraint && SQLite3.ExtendedErrCode (this.Handle) == SQLite3.ExtendedResult.ConstraintNotNull) {
-                    throw NotNullConstraintViolationException.New (ex, map, obj);
-                }
+				if (ex.Result == SQLite3.Result.Constraint && SQLite3.ExtendedErrCode (this.Handle) == SQLite3.ExtendedResult.ConstraintNotNull) {
+					throw NotNullConstraintViolationException.New (ex, map, obj);
+				}
 
-                throw;
-            }
+				throw;
+			}
 
-            if (rowsAffected > 0)
-                OnTableChanged (map, NotifyTableChangedAction.Update);
+			if (rowsAffected > 0)
+				OnTableChanged (map, NotifyTableChangedAction.Update);
 
-            return rowsAffected;
-        }
+			return rowsAffected;
+		}
 
 		/// <summary>
 		/// Updates all specified objects.
@@ -2408,22 +2408,22 @@ namespace SQLite
 		[RequiresUnreferencedCode ("This method requires ''DynamicallyAccessedMemberTypes.All' on the runtime type of all objects in 'objects'.")]
 #endif
 		public int UpdateAll (System.Collections.IEnumerable objects, bool runInTransaction = true)
-        {
-            var c = 0;
-            if (runInTransaction) {
-                RunInTransaction (() => {
-                    foreach (var r in objects) {
-                        c += Update (r);
-                    }
-                });
-            }
-            else {
-                foreach (var r in objects) {
-                    c += Update (r);
-                }
-            }
-            return c;
-        }
+		{
+			var c = 0;
+			if (runInTransaction) {
+				RunInTransaction (() => {
+					foreach (var r in objects) {
+						c += Update (r);
+					}
+				});
+			}
+			else {
+				foreach (var r in objects) {
+					c += Update (r);
+				}
+			}
+			return c;
+		}
 
 		/// <summary>
 		/// Deletes the given object from the database using its primary key.
@@ -2438,1120 +2438,1120 @@ namespace SQLite
 		[RequiresUnreferencedCode ("This method requires ''DynamicallyAccessedMemberTypes.All' on the runtime type of 'objectToDelete'.")]
 #endif
 		public int Delete (object objectToDelete)
-        {
-            var map = GetMapping (Orm.GetType (objectToDelete));
-            var pk = map.PK;
-            if (pk == null) {
-                throw new NotSupportedException ("Cannot delete " + map.TableName + ": it has no PK");
-            }
-            var q = string.Format ("delete from \"{0}\" where \"{1}\" = ?", map.TableName, pk.Name);
-            var count = Execute (q, pk.GetValue (objectToDelete));
-            if (count > 0)
-                OnTableChanged (map, NotifyTableChangedAction.Delete);
-            return count;
-        }
+		{
+			var map = GetMapping (Orm.GetType (objectToDelete));
+			var pk = map.PK;
+			if (pk == null) {
+				throw new NotSupportedException ("Cannot delete " + map.TableName + ": it has no PK");
+			}
+			var q = string.Format ("delete from \"{0}\" where \"{1}\" = ?", map.TableName, pk.Name);
+			var count = Execute (q, pk.GetValue (objectToDelete));
+			if (count > 0)
+				OnTableChanged (map, NotifyTableChangedAction.Delete);
+			return count;
+		}
 
-        /// <summary>
-        /// Deletes the object with the specified primary key.
-        /// </summary>
-        /// <param name="primaryKey">
-        /// The primary key of the object to delete.
-        /// </param>
-        /// <returns>
-        /// The number of objects deleted.
-        /// </returns>
-        /// <typeparam name='T'>
-        /// The type of object.
-        /// </typeparam>
-        public int Delete<
+		/// <summary>
+		/// Deletes the object with the specified primary key.
+		/// </summary>
+		/// <param name="primaryKey">
+		/// The primary key of the object to delete.
+		/// </param>
+		/// <returns>
+		/// The number of objects deleted.
+		/// </returns>
+		/// <typeparam name='T'>
+		/// The type of object.
+		/// </typeparam>
+		public int Delete<
 #if NET8_0_OR_GREATER
 			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
 #endif
 			T> (object primaryKey)
-        {
-            return Delete (primaryKey, GetMapping (typeof (T)));
-        }
+		{
+			return Delete (primaryKey, GetMapping (typeof (T)));
+		}
 
-        /// <summary>
-        /// Deletes the object with the specified primary key.
-        /// </summary>
-        /// <param name="primaryKey">
-        /// The primary key of the object to delete.
-        /// </param>
-        /// <param name="map">
-        /// The TableMapping used to identify the table.
-        /// </param>
-        /// <returns>
-        /// The number of objects deleted.
-        /// </returns>
-        public int Delete (object primaryKey, TableMapping map)
-        {
-            var pk = map.PK;
-            if (pk == null) {
-                throw new NotSupportedException ("Cannot delete " + map.TableName + ": it has no PK");
-            }
-            var q = string.Format ("delete from \"{0}\" where \"{1}\" = ?", map.TableName, pk.Name);
-            var count = Execute (q, primaryKey);
-            if (count > 0)
-                OnTableChanged (map, NotifyTableChangedAction.Delete);
-            return count;
-        }
+		/// <summary>
+		/// Deletes the object with the specified primary key.
+		/// </summary>
+		/// <param name="primaryKey">
+		/// The primary key of the object to delete.
+		/// </param>
+		/// <param name="map">
+		/// The TableMapping used to identify the table.
+		/// </param>
+		/// <returns>
+		/// The number of objects deleted.
+		/// </returns>
+		public int Delete (object primaryKey, TableMapping map)
+		{
+			var pk = map.PK;
+			if (pk == null) {
+				throw new NotSupportedException ("Cannot delete " + map.TableName + ": it has no PK");
+			}
+			var q = string.Format ("delete from \"{0}\" where \"{1}\" = ?", map.TableName, pk.Name);
+			var count = Execute (q, primaryKey);
+			if (count > 0)
+				OnTableChanged (map, NotifyTableChangedAction.Delete);
+			return count;
+		}
 
-        /// <summary>
-        /// Deletes all the objects from the specified table.
-        /// WARNING WARNING: Let me repeat. It deletes ALL the objects from the
-        /// specified table. Do you really want to do that?
-        /// </summary>
-        /// <returns>
-        /// The number of objects deleted.
-        /// </returns>
-        /// <typeparam name='T'>
-        /// The type of objects to delete.
-        /// </typeparam>
-        public int DeleteAll<
+		/// <summary>
+		/// Deletes all the objects from the specified table.
+		/// WARNING WARNING: Let me repeat. It deletes ALL the objects from the
+		/// specified table. Do you really want to do that?
+		/// </summary>
+		/// <returns>
+		/// The number of objects deleted.
+		/// </returns>
+		/// <typeparam name='T'>
+		/// The type of objects to delete.
+		/// </typeparam>
+		public int DeleteAll<
 #if NET8_0_OR_GREATER
 			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
 #endif
 			T> ()
-        {
-            var map = GetMapping (typeof (T));
-            return DeleteAll (map);
-        }
+		{
+			var map = GetMapping (typeof (T));
+			return DeleteAll (map);
+		}
 
-        /// <summary>
-        /// Deletes all the objects from the specified table.
-        /// WARNING WARNING: Let me repeat. It deletes ALL the objects from the
-        /// specified table. Do you really want to do that?
-        /// </summary>
-        /// <param name="map">
-        /// The TableMapping used to identify the table.
-        /// </param>
-        /// <returns>
-        /// The number of objects deleted.
-        /// </returns>
-        public int DeleteAll (TableMapping map)
-        {
-            var query = string.Format ("delete from \"{0}\"", map.TableName);
-            var count = Execute (query);
-            if (count > 0)
-                OnTableChanged (map, NotifyTableChangedAction.Delete);
-            return count;
-        }
+		/// <summary>
+		/// Deletes all the objects from the specified table.
+		/// WARNING WARNING: Let me repeat. It deletes ALL the objects from the
+		/// specified table. Do you really want to do that?
+		/// </summary>
+		/// <param name="map">
+		/// The TableMapping used to identify the table.
+		/// </param>
+		/// <returns>
+		/// The number of objects deleted.
+		/// </returns>
+		public int DeleteAll (TableMapping map)
+		{
+			var query = string.Format ("delete from \"{0}\"", map.TableName);
+			var count = Execute (query);
+			if (count > 0)
+				OnTableChanged (map, NotifyTableChangedAction.Delete);
+			return count;
+		}
 
-        /// <summary>
-        /// Backup the entire database to the specified path.
-        /// </summary>
-        /// <param name="destinationDatabasePath">Path to backup file.</param>
-        /// <param name="databaseName">The name of the database to backup (usually "main").</param>
-        public void Backup (string destinationDatabasePath, string databaseName = "main")
-        {
-            // Open the destination
-            var r = SQLite3.Open (destinationDatabasePath, out var destHandle);
-            if (r != SQLite3.Result.OK) {
-                throw SQLiteException.New (r, "Failed to open destination database");
-            }
+		/// <summary>
+		/// Backup the entire database to the specified path.
+		/// </summary>
+		/// <param name="destinationDatabasePath">Path to backup file.</param>
+		/// <param name="databaseName">The name of the database to backup (usually "main").</param>
+		public void Backup (string destinationDatabasePath, string databaseName = "main")
+		{
+			// Open the destination
+			var r = SQLite3.Open (destinationDatabasePath, out var destHandle);
+			if (r != SQLite3.Result.OK) {
+				throw SQLiteException.New (r, "Failed to open destination database");
+			}
 
-            // Init the backup
-            var backup = SQLite3.BackupInit (destHandle, databaseName, Handle, databaseName);
-            if (backup == NullBackupHandle) {
-                SQLite3.Close (destHandle);
-                throw new Exception ("Failed to create backup");
-            }
+			// Init the backup
+			var backup = SQLite3.BackupInit (destHandle, databaseName, Handle, databaseName);
+			if (backup == NullBackupHandle) {
+				SQLite3.Close (destHandle);
+				throw new Exception ("Failed to create backup");
+			}
 
-            // Perform it
-            SQLite3.BackupStep (backup, -1);
-            SQLite3.BackupFinish (backup);
+			// Perform it
+			SQLite3.BackupStep (backup, -1);
+			SQLite3.BackupFinish (backup);
 
-            // Check for errors
-            r = SQLite3.GetResult (destHandle);
-            string msg = "";
-            if (r != SQLite3.Result.OK) {
-                msg = SQLite3.GetErrmsg (destHandle);
-            }
+			// Check for errors
+			r = SQLite3.GetResult (destHandle);
+			string msg = "";
+			if (r != SQLite3.Result.OK) {
+				msg = SQLite3.GetErrmsg (destHandle);
+			}
 
-            // Close everything and report errors
-            SQLite3.Close (destHandle);
-            if (r != SQLite3.Result.OK) {
-                throw SQLiteException.New (r, msg);
-            }
-        }
+			// Close everything and report errors
+			SQLite3.Close (destHandle);
+			if (r != SQLite3.Result.OK) {
+				throw SQLiteException.New (r, msg);
+			}
+		}
 
-        ~SQLiteConnection ()
-        {
-            Dispose (false);
-        }
+		~SQLiteConnection ()
+		{
+			Dispose (false);
+		}
 
-        public void Dispose ()
-        {
-            Dispose (true);
-            GC.SuppressFinalize (this);
-        }
+		public void Dispose ()
+		{
+			Dispose (true);
+			GC.SuppressFinalize (this);
+		}
 
-        public void Close ()
-        {
-            Dispose (true);
-        }
+		public void Close ()
+		{
+			Dispose (true);
+		}
 
-        protected virtual void Dispose (bool disposing)
-        {
-            var useClose2 = LibVersionNumber >= 3007014;
+		protected virtual void Dispose (bool disposing)
+		{
+			var useClose2 = LibVersionNumber >= 3007014;
 
-            if (_open && Handle != NullHandle) {
-                try {
-                    if (disposing) {
-                        lock (_insertCommandMap) {
-                            foreach (var sqlInsertCommand in _insertCommandMap.Values) {
-                                sqlInsertCommand.Dispose ();
-                            }
-                            _insertCommandMap.Clear ();
-                        }
+			if (_open && Handle != NullHandle) {
+				try {
+					if (disposing) {
+						lock (_insertCommandMap) {
+							foreach (var sqlInsertCommand in _insertCommandMap.Values) {
+								sqlInsertCommand.Dispose ();
+							}
+							_insertCommandMap.Clear ();
+						}
 
-                        var r = useClose2 ? SQLite3.Close2 (Handle) : SQLite3.Close (Handle);
-                        if (r != SQLite3.Result.OK) {
-                            string msg = SQLite3.GetErrmsg (Handle);
-                            throw SQLiteException.New (r, msg);
-                        }
-                    }
-                    else {
-                        var r = useClose2 ? SQLite3.Close2 (Handle) : SQLite3.Close (Handle);
-                    }
-                }
-                finally {
-                    Handle = NullHandle;
-                    _open = false;
-                }
-            }
-        }
+						var r = useClose2 ? SQLite3.Close2 (Handle) : SQLite3.Close (Handle);
+						if (r != SQLite3.Result.OK) {
+							string msg = SQLite3.GetErrmsg (Handle);
+							throw SQLiteException.New (r, msg);
+						}
+					}
+					else {
+						var r = useClose2 ? SQLite3.Close2 (Handle) : SQLite3.Close (Handle);
+					}
+				}
+				finally {
+					Handle = NullHandle;
+					_open = false;
+				}
+			}
+		}
 
-        void OnTableChanged (TableMapping table, NotifyTableChangedAction action)
-        {
-            var ev = TableChanged;
-            if (ev != null)
-                ev (this, new NotifyTableChangedEventArgs (table, action));
-        }
+		void OnTableChanged (TableMapping table, NotifyTableChangedAction action)
+		{
+			var ev = TableChanged;
+			if (ev != null)
+				ev (this, new NotifyTableChangedEventArgs (table, action));
+		}
 
-        public event EventHandler<NotifyTableChangedEventArgs> TableChanged;
-    }
+		public event EventHandler<NotifyTableChangedEventArgs> TableChanged;
+	}
 
-    public class NotifyTableChangedEventArgs : EventArgs
-    {
-        public TableMapping Table { get; private set; }
-        public NotifyTableChangedAction Action { get; private set; }
+	public class NotifyTableChangedEventArgs : EventArgs
+	{
+		public TableMapping Table { get; private set; }
+		public NotifyTableChangedAction Action { get; private set; }
 
-        public NotifyTableChangedEventArgs (TableMapping table, NotifyTableChangedAction action)
-        {
-            Table = table;
-            Action = action;
-        }
-    }
+		public NotifyTableChangedEventArgs (TableMapping table, NotifyTableChangedAction action)
+		{
+			Table = table;
+			Action = action;
+		}
+	}
 
-    public enum NotifyTableChangedAction
-    {
-        Insert,
-        Update,
-        Delete,
-    }
+	public enum NotifyTableChangedAction
+	{
+		Insert,
+		Update,
+		Delete,
+	}
 
-    /// <summary>
-    /// Represents a parsed connection string.
-    /// </summary>
-    public class SQLiteConnectionString
-    {
-        const string DateTimeSqliteDefaultFormat = "yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fff";
+	/// <summary>
+	/// Represents a parsed connection string.
+	/// </summary>
+	public class SQLiteConnectionString
+	{
+		const string DateTimeSqliteDefaultFormat = "yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fff";
 
-        public string UniqueKey { get; }
-        public string DatabasePath { get; }
-        public bool StoreDateTimeAsTicks { get; }
-        public bool StoreTimeSpanAsTicks { get; }
-        public string DateTimeStringFormat { get; }
-        public System.Globalization.DateTimeStyles DateTimeStyle { get; }
-        public object Key { get; }
-        public SQLiteOpenFlags OpenFlags { get; }
-        public Action<SQLiteConnection> PreKeyAction { get; }
-        public Action<SQLiteConnection> PostKeyAction { get; }
-        public string VfsName { get; }
+		public string UniqueKey { get; }
+		public string DatabasePath { get; }
+		public bool StoreDateTimeAsTicks { get; }
+		public bool StoreTimeSpanAsTicks { get; }
+		public string DateTimeStringFormat { get; }
+		public System.Globalization.DateTimeStyles DateTimeStyle { get; }
+		public object Key { get; }
+		public SQLiteOpenFlags OpenFlags { get; }
+		public Action<SQLiteConnection> PreKeyAction { get; }
+		public Action<SQLiteConnection> PostKeyAction { get; }
+		public string VfsName { get; }
 
 #if NETFX_CORE
-        static readonly string MetroStyleDataPath = Windows.Storage.ApplicationData.Current.LocalFolder.Path;
+		static readonly string MetroStyleDataPath = Windows.Storage.ApplicationData.Current.LocalFolder.Path;
 
-        public static readonly string[] InMemoryDbPaths = new[]
-        {
-            ":memory:",
-            "file::memory:"
-        };
+		public static readonly string[] InMemoryDbPaths = new[]
+		{
+			":memory:",
+			"file::memory:"
+		};
 
-        public static bool IsInMemoryPath(string databasePath)
-        {
-            return InMemoryDbPaths.Any(i => i.Equals(databasePath, StringComparison.OrdinalIgnoreCase));
-        }
+		public static bool IsInMemoryPath(string databasePath)
+		{
+			return InMemoryDbPaths.Any(i => i.Equals(databasePath, StringComparison.OrdinalIgnoreCase));
+		}
 
 #endif
 
-        /// <summary>
-        /// Constructs a new SQLiteConnectionString with all the data needed to open an SQLiteConnection.
-        /// </summary>
-        /// <param name="databasePath">
-        /// Specifies the path to the database file.
-        /// </param>
-        /// <param name="storeDateTimeAsTicks">
-        /// Specifies whether to store DateTime properties as ticks (true) or strings (false). You
-        /// absolutely do want to store them as Ticks in all new projects. The value of false is
-        /// only here for backwards compatibility. There is a *significant* speed advantage, with no
-        /// down sides, when setting storeDateTimeAsTicks = true.
-        /// If you use DateTimeOffset properties, it will be always stored as ticks regardingless
-        /// the storeDateTimeAsTicks parameter.
-        /// </param>
-        public SQLiteConnectionString (string databasePath, bool storeDateTimeAsTicks = true)
-            : this (databasePath, SQLiteOpenFlags.Create | SQLiteOpenFlags.ReadWrite, storeDateTimeAsTicks)
-        {
-        }
+		/// <summary>
+		/// Constructs a new SQLiteConnectionString with all the data needed to open an SQLiteConnection.
+		/// </summary>
+		/// <param name="databasePath">
+		/// Specifies the path to the database file.
+		/// </param>
+		/// <param name="storeDateTimeAsTicks">
+		/// Specifies whether to store DateTime properties as ticks (true) or strings (false). You
+		/// absolutely do want to store them as Ticks in all new projects. The value of false is
+		/// only here for backwards compatibility. There is a *significant* speed advantage, with no
+		/// down sides, when setting storeDateTimeAsTicks = true.
+		/// If you use DateTimeOffset properties, it will be always stored as ticks regardingless
+		/// the storeDateTimeAsTicks parameter.
+		/// </param>
+		public SQLiteConnectionString (string databasePath, bool storeDateTimeAsTicks = true)
+			: this (databasePath, SQLiteOpenFlags.Create | SQLiteOpenFlags.ReadWrite, storeDateTimeAsTicks)
+		{
+		}
 
-        /// <summary>
-        /// Constructs a new SQLiteConnectionString with all the data needed to open an SQLiteConnection.
-        /// </summary>
-        /// <param name="databasePath">
-        /// Specifies the path to the database file.
-        /// </param>
-        /// <param name="storeDateTimeAsTicks">
-        /// Specifies whether to store DateTime properties as ticks (true) or strings (false). You
-        /// absolutely do want to store them as Ticks in all new projects. The value of false is
-        /// only here for backwards compatibility. There is a *significant* speed advantage, with no
-        /// down sides, when setting storeDateTimeAsTicks = true.
-        /// If you use DateTimeOffset properties, it will be always stored as ticks regardingless
-        /// the storeDateTimeAsTicks parameter.
-        /// </param>
-        /// <param name="key">
-        /// Specifies the encryption key to use on the database. Should be a string or a byte[].
-        /// </param>
-        /// <param name="preKeyAction">
-        /// Executes prior to setting key for SQLCipher databases
-        /// </param>
-        /// <param name="postKeyAction">
-        /// Executes after setting key for SQLCipher databases
-        /// </param>
-        /// <param name="vfsName">
-        /// Specifies the Virtual File System to use on the database.
-        /// </param>
-        public SQLiteConnectionString (string databasePath, bool storeDateTimeAsTicks, object key = null, Action<SQLiteConnection> preKeyAction = null, Action<SQLiteConnection> postKeyAction = null, string vfsName = null)
-            : this (databasePath, SQLiteOpenFlags.Create | SQLiteOpenFlags.ReadWrite, storeDateTimeAsTicks, key, preKeyAction, postKeyAction, vfsName)
-        {
-        }
+		/// <summary>
+		/// Constructs a new SQLiteConnectionString with all the data needed to open an SQLiteConnection.
+		/// </summary>
+		/// <param name="databasePath">
+		/// Specifies the path to the database file.
+		/// </param>
+		/// <param name="storeDateTimeAsTicks">
+		/// Specifies whether to store DateTime properties as ticks (true) or strings (false). You
+		/// absolutely do want to store them as Ticks in all new projects. The value of false is
+		/// only here for backwards compatibility. There is a *significant* speed advantage, with no
+		/// down sides, when setting storeDateTimeAsTicks = true.
+		/// If you use DateTimeOffset properties, it will be always stored as ticks regardingless
+		/// the storeDateTimeAsTicks parameter.
+		/// </param>
+		/// <param name="key">
+		/// Specifies the encryption key to use on the database. Should be a string or a byte[].
+		/// </param>
+		/// <param name="preKeyAction">
+		/// Executes prior to setting key for SQLCipher databases
+		/// </param>
+		/// <param name="postKeyAction">
+		/// Executes after setting key for SQLCipher databases
+		/// </param>
+		/// <param name="vfsName">
+		/// Specifies the Virtual File System to use on the database.
+		/// </param>
+		public SQLiteConnectionString (string databasePath, bool storeDateTimeAsTicks, object key = null, Action<SQLiteConnection> preKeyAction = null, Action<SQLiteConnection> postKeyAction = null, string vfsName = null)
+			: this (databasePath, SQLiteOpenFlags.Create | SQLiteOpenFlags.ReadWrite, storeDateTimeAsTicks, key, preKeyAction, postKeyAction, vfsName)
+		{
+		}
 
-        /// <summary>
-        /// Constructs a new SQLiteConnectionString with all the data needed to open an SQLiteConnection.
-        /// </summary>
-        /// <param name="databasePath">
-        /// Specifies the path to the database file.
-        /// </param>
-        /// <param name="openFlags">
-        /// Flags controlling how the connection should be opened.
-        /// </param>
-        /// <param name="storeDateTimeAsTicks">
-        /// Specifies whether to store DateTime properties as ticks (true) or strings (false). You
-        /// absolutely do want to store them as Ticks in all new projects. The value of false is
-        /// only here for backwards compatibility. There is a *significant* speed advantage, with no
-        /// down sides, when setting storeDateTimeAsTicks = true.
-        /// If you use DateTimeOffset properties, it will be always stored as ticks regardingless
-        /// the storeDateTimeAsTicks parameter.
-        /// </param>
-        /// <param name="key">
-        /// Specifies the encryption key to use on the database. Should be a string or a byte[].
-        /// </param>
-        /// <param name="preKeyAction">
-        /// Executes prior to setting key for SQLCipher databases
-        /// </param>
-        /// <param name="postKeyAction">
-        /// Executes after setting key for SQLCipher databases
-        /// </param>
-        /// <param name="vfsName">
-        /// Specifies the Virtual File System to use on the database.
-        /// </param>
-        /// <param name="dateTimeStringFormat">
-        /// Specifies the format to use when storing DateTime properties as strings.
-        /// </param>
-        /// <param name="storeTimeSpanAsTicks">
-        /// Specifies whether to store TimeSpan properties as ticks (true) or strings (false). You
-        /// absolutely do want to store them as Ticks in all new projects. The value of false is
-        /// only here for backwards compatibility. There is a *significant* speed advantage, with no
-        /// down sides, when setting storeTimeSpanAsTicks = true.
-        /// </param>
-        public SQLiteConnectionString (string databasePath, SQLiteOpenFlags openFlags, bool storeDateTimeAsTicks, object key = null, Action<SQLiteConnection> preKeyAction = null, Action<SQLiteConnection> postKeyAction = null, string vfsName = null, string dateTimeStringFormat = DateTimeSqliteDefaultFormat, bool storeTimeSpanAsTicks = true)
-        {
-            if (key != null && !((key is byte[]) || (key is string)))
-                throw new ArgumentException ("Encryption keys must be strings or byte arrays", nameof (key));
+		/// <summary>
+		/// Constructs a new SQLiteConnectionString with all the data needed to open an SQLiteConnection.
+		/// </summary>
+		/// <param name="databasePath">
+		/// Specifies the path to the database file.
+		/// </param>
+		/// <param name="openFlags">
+		/// Flags controlling how the connection should be opened.
+		/// </param>
+		/// <param name="storeDateTimeAsTicks">
+		/// Specifies whether to store DateTime properties as ticks (true) or strings (false). You
+		/// absolutely do want to store them as Ticks in all new projects. The value of false is
+		/// only here for backwards compatibility. There is a *significant* speed advantage, with no
+		/// down sides, when setting storeDateTimeAsTicks = true.
+		/// If you use DateTimeOffset properties, it will be always stored as ticks regardingless
+		/// the storeDateTimeAsTicks parameter.
+		/// </param>
+		/// <param name="key">
+		/// Specifies the encryption key to use on the database. Should be a string or a byte[].
+		/// </param>
+		/// <param name="preKeyAction">
+		/// Executes prior to setting key for SQLCipher databases
+		/// </param>
+		/// <param name="postKeyAction">
+		/// Executes after setting key for SQLCipher databases
+		/// </param>
+		/// <param name="vfsName">
+		/// Specifies the Virtual File System to use on the database.
+		/// </param>
+		/// <param name="dateTimeStringFormat">
+		/// Specifies the format to use when storing DateTime properties as strings.
+		/// </param>
+		/// <param name="storeTimeSpanAsTicks">
+		/// Specifies whether to store TimeSpan properties as ticks (true) or strings (false). You
+		/// absolutely do want to store them as Ticks in all new projects. The value of false is
+		/// only here for backwards compatibility. There is a *significant* speed advantage, with no
+		/// down sides, when setting storeTimeSpanAsTicks = true.
+		/// </param>
+		public SQLiteConnectionString (string databasePath, SQLiteOpenFlags openFlags, bool storeDateTimeAsTicks, object key = null, Action<SQLiteConnection> preKeyAction = null, Action<SQLiteConnection> postKeyAction = null, string vfsName = null, string dateTimeStringFormat = DateTimeSqliteDefaultFormat, bool storeTimeSpanAsTicks = true)
+		{
+			if (key != null && !((key is byte[]) || (key is string)))
+				throw new ArgumentException ("Encryption keys must be strings or byte arrays", nameof (key));
 
-            UniqueKey = string.Format ("{0}_{1:X8}", databasePath, (uint)openFlags);
-            StoreDateTimeAsTicks = storeDateTimeAsTicks;
-            StoreTimeSpanAsTicks = storeTimeSpanAsTicks;
-            DateTimeStringFormat = dateTimeStringFormat;
-            DateTimeStyle = "o".Equals (DateTimeStringFormat, StringComparison.OrdinalIgnoreCase) || "r".Equals (DateTimeStringFormat, StringComparison.OrdinalIgnoreCase) ? System.Globalization.DateTimeStyles.RoundtripKind : System.Globalization.DateTimeStyles.None;
-            Key = key;
-            PreKeyAction = preKeyAction;
-            PostKeyAction = postKeyAction;
-            OpenFlags = openFlags;
-            VfsName = vfsName;
+			UniqueKey = string.Format ("{0}_{1:X8}", databasePath, (uint)openFlags);
+			StoreDateTimeAsTicks = storeDateTimeAsTicks;
+			StoreTimeSpanAsTicks = storeTimeSpanAsTicks;
+			DateTimeStringFormat = dateTimeStringFormat;
+			DateTimeStyle = "o".Equals (DateTimeStringFormat, StringComparison.OrdinalIgnoreCase) || "r".Equals (DateTimeStringFormat, StringComparison.OrdinalIgnoreCase) ? System.Globalization.DateTimeStyles.RoundtripKind : System.Globalization.DateTimeStyles.None;
+			Key = key;
+			PreKeyAction = preKeyAction;
+			PostKeyAction = postKeyAction;
+			OpenFlags = openFlags;
+			VfsName = vfsName;
 
 #if NETFX_CORE
-            DatabasePath = IsInMemoryPath(databasePath)
-                ? databasePath
-                : System.IO.Path.Combine(MetroStyleDataPath, databasePath);
+			DatabasePath = IsInMemoryPath(databasePath)
+				? databasePath
+				: System.IO.Path.Combine(MetroStyleDataPath, databasePath);
 
 #else
-            DatabasePath = databasePath;
+			DatabasePath = databasePath;
 #endif
-        }
-    }
+		}
+	}
 
-    [AttributeUsage (AttributeTargets.Class)]
-    public class TableAttribute : Attribute
-    {
-        public string Name { get; set; }
+	[AttributeUsage (AttributeTargets.Class)]
+	public class TableAttribute : Attribute
+	{
+		public string Name { get; set; }
 
-        /// <summary>
-        /// Flag whether to create the table without rowid (see https://sqlite.org/withoutrowid.html)
-        ///
-        /// The default is <c>false</c> so that sqlite adds an implicit <c>rowid</c> to every table created.
-        /// </summary>
-        public bool WithoutRowId { get; set; }
+		/// <summary>
+		/// Flag whether to create the table without rowid (see https://sqlite.org/withoutrowid.html)
+		///
+		/// The default is <c>false</c> so that sqlite adds an implicit <c>rowid</c> to every table created.
+		/// </summary>
+		public bool WithoutRowId { get; set; }
 
-        public TableAttribute (string name)
-        {
-            Name = name;
-        }
-    }
+		public TableAttribute (string name)
+		{
+			Name = name;
+		}
+	}
 
-    [AttributeUsage (AttributeTargets.Property)]
-    public class ColumnAttribute : Attribute
-    {
-        public string Name { get; set; }
+	[AttributeUsage (AttributeTargets.Property)]
+	public class ColumnAttribute : Attribute
+	{
+		public string Name { get; set; }
 
-        public ColumnAttribute (string name)
-        {
-            Name = name;
-        }
-    }
+		public ColumnAttribute (string name)
+		{
+			Name = name;
+		}
+	}
 
-    [AttributeUsage (AttributeTargets.Property)]
-    public class PrimaryKeyAttribute : Attribute
-    {
-    }
+	[AttributeUsage (AttributeTargets.Property)]
+	public class PrimaryKeyAttribute : Attribute
+	{
+	}
 
-    [AttributeUsage (AttributeTargets.Property)]
-    public class AutoIncrementAttribute : Attribute
-    {
-    }
+	[AttributeUsage (AttributeTargets.Property)]
+	public class AutoIncrementAttribute : Attribute
+	{
+	}
 
-    [AttributeUsage (AttributeTargets.Property, AllowMultiple = true)]
-    public class IndexedAttribute : Attribute
-    {
-        public string Name { get; set; }
-        public int Order { get; set; }
-        public virtual bool Unique { get; set; }
+	[AttributeUsage (AttributeTargets.Property, AllowMultiple = true)]
+	public class IndexedAttribute : Attribute
+	{
+		public string Name { get; set; }
+		public int Order { get; set; }
+		public virtual bool Unique { get; set; }
 
-        public IndexedAttribute ()
-        {
-        }
+		public IndexedAttribute ()
+		{
+		}
 
-        public IndexedAttribute (string name, int order)
-        {
-            Name = name;
-            Order = order;
-        }
-    }
+		public IndexedAttribute (string name, int order)
+		{
+			Name = name;
+			Order = order;
+		}
+	}
 
-    [AttributeUsage (AttributeTargets.Property)]
-    public class IgnoreAttribute : Attribute
-    {
-    }
+	[AttributeUsage (AttributeTargets.Property)]
+	public class IgnoreAttribute : Attribute
+	{
+	}
 
-    [AttributeUsage (AttributeTargets.Property)]
-    public class UniqueAttribute : IndexedAttribute
-    {
-        public override bool Unique {
-            get { return true; }
-            set { /* throw?  */ }
-        }
-    }
+	[AttributeUsage (AttributeTargets.Property)]
+	public class UniqueAttribute : IndexedAttribute
+	{
+		public override bool Unique {
+			get { return true; }
+			set { /* throw?  */ }
+		}
+	}
 
-    [AttributeUsage (AttributeTargets.Property)]
-    public class MaxLengthAttribute : Attribute
-    {
-        public int Value { get; private set; }
+	[AttributeUsage (AttributeTargets.Property)]
+	public class MaxLengthAttribute : Attribute
+	{
+		public int Value { get; private set; }
 
-        public MaxLengthAttribute (int length)
-        {
-            Value = length;
-        }
-    }
+		public MaxLengthAttribute (int length)
+		{
+			Value = length;
+		}
+	}
 
-    public sealed class PreserveAttribute : System.Attribute
-    {
-        public bool AllMembers;
-        public bool Conditional;
-    }
+	public sealed class PreserveAttribute : System.Attribute
+	{
+		public bool AllMembers;
+		public bool Conditional;
+	}
 
-    /// <summary>
-    /// Select the collating sequence to use on a column.
-    /// "BINARY", "NOCASE", and "RTRIM" are supported.
-    /// "BINARY" is the default.
-    /// </summary>
-    [AttributeUsage (AttributeTargets.Property)]
-    public class CollationAttribute : Attribute
-    {
-        public string Value { get; private set; }
+	/// <summary>
+	/// Select the collating sequence to use on a column.
+	/// "BINARY", "NOCASE", and "RTRIM" are supported.
+	/// "BINARY" is the default.
+	/// </summary>
+	[AttributeUsage (AttributeTargets.Property)]
+	public class CollationAttribute : Attribute
+	{
+		public string Value { get; private set; }
 
-        public CollationAttribute (string collation)
-        {
-            Value = collation;
-        }
-    }
+		public CollationAttribute (string collation)
+		{
+			Value = collation;
+		}
+	}
 
-    [AttributeUsage (AttributeTargets.Property)]
-    public class NotNullAttribute : Attribute
-    {
-    }
+	[AttributeUsage (AttributeTargets.Property)]
+	public class NotNullAttribute : Attribute
+	{
+	}
 
-    [AttributeUsage (AttributeTargets.Enum)]
-    public class StoreAsTextAttribute : Attribute
-    {
-    }
+	[AttributeUsage (AttributeTargets.Enum)]
+	public class StoreAsTextAttribute : Attribute
+	{
+	}
 
-    public class TableMapping
-    {
+	public class TableMapping
+	{
 #if NET8_0_OR_GREATER
 		[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
 #endif
 		public Type MappedType { get; private set; }
 
-        public string TableName { get; private set; }
+		public string TableName { get; private set; }
 
-        public bool WithoutRowId { get; private set; }
+		public bool WithoutRowId { get; private set; }
 
-        public Column[] Columns { get; private set; }
+		public Column[] Columns { get; private set; }
 
-        public Column PK { get; private set; }
+		public Column PK { get; private set; }
 
-        public string GetByPrimaryKeySql { get; private set; }
+		public string GetByPrimaryKeySql { get; private set; }
 
-        public CreateFlags CreateFlags { get; private set; }
+		public CreateFlags CreateFlags { get; private set; }
 
-        internal MapMethod Method { get; private set; } = MapMethod.ByName;
+		internal MapMethod Method { get; private set; } = MapMethod.ByName;
 
-        readonly Column _autoPk;
-        readonly Column[] _insertColumns;
-        readonly Column[] _insertOrReplaceColumns;
+		readonly Column _autoPk;
+		readonly Column[] _insertColumns;
+		readonly Column[] _insertOrReplaceColumns;
 
-        public TableMapping (
+		public TableMapping (
 #if NET8_0_OR_GREATER
 			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
 #endif
 			Type type,
 			CreateFlags createFlags = CreateFlags.None)
-        {
-            MappedType = type;
-            CreateFlags = createFlags;
+		{
+			MappedType = type;
+			CreateFlags = createFlags;
 
 #if ENABLE_IL2CPP
 			var typeInfo = type.GetTypeInfo ();
-            var tableAttr = typeInfo.GetCustomAttribute<TableAttribute> ();
+			var tableAttr = typeInfo.GetCustomAttribute<TableAttribute> ();
 #elif NET8_0_OR_GREATER
 			var tableAttr = type.GetCustomAttributes<TableAttribute> ().FirstOrDefault ();
 #else
 			var typeInfo = type.GetTypeInfo ();
 			var tableAttr =
-                typeInfo.CustomAttributes
-                        .Where (x => x.AttributeType == typeof (TableAttribute))
-                        .Select (x => (TableAttribute)Orm.InflateAttribute (x))
-                        .FirstOrDefault ();
+				typeInfo.CustomAttributes
+						.Where (x => x.AttributeType == typeof (TableAttribute))
+						.Select (x => (TableAttribute)Orm.InflateAttribute (x))
+						.FirstOrDefault ();
 #endif
 
 			TableName = (tableAttr != null && !string.IsNullOrEmpty (tableAttr.Name)) ? tableAttr.Name : MappedType.Name;
-            WithoutRowId = tableAttr != null ? tableAttr.WithoutRowId : false;
+			WithoutRowId = tableAttr != null ? tableAttr.WithoutRowId : false;
 
-            var members = GetPublicMembers(type);
-            var cols = new List<Column>(members.Count);
-            foreach(var m in members)
-            {
-                var ignore = m.IsDefined(typeof(IgnoreAttribute), true);
-                if(!ignore)
-                    cols.Add(new Column(m, createFlags));
-            }
-            Columns = cols.ToArray ();
-            foreach (var c in Columns) {
-                if (c.IsAutoInc && c.IsPK) {
-                    _autoPk = c;
-                }
-                if (c.IsPK) {
-                    PK = c;
-                }
-            }
+			var members = GetPublicMembers(type);
+			var cols = new List<Column>(members.Count);
+			foreach(var m in members)
+			{
+				var ignore = m.IsDefined(typeof(IgnoreAttribute), true);
+				if(!ignore)
+					cols.Add(new Column(m, createFlags));
+			}
+			Columns = cols.ToArray ();
+			foreach (var c in Columns) {
+				if (c.IsAutoInc && c.IsPK) {
+					_autoPk = c;
+				}
+				if (c.IsPK) {
+					PK = c;
+				}
+			}
 
-            HasAutoIncPK = _autoPk != null;
+			HasAutoIncPK = _autoPk != null;
 
-            if (PK != null) {
-                GetByPrimaryKeySql = string.Format ("select * from \"{0}\" where \"{1}\" = ?", TableName, PK.Name);
-            }
-            else {
-                // People should not be calling Get/Find without a PK
-                GetByPrimaryKeySql = string.Format ("select * from \"{0}\" limit 1", TableName);
-            }
+			if (PK != null) {
+				GetByPrimaryKeySql = string.Format ("select * from \"{0}\" where \"{1}\" = ?", TableName, PK.Name);
+			}
+			else {
+				// People should not be calling Get/Find without a PK
+				GetByPrimaryKeySql = string.Format ("select * from \"{0}\" limit 1", TableName);
+			}
 
-            _insertColumns = Columns.Where (c => !c.IsAutoInc).ToArray ();
-            _insertOrReplaceColumns = Columns.ToArray ();
-        }
+			_insertColumns = Columns.Where (c => !c.IsAutoInc).ToArray ();
+			_insertOrReplaceColumns = Columns.ToArray ();
+		}
 
-        private IReadOnlyCollection<MemberInfo> GetPublicMembers(
+		private IReadOnlyCollection<MemberInfo> GetPublicMembers(
 #if NET8_0_OR_GREATER
 			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
 #endif
 			Type type)
-        {
-            if(type.Name.StartsWith("ValueTuple`"))
-                return GetFieldsFromValueTuple(type);
+		{
+			if(type.Name.StartsWith("ValueTuple`"))
+				return GetFieldsFromValueTuple(type);
 
-            var members = new List<MemberInfo>();
-            var memberNames = new HashSet<string>();
-            var newMembers = new List<MemberInfo>();
-            do
-            {
-                var ti = type.GetTypeInfo();
-                newMembers.Clear();
+			var members = new List<MemberInfo>();
+			var memberNames = new HashSet<string>();
+			var newMembers = new List<MemberInfo>();
+			do
+			{
+				var ti = type.GetTypeInfo();
+				newMembers.Clear();
 
-                newMembers.AddRange(
-                    from p in ti.DeclaredProperties
-                    where !memberNames.Contains(p.Name) &&
-                        p.CanRead && p.CanWrite &&
-                        p.GetMethod != null && p.SetMethod != null &&
-                        p.GetMethod.IsPublic && p.SetMethod.IsPublic &&
-                        !p.GetMethod.IsStatic && !p.SetMethod.IsStatic
-                    select p);
+				newMembers.AddRange(
+					from p in ti.DeclaredProperties
+					where !memberNames.Contains(p.Name) &&
+						p.CanRead && p.CanWrite &&
+						p.GetMethod != null && p.SetMethod != null &&
+						p.GetMethod.IsPublic && p.SetMethod.IsPublic &&
+						!p.GetMethod.IsStatic && !p.SetMethod.IsStatic
+					select p);
 
-                members.AddRange(newMembers);
-                foreach(var m in newMembers)
-                    memberNames.Add(m.Name);
+				members.AddRange(newMembers);
+				foreach(var m in newMembers)
+					memberNames.Add(m.Name);
 
-                type = ti.BaseType;
-            }
-            while(type != typeof(object));
+				type = ti.BaseType;
+			}
+			while(type != typeof(object));
 
-            return members;
-        }
+			return members;
+		}
 
-        private IReadOnlyCollection<MemberInfo> GetFieldsFromValueTuple(
+		private IReadOnlyCollection<MemberInfo> GetFieldsFromValueTuple(
 #if NET8_0_OR_GREATER
 			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.NonPublicFields)]
 #endif
 			Type type)
-        {
-            Method = MapMethod.ByPosition;
-            var fields = type.GetFields();
+		{
+			Method = MapMethod.ByPosition;
+			var fields = type.GetFields();
 
-            // https://docs.microsoft.com/en-us/dotnet/api/system.valuetuple-8.rest
-            if(fields.Length >= 8)
-                throw new NotSupportedException("ValueTuple with more than 7 members not supported due to nesting; see https://docs.microsoft.com/en-us/dotnet/api/system.valuetuple-8.rest");
+			// https://docs.microsoft.com/en-us/dotnet/api/system.valuetuple-8.rest
+			if(fields.Length >= 8)
+				throw new NotSupportedException("ValueTuple with more than 7 members not supported due to nesting; see https://docs.microsoft.com/en-us/dotnet/api/system.valuetuple-8.rest");
 
-            return fields;
-        }
+			return fields;
+		}
 
-        public bool HasAutoIncPK { get; private set; }
+		public bool HasAutoIncPK { get; private set; }
 
-        public void SetAutoIncPK (object obj, long id)
-        {
-            if (_autoPk != null) {
-                _autoPk.SetValue (obj, Convert.ChangeType (id, _autoPk.ColumnType, null));
-            }
-        }
+		public void SetAutoIncPK (object obj, long id)
+		{
+			if (_autoPk != null) {
+				_autoPk.SetValue (obj, Convert.ChangeType (id, _autoPk.ColumnType, null));
+			}
+		}
 
-        public Column[] InsertColumns {
-            get {
-                return _insertColumns;
-            }
-        }
+		public Column[] InsertColumns {
+			get {
+				return _insertColumns;
+			}
+		}
 
-        public Column[] InsertOrReplaceColumns {
-            get {
-                return _insertOrReplaceColumns;
-            }
-        }
+		public Column[] InsertOrReplaceColumns {
+			get {
+				return _insertOrReplaceColumns;
+			}
+		}
 
-        public Column FindColumnWithPropertyName (string propertyName)
-        {
-            var exact = Columns.FirstOrDefault (c => c.PropertyName == propertyName);
-            return exact;
-        }
+		public Column FindColumnWithPropertyName (string propertyName)
+		{
+			var exact = Columns.FirstOrDefault (c => c.PropertyName == propertyName);
+			return exact;
+		}
 
-        public Column FindColumn (string columnName)
-        {
-            if(Method != MapMethod.ByName)
-                throw new InvalidOperationException($"This {nameof(TableMapping)} is not mapped by name, but {Method}.");
+		public Column FindColumn (string columnName)
+		{
+			if(Method != MapMethod.ByName)
+				throw new InvalidOperationException($"This {nameof(TableMapping)} is not mapped by name, but {Method}.");
 
-            var exact = Columns.FirstOrDefault (c => c.Name.ToLower () == columnName.ToLower ());
-            return exact;
-        }
+			var exact = Columns.FirstOrDefault (c => c.Name.ToLower () == columnName.ToLower ());
+			return exact;
+		}
 
-        public class Column
-        {
-            MemberInfo _member;
+		public class Column
+		{
+			MemberInfo _member;
 
-            public string Name { get; private set; }
+			public string Name { get; private set; }
 
-            public PropertyInfo PropertyInfo => _member as PropertyInfo;
+			public PropertyInfo PropertyInfo => _member as PropertyInfo;
 
-            public string PropertyName { get { return _member.Name; } }
+			public string PropertyName { get { return _member.Name; } }
 
-            public Type ColumnType { get; private set; }
+			public Type ColumnType { get; private set; }
 
-            public string Collation { get; private set; }
+			public string Collation { get; private set; }
 
-            public bool IsAutoInc { get; private set; }
-            public bool IsAutoGuid { get; private set; }
+			public bool IsAutoInc { get; private set; }
+			public bool IsAutoGuid { get; private set; }
 
-            public bool IsPK { get; private set; }
+			public bool IsPK { get; private set; }
 
-            public IEnumerable<IndexedAttribute> Indices { get; set; }
+			public IEnumerable<IndexedAttribute> Indices { get; set; }
 
-            public bool IsNullable { get; private set; }
+			public bool IsNullable { get; private set; }
 
-            public int? MaxStringLength { get; private set; }
+			public int? MaxStringLength { get; private set; }
 
-            public bool StoreAsText { get; private set; }
+			public bool StoreAsText { get; private set; }
 
-            public Column (MemberInfo member, CreateFlags createFlags = CreateFlags.None)
-            {
-                _member = member;
-                var memberType = GetMemberType(member);
+			public Column (MemberInfo member, CreateFlags createFlags = CreateFlags.None)
+			{
+				_member = member;
+				var memberType = GetMemberType(member);
 
-                var colAttr = member.CustomAttributes.FirstOrDefault (x => x.AttributeType == typeof (ColumnAttribute));
+				var colAttr = member.CustomAttributes.FirstOrDefault (x => x.AttributeType == typeof (ColumnAttribute));
 #if ENABLE_IL2CPP
-                var ca = member.GetCustomAttribute(typeof(ColumnAttribute)) as ColumnAttribute;
-                Name = ca == null ? member.Name : ca.Name;
+				var ca = member.GetCustomAttribute(typeof(ColumnAttribute)) as ColumnAttribute;
+				Name = ca == null ? member.Name : ca.Name;
 #else
-                Name = (colAttr != null && colAttr.ConstructorArguments.Count > 0) ?
-                        colAttr.ConstructorArguments[0].Value?.ToString () :
-                        member.Name;
+				Name = (colAttr != null && colAttr.ConstructorArguments.Count > 0) ?
+						colAttr.ConstructorArguments[0].Value?.ToString () :
+						member.Name;
 #endif
-                //If this type is Nullable<T> then Nullable.GetUnderlyingType returns the T, otherwise it returns null, so get the actual type instead
-                ColumnType = Nullable.GetUnderlyingType (memberType) ?? memberType;
-                Collation = Orm.Collation (member);
+				//If this type is Nullable<T> then Nullable.GetUnderlyingType returns the T, otherwise it returns null, so get the actual type instead
+				ColumnType = Nullable.GetUnderlyingType (memberType) ?? memberType;
+				Collation = Orm.Collation (member);
 
-                IsPK = Orm.IsPK (member) ||
-                    (((createFlags & CreateFlags.ImplicitPK) == CreateFlags.ImplicitPK) &&
-                        string.Compare (member.Name, Orm.ImplicitPkName, StringComparison.OrdinalIgnoreCase) == 0);
+				IsPK = Orm.IsPK (member) ||
+					(((createFlags & CreateFlags.ImplicitPK) == CreateFlags.ImplicitPK) &&
+						string.Compare (member.Name, Orm.ImplicitPkName, StringComparison.OrdinalIgnoreCase) == 0);
 
-                var isAuto = Orm.IsAutoInc (member) || (IsPK && ((createFlags & CreateFlags.AutoIncPK) == CreateFlags.AutoIncPK));
-                IsAutoGuid = isAuto && ColumnType == typeof (Guid);
-                IsAutoInc = isAuto && !IsAutoGuid;
+				var isAuto = Orm.IsAutoInc (member) || (IsPK && ((createFlags & CreateFlags.AutoIncPK) == CreateFlags.AutoIncPK));
+				IsAutoGuid = isAuto && ColumnType == typeof (Guid);
+				IsAutoInc = isAuto && !IsAutoGuid;
 
-                Indices = Orm.GetIndices (member);
-                if (!Indices.Any ()
-                    && !IsPK
-                    && ((createFlags & CreateFlags.ImplicitIndex) == CreateFlags.ImplicitIndex)
-                    && Name.EndsWith (Orm.ImplicitIndexSuffix, StringComparison.OrdinalIgnoreCase)
-                    ) {
-                    Indices = new IndexedAttribute[] { new IndexedAttribute () };
-                }
-                IsNullable = !(IsPK || Orm.IsMarkedNotNull (member));
-                MaxStringLength = Orm.MaxStringLength (member);
+				Indices = Orm.GetIndices (member);
+				if (!Indices.Any ()
+					&& !IsPK
+					&& ((createFlags & CreateFlags.ImplicitIndex) == CreateFlags.ImplicitIndex)
+					&& Name.EndsWith (Orm.ImplicitIndexSuffix, StringComparison.OrdinalIgnoreCase)
+					) {
+					Indices = new IndexedAttribute[] { new IndexedAttribute () };
+				}
+				IsNullable = !(IsPK || Orm.IsMarkedNotNull (member));
+				MaxStringLength = Orm.MaxStringLength (member);
 
-                StoreAsText = memberType.GetTypeInfo ().CustomAttributes.Any (x => x.AttributeType == typeof (StoreAsTextAttribute));
-            }
+				StoreAsText = memberType.GetTypeInfo ().CustomAttributes.Any (x => x.AttributeType == typeof (StoreAsTextAttribute));
+			}
 
-            public Column (PropertyInfo member, CreateFlags createFlags = CreateFlags.None)
-                : this((MemberInfo)member, createFlags)
-            { }
+			public Column (PropertyInfo member, CreateFlags createFlags = CreateFlags.None)
+				: this((MemberInfo)member, createFlags)
+			{ }
 
-            public void SetValue (object obj, object val)
-            {
-                if(_member is PropertyInfo propy)
-                {
-                    if (val != null && ColumnType.GetTypeInfo ().IsEnum)
-                        propy.SetValue (obj, Enum.ToObject (ColumnType, val));
-                    else
-                        propy.SetValue (obj, val);
-                }
-                else if(_member is FieldInfo field)
-                {
-                    if (val != null && ColumnType.GetTypeInfo ().IsEnum)
-                        field.SetValue (obj, Enum.ToObject (ColumnType, val));
-                    else
-                        field.SetValue (obj, val);
-                }
-                else
-                    throw new InvalidProgramException("unreachable condition");
-            }
+			public void SetValue (object obj, object val)
+			{
+				if(_member is PropertyInfo propy)
+				{
+					if (val != null && ColumnType.GetTypeInfo ().IsEnum)
+						propy.SetValue (obj, Enum.ToObject (ColumnType, val));
+					else
+						propy.SetValue (obj, val);
+				}
+				else if(_member is FieldInfo field)
+				{
+					if (val != null && ColumnType.GetTypeInfo ().IsEnum)
+						field.SetValue (obj, Enum.ToObject (ColumnType, val));
+					else
+						field.SetValue (obj, val);
+				}
+				else
+					throw new InvalidProgramException("unreachable condition");
+			}
 
-            public object GetValue (object obj)
-            {
-                if(_member is PropertyInfo propy)
-                    return propy.GetValue(obj);
-                else if(_member is FieldInfo field)
-                    return field.GetValue(obj);
-                else
-                    throw new InvalidProgramException("unreachable condition");
-            }
+			public object GetValue (object obj)
+			{
+				if(_member is PropertyInfo propy)
+					return propy.GetValue(obj);
+				else if(_member is FieldInfo field)
+					return field.GetValue(obj);
+				else
+					throw new InvalidProgramException("unreachable condition");
+			}
 
-            private static Type GetMemberType(MemberInfo m)
-            {
-                switch(m.MemberType)
-                {
-                    case MemberTypes.Property: return ((PropertyInfo)m).PropertyType;
-                    case MemberTypes.Field: return ((FieldInfo)m).FieldType;
-                    default: throw new InvalidProgramException($"{nameof(TableMapping)} supports properties or fields only.");
-                }
-            }
-        }
+			private static Type GetMemberType(MemberInfo m)
+			{
+				switch(m.MemberType)
+				{
+					case MemberTypes.Property: return ((PropertyInfo)m).PropertyType;
+					case MemberTypes.Field: return ((FieldInfo)m).FieldType;
+					default: throw new InvalidProgramException($"{nameof(TableMapping)} supports properties or fields only.");
+				}
+			}
+		}
 
-        internal enum MapMethod
-        {
-            ByName,
-            ByPosition
-        }
-    }
+		internal enum MapMethod
+		{
+			ByName,
+			ByPosition
+		}
+	}
 
-    class EnumCacheInfo
-    {
-        public EnumCacheInfo (Type type)
-        {
-            var typeInfo = type.GetTypeInfo ();
+	class EnumCacheInfo
+	{
+		public EnumCacheInfo (Type type)
+		{
+			var typeInfo = type.GetTypeInfo ();
 
-            IsEnum = typeInfo.IsEnum;
+			IsEnum = typeInfo.IsEnum;
 
-            if (IsEnum) {
-                StoreAsText = typeInfo.CustomAttributes.Any (x => x.AttributeType == typeof (StoreAsTextAttribute));
+			if (IsEnum) {
+				StoreAsText = typeInfo.CustomAttributes.Any (x => x.AttributeType == typeof (StoreAsTextAttribute));
 
-                if (StoreAsText) {
-                    EnumValues = new Dictionary<int, string> ();
+				if (StoreAsText) {
+					EnumValues = new Dictionary<int, string> ();
 #if NET8_0_OR_GREATER
-                    foreach (object e in Enum.GetValuesAsUnderlyingType (type)) {
-                        EnumValues[Convert.ToInt32 (e)] = Enum.ToObject(type, e).ToString ();
-                    }
+					foreach (object e in Enum.GetValuesAsUnderlyingType (type)) {
+						EnumValues[Convert.ToInt32 (e)] = Enum.ToObject(type, e).ToString ();
+					}
 #else
-                    foreach (object e in Enum.GetValues (type)) {
-                        EnumValues[Convert.ToInt32 (e)] = e.ToString ();
-                    }
+					foreach (object e in Enum.GetValues (type)) {
+						EnumValues[Convert.ToInt32 (e)] = e.ToString ();
+					}
 #endif
-                }
-            }
-        }
+				}
+			}
+		}
 
-        public bool IsEnum { get; private set; }
+		public bool IsEnum { get; private set; }
 
-        public bool StoreAsText { get; private set; }
+		public bool StoreAsText { get; private set; }
 
-        public Dictionary<int, string> EnumValues { get; private set; }
-    }
+		public Dictionary<int, string> EnumValues { get; private set; }
+	}
 
-    static class EnumCache
-    {
-        static readonly Dictionary<Type, EnumCacheInfo> Cache = new Dictionary<Type, EnumCacheInfo> ();
+	static class EnumCache
+	{
+		static readonly Dictionary<Type, EnumCacheInfo> Cache = new Dictionary<Type, EnumCacheInfo> ();
 
-        public static EnumCacheInfo GetInfo<T> ()
-        {
-            return GetInfo (typeof (T));
-        }
+		public static EnumCacheInfo GetInfo<T> ()
+		{
+			return GetInfo (typeof (T));
+		}
 
-        public static EnumCacheInfo GetInfo (Type type)
-        {
-            lock (Cache) {
-                EnumCacheInfo info = null;
-                if (!Cache.TryGetValue (type, out info)) {
-                    info = new EnumCacheInfo (type);
-                    Cache[type] = info;
-                }
+		public static EnumCacheInfo GetInfo (Type type)
+		{
+			lock (Cache) {
+				EnumCacheInfo info = null;
+				if (!Cache.TryGetValue (type, out info)) {
+					info = new EnumCacheInfo (type);
+					Cache[type] = info;
+				}
 
-                return info;
-            }
-        }
-    }
+				return info;
+			}
+		}
+	}
 
-    public static class Orm
-    {
-        public const int DefaultMaxStringLength = 140;
-        public const string ImplicitPkName = "Id";
-        public const string ImplicitIndexSuffix = "Id";
+	public static class Orm
+	{
+		public const int DefaultMaxStringLength = 140;
+		public const string ImplicitPkName = "Id";
+		public const string ImplicitIndexSuffix = "Id";
 
-        public static Type GetType (object obj)
-        {
-            if (obj == null)
-                return typeof (object);
-            var rt = obj as IReflectableType;
-            if (rt != null)
-                return rt.GetTypeInfo ().AsType ();
-            return obj.GetType ();
-        }
+		public static Type GetType (object obj)
+		{
+			if (obj == null)
+				return typeof (object);
+			var rt = obj as IReflectableType;
+			if (rt != null)
+				return rt.GetTypeInfo ().AsType ();
+			return obj.GetType ();
+		}
 
-        public static string SqlDecl (TableMapping.Column p, bool storeDateTimeAsTicks, bool storeTimeSpanAsTicks)
-        {
-            string decl = "\"" + p.Name + "\" " + SqlType (p, storeDateTimeAsTicks, storeTimeSpanAsTicks) + " ";
+		public static string SqlDecl (TableMapping.Column p, bool storeDateTimeAsTicks, bool storeTimeSpanAsTicks)
+		{
+			string decl = "\"" + p.Name + "\" " + SqlType (p, storeDateTimeAsTicks, storeTimeSpanAsTicks) + " ";
 
-            if (p.IsPK) {
-                decl += "primary key ";
-            }
-            if (p.IsAutoInc) {
-                decl += "autoincrement ";
-            }
-            if (!p.IsNullable) {
-                decl += "not null ";
-            }
-            if (!string.IsNullOrEmpty (p.Collation)) {
-                decl += "collate " + p.Collation + " ";
-            }
+			if (p.IsPK) {
+				decl += "primary key ";
+			}
+			if (p.IsAutoInc) {
+				decl += "autoincrement ";
+			}
+			if (!p.IsNullable) {
+				decl += "not null ";
+			}
+			if (!string.IsNullOrEmpty (p.Collation)) {
+				decl += "collate " + p.Collation + " ";
+			}
 
-            return decl;
-        }
+			return decl;
+		}
 
-        public static string SqlType (TableMapping.Column p, bool storeDateTimeAsTicks, bool storeTimeSpanAsTicks)
-        {
-            var clrType = p.ColumnType;
-            if (clrType == typeof (Boolean) || clrType == typeof (Byte) || clrType == typeof (UInt16) || clrType == typeof (SByte) || clrType == typeof (Int16) || clrType == typeof (Int32) || clrType == typeof (UInt32) || clrType == typeof (Int64) || clrType == typeof (UInt64)) {
-                return "integer";
-            }
-            else if (clrType == typeof (Single) || clrType == typeof (Double) || clrType == typeof (Decimal)) {
-                return "float";
-            }
-            else if (clrType == typeof (String) || clrType == typeof (StringBuilder) || clrType == typeof (Uri) || clrType == typeof (UriBuilder)) {
-                int? len = p.MaxStringLength;
+		public static string SqlType (TableMapping.Column p, bool storeDateTimeAsTicks, bool storeTimeSpanAsTicks)
+		{
+			var clrType = p.ColumnType;
+			if (clrType == typeof (Boolean) || clrType == typeof (Byte) || clrType == typeof (UInt16) || clrType == typeof (SByte) || clrType == typeof (Int16) || clrType == typeof (Int32) || clrType == typeof (UInt32) || clrType == typeof (Int64) || clrType == typeof (UInt64)) {
+				return "integer";
+			}
+			else if (clrType == typeof (Single) || clrType == typeof (Double) || clrType == typeof (Decimal)) {
+				return "float";
+			}
+			else if (clrType == typeof (String) || clrType == typeof (StringBuilder) || clrType == typeof (Uri) || clrType == typeof (UriBuilder)) {
+				int? len = p.MaxStringLength;
 
-                if (len.HasValue)
-                    return "varchar(" + len.Value + ")";
+				if (len.HasValue)
+					return "varchar(" + len.Value + ")";
 
-                return "varchar";
-            }
-            else if (clrType == typeof (TimeSpan)) {
-                return storeTimeSpanAsTicks ? "bigint" : "time";
-            }
-            else if (clrType == typeof (DateTime)) {
-                return storeDateTimeAsTicks ? "bigint" : "datetime";
-            }
-            else if (clrType == typeof (DateTimeOffset)) {
-                return "bigint";
-            }
-            else if (clrType.GetTypeInfo ().IsEnum) {
-                if (p.StoreAsText)
-                    return "varchar";
-                else
-                    return "integer";
-            }
-            else if (clrType == typeof (byte[])) {
-                return "blob";
-            }
-            else if (clrType == typeof (Guid)) {
-                return "varchar(36)";
-            }
-            else {
-                throw new NotSupportedException ("Don't know about " + clrType);
-            }
-        }
+				return "varchar";
+			}
+			else if (clrType == typeof (TimeSpan)) {
+				return storeTimeSpanAsTicks ? "bigint" : "time";
+			}
+			else if (clrType == typeof (DateTime)) {
+				return storeDateTimeAsTicks ? "bigint" : "datetime";
+			}
+			else if (clrType == typeof (DateTimeOffset)) {
+				return "bigint";
+			}
+			else if (clrType.GetTypeInfo ().IsEnum) {
+				if (p.StoreAsText)
+					return "varchar";
+				else
+					return "integer";
+			}
+			else if (clrType == typeof (byte[])) {
+				return "blob";
+			}
+			else if (clrType == typeof (Guid)) {
+				return "varchar(36)";
+			}
+			else {
+				throw new NotSupportedException ("Don't know about " + clrType);
+			}
+		}
 
-        public static bool IsPK (MemberInfo p)
-        {
-            return p.CustomAttributes.Any (x => x.AttributeType == typeof (PrimaryKeyAttribute));
-        }
+		public static bool IsPK (MemberInfo p)
+		{
+			return p.CustomAttributes.Any (x => x.AttributeType == typeof (PrimaryKeyAttribute));
+		}
 
-        public static string Collation (MemberInfo p)
-        {
+		public static string Collation (MemberInfo p)
+		{
 #if ENABLE_IL2CPP
-            return (p.GetCustomAttribute<CollationAttribute> ()?.Value) ?? "";
+			return (p.GetCustomAttribute<CollationAttribute> ()?.Value) ?? "";
 #else
-            return
-                (p.CustomAttributes
-                 .Where (x => typeof (CollationAttribute) == x.AttributeType)
-                 .Select (x => {
-                     var args = x.ConstructorArguments;
-                     return args.Count > 0 ? ((args[0].Value as string) ?? "") : "";
-                 })
-                 .FirstOrDefault ()) ?? "";
+			return
+				(p.CustomAttributes
+				 .Where (x => typeof (CollationAttribute) == x.AttributeType)
+				 .Select (x => {
+					 var args = x.ConstructorArguments;
+					 return args.Count > 0 ? ((args[0].Value as string) ?? "") : "";
+				 })
+				 .FirstOrDefault ()) ?? "";
 #endif
-        }
+		}
 
-        public static bool IsAutoInc (MemberInfo p)
-        {
-            return p.CustomAttributes.Any (x => x.AttributeType == typeof (AutoIncrementAttribute));
-        }
+		public static bool IsAutoInc (MemberInfo p)
+		{
+			return p.CustomAttributes.Any (x => x.AttributeType == typeof (AutoIncrementAttribute));
+		}
 
-        public static FieldInfo GetField (
+		public static FieldInfo GetField (
 #if NET8_0_OR_GREATER
 			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
 #endif
 			TypeInfo t,
 			string name)
-        {
+		{
 			var f = t.GetDeclaredField (name);
-            if (f != null)
-                return f;
-            return GetField (t.BaseType.GetTypeInfo (), name);
-        }
+			if (f != null)
+				return f;
+			return GetField (t.BaseType.GetTypeInfo (), name);
+		}
 
-        public static PropertyInfo GetProperty (
+		public static PropertyInfo GetProperty (
 #if NET8_0_OR_GREATER
 			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
 #endif
 			TypeInfo t,
 			string name)
-        {
-            var f = t.GetDeclaredProperty (name);
-            if (f != null)
-                return f;
-            return GetProperty (t.BaseType.GetTypeInfo (), name);
-        }
+		{
+			var f = t.GetDeclaredProperty (name);
+			if (f != null)
+				return f;
+			return GetProperty (t.BaseType.GetTypeInfo (), name);
+		}
 
 #if !NET8_0_OR_GREATER
 		public static object InflateAttribute (CustomAttributeData x)
-        {
-            var atype = x.AttributeType;
-            var typeInfo = atype.GetTypeInfo ();
+		{
+			var atype = x.AttributeType;
+			var typeInfo = atype.GetTypeInfo ();
 #if ENABLE_IL2CPP
-            var r = Activator.CreateInstance (x.AttributeType);
+			var r = Activator.CreateInstance (x.AttributeType);
 #else
-            var args = x.ConstructorArguments.Select (a => a.Value).ToArray ();
-            var r = Activator.CreateInstance (x.AttributeType, args);
-            foreach (var arg in x.NamedArguments) {
-                if (arg.IsField) {
-                    GetField (typeInfo, arg.MemberName).SetValue (r, arg.TypedValue.Value);
-                }
-                else {
-                    GetProperty (typeInfo, arg.MemberName).SetValue (r, arg.TypedValue.Value);
-                }
-            }
+			var args = x.ConstructorArguments.Select (a => a.Value).ToArray ();
+			var r = Activator.CreateInstance (x.AttributeType, args);
+			foreach (var arg in x.NamedArguments) {
+				if (arg.IsField) {
+					GetField (typeInfo, arg.MemberName).SetValue (r, arg.TypedValue.Value);
+				}
+				else {
+					GetProperty (typeInfo, arg.MemberName).SetValue (r, arg.TypedValue.Value);
+				}
+			}
 #endif
-            return r;
-        }
+			return r;
+		}
 #endif
 
-        public static IEnumerable<IndexedAttribute> GetIndices (MemberInfo p)
-        {
+		public static IEnumerable<IndexedAttribute> GetIndices (MemberInfo p)
+		{
 #if ENABLE_IL2CPP || NET8_0_OR_GREATER
 			return p.GetCustomAttributes<IndexedAttribute> ();
 #else
 			var indexedInfo = typeof (IndexedAttribute).GetTypeInfo ();
-            return
-                p.CustomAttributes
-                 .Where (x => indexedInfo.IsAssignableFrom (x.AttributeType.GetTypeInfo ()))
-                 .Select (x => (IndexedAttribute)InflateAttribute (x));
+			return
+				p.CustomAttributes
+				 .Where (x => indexedInfo.IsAssignableFrom (x.AttributeType.GetTypeInfo ()))
+				 .Select (x => (IndexedAttribute)InflateAttribute (x));
 #endif
-        }
+		}
 
-        public static int? MaxStringLength (MemberInfo p)
-        {
+		public static int? MaxStringLength (MemberInfo p)
+		{
 #if ENABLE_IL2CPP
-            return p.GetCustomAttribute<MaxLengthAttribute> ()?.Value;
+			return p.GetCustomAttribute<MaxLengthAttribute> ()?.Value;
 #elif NET8_0_OR_GREATER
 			return p.GetCustomAttributes<MaxLengthAttribute> ().FirstOrDefault ()?.Value;
 #else
 			var attr = p.CustomAttributes.FirstOrDefault (x => x.AttributeType == typeof (MaxLengthAttribute));
-            if (attr != null) {
-                var attrv = (MaxLengthAttribute)InflateAttribute (attr);
-                return attrv.Value;
-            }
-            return null;
+			if (attr != null) {
+				var attrv = (MaxLengthAttribute)InflateAttribute (attr);
+				return attrv.Value;
+			}
+			return null;
 #endif
 		}
 
-        public static int? MaxStringLength (PropertyInfo p) => MaxStringLength((MemberInfo)p);
+		public static int? MaxStringLength (PropertyInfo p) => MaxStringLength((MemberInfo)p);
 
-        public static bool IsMarkedNotNull (MemberInfo p)
-        {
-            return p.CustomAttributes.Any (x => x.AttributeType == typeof (NotNullAttribute));
-        }
-    }
+		public static bool IsMarkedNotNull (MemberInfo p)
+		{
+			return p.CustomAttributes.Any (x => x.AttributeType == typeof (NotNullAttribute));
+		}
+	}
 
-    public partial class SQLiteCommand
-    {
-        SQLiteConnection _conn;
-        private List<Binding> _bindings;
+	public partial class SQLiteCommand
+	{
+		SQLiteConnection _conn;
+		private List<Binding> _bindings;
 
-        public string CommandText { get; set; }
+		public string CommandText { get; set; }
 
-        public SQLiteCommand (SQLiteConnection conn)
-        {
-            _conn = conn;
-            _bindings = new List<Binding> ();
-            CommandText = "";
-        }
+		public SQLiteCommand (SQLiteConnection conn)
+		{
+			_conn = conn;
+			_bindings = new List<Binding> ();
+			CommandText = "";
+		}
 
-        public int ExecuteNonQuery ()
-        {
-            if (_conn.Trace) {
-                _conn.Tracer?.Invoke ("Executing: " + this);
-            }
+		public int ExecuteNonQuery ()
+		{
+			if (_conn.Trace) {
+				_conn.Tracer?.Invoke ("Executing: " + this);
+			}
 
-            var r = SQLite3.Result.OK;
-            var stmt = Prepare ();
-            r = SQLite3.Step (stmt);
-            Finalize (stmt);
-            if (r == SQLite3.Result.Done) {
-                int rowsAffected = SQLite3.Changes (_conn.Handle);
-                return rowsAffected;
-            }
-            else if (r == SQLite3.Result.Error) {
-                string msg = SQLite3.GetErrmsg (_conn.Handle);
-                throw SQLiteException.New (r, msg);
-            }
-            else if (r == SQLite3.Result.Constraint) {
-                if (SQLite3.ExtendedErrCode (_conn.Handle) == SQLite3.ExtendedResult.ConstraintNotNull) {
-                    throw NotNullConstraintViolationException.New (r, SQLite3.GetErrmsg (_conn.Handle));
-                }
-            }
+			var r = SQLite3.Result.OK;
+			var stmt = Prepare ();
+			r = SQLite3.Step (stmt);
+			Finalize (stmt);
+			if (r == SQLite3.Result.Done) {
+				int rowsAffected = SQLite3.Changes (_conn.Handle);
+				return rowsAffected;
+			}
+			else if (r == SQLite3.Result.Error) {
+				string msg = SQLite3.GetErrmsg (_conn.Handle);
+				throw SQLiteException.New (r, msg);
+			}
+			else if (r == SQLite3.Result.Constraint) {
+				if (SQLite3.ExtendedErrCode (_conn.Handle) == SQLite3.ExtendedResult.ConstraintNotNull) {
+					throw NotNullConstraintViolationException.New (r, SQLite3.GetErrmsg (_conn.Handle));
+				}
+			}
 
-            throw SQLiteException.New (r, SQLite3.GetErrmsg (_conn.Handle));
-        }
+			throw SQLiteException.New (r, SQLite3.GetErrmsg (_conn.Handle));
+		}
 
-        public IEnumerable<T> ExecuteDeferredQuery<
+		public IEnumerable<T> ExecuteDeferredQuery<
 #if NET8_0_OR_GREATER
 			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
 #endif
 			T> ()
-        {
-            return ExecuteDeferredQuery<T> (_conn.GetMapping (typeof (T)));
-        }
+		{
+			return ExecuteDeferredQuery<T> (_conn.GetMapping (typeof (T)));
+		}
 
-        public List<T> ExecuteQuery<
+		public List<T> ExecuteQuery<
 #if NET8_0_OR_GREATER
 			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
 #endif
 			T> ()
-        {
-            return ExecuteDeferredQuery<T> (_conn.GetMapping (typeof (T))).ToList ();
-        }
+		{
+			return ExecuteDeferredQuery<T> (_conn.GetMapping (typeof (T))).ToList ();
+		}
 
-        public List<T> ExecuteQuery<T> (TableMapping map)
-        {
-            return ExecuteDeferredQuery<T> (map).ToList ();
-        }
+		public List<T> ExecuteQuery<T> (TableMapping map)
+		{
+			return ExecuteDeferredQuery<T> (map).ToList ();
+		}
 
-        /// <summary>
-        /// Invoked every time an instance is loaded from the database.
-        /// </summary>
-        /// <param name='obj'>
-        /// The newly created object.
-        /// </param>
-        /// <remarks>
-        /// This can be overridden in combination with the <see cref="SQLiteConnection.NewCommand"/>
-        /// method to hook into the life-cycle of objects.
-        /// </remarks>
-        protected virtual void OnInstanceCreated (object obj)
-        {
-            // Can be overridden.
-        }
+		/// <summary>
+		/// Invoked every time an instance is loaded from the database.
+		/// </summary>
+		/// <param name='obj'>
+		/// The newly created object.
+		/// </param>
+		/// <remarks>
+		/// This can be overridden in combination with the <see cref="SQLiteConnection.NewCommand"/>
+		/// method to hook into the life-cycle of objects.
+		/// </remarks>
+		protected virtual void OnInstanceCreated (object obj)
+		{
+			// Can be overridden.
+		}
 
-        public IEnumerable<T> ExecuteDeferredQuery<T> (TableMapping map)
-        {
-            if (_conn.Trace) {
-                _conn.Tracer?.Invoke ("Executing Query: " + this);
-            }
+		public IEnumerable<T> ExecuteDeferredQuery<T> (TableMapping map)
+		{
+			if (_conn.Trace) {
+				_conn.Tracer?.Invoke ("Executing Query: " + this);
+			}
 
-            var stmt = Prepare ();
-            try {
-                var cols = new TableMapping.Column[SQLite3.ColumnCount (stmt)];
-                var fastColumnSetters = new Action<object, Sqlite3Statement, int>[SQLite3.ColumnCount (stmt)];
+			var stmt = Prepare ();
+			try {
+				var cols = new TableMapping.Column[SQLite3.ColumnCount (stmt)];
+				var fastColumnSetters = new Action<object, Sqlite3Statement, int>[SQLite3.ColumnCount (stmt)];
 
-                if (map.Method == TableMapping.MapMethod.ByPosition)
-                {
-                    Array.Copy(map.Columns, cols, Math.Min(cols.Length, map.Columns.Length));
-                }
-                else if (map.Method == TableMapping.MapMethod.ByName) {
-                    MethodInfo getSetter = null;
-                    if (typeof(T) != map.MappedType) {
+				if (map.Method == TableMapping.MapMethod.ByPosition)
+				{
+					Array.Copy(map.Columns, cols, Math.Min(cols.Length, map.Columns.Length));
+				}
+				else if (map.Method == TableMapping.MapMethod.ByName) {
+					MethodInfo getSetter = null;
+					if (typeof(T) != map.MappedType) {
 #if NET8_0_OR_GREATER
 						if (!RuntimeFeature.IsDynamicCodeSupported) {
 							if (map.MappedType.IsValueType) {
@@ -3561,358 +3561,358 @@ namespace SQLite
 						}
 #endif
 						getSetter = FastColumnSetter.GetFastSetterMethodInfoUnsafe (map.MappedType);
-                    }
+					}
 
-                    for (int i = 0; i < cols.Length; i++) {						
-                        var name = SQLite3.ColumnName16 (stmt, i);
-                        cols[i] = map.FindColumn (name);
-                        if (cols[i] != null)
-                            if (getSetter != null) {
-                                fastColumnSetters[i] = (Action<object, Sqlite3Statement, int>)getSetter.Invoke(null, new object[]{ _conn, cols[i]});
-                            }
-                            else {
-                                fastColumnSetters[i] = FastColumnSetter.GetFastSetter<T>(_conn, cols[i]);
-                            }
-                    }
-                }
+					for (int i = 0; i < cols.Length; i++) {						
+						var name = SQLite3.ColumnName16 (stmt, i);
+						cols[i] = map.FindColumn (name);
+						if (cols[i] != null)
+							if (getSetter != null) {
+								fastColumnSetters[i] = (Action<object, Sqlite3Statement, int>)getSetter.Invoke(null, new object[]{ _conn, cols[i]});
+							}
+							else {
+								fastColumnSetters[i] = FastColumnSetter.GetFastSetter<T>(_conn, cols[i]);
+							}
+					}
+				}
 
-                while (SQLite3.Step (stmt) == SQLite3.Result.Row) {
-                    var obj = Activator.CreateInstance (map.MappedType);
-                    for (int i = 0; i < cols.Length; i++) {
-                        if (cols[i] == null)
-                            continue;
+				while (SQLite3.Step (stmt) == SQLite3.Result.Row) {
+					var obj = Activator.CreateInstance (map.MappedType);
+					for (int i = 0; i < cols.Length; i++) {
+						if (cols[i] == null)
+							continue;
 
-                        if (fastColumnSetters[i] != null) {
-                            fastColumnSetters[i].Invoke (obj, stmt, i);
-                        }
-                        else {
-                            var colType = SQLite3.ColumnType (stmt, i);
-                            var val = ReadCol (stmt, i, colType, cols[i].ColumnType);
-                            cols[i].SetValue (obj, val);
-                        }
-                    }
-                    OnInstanceCreated (obj);
-                    yield return (T)obj;
-                }
-            }
-            finally {
-                SQLite3.Finalize (stmt);
-            }
-        }
+						if (fastColumnSetters[i] != null) {
+							fastColumnSetters[i].Invoke (obj, stmt, i);
+						}
+						else {
+							var colType = SQLite3.ColumnType (stmt, i);
+							var val = ReadCol (stmt, i, colType, cols[i].ColumnType);
+							cols[i].SetValue (obj, val);
+						}
+					}
+					OnInstanceCreated (obj);
+					yield return (T)obj;
+				}
+			}
+			finally {
+				SQLite3.Finalize (stmt);
+			}
+		}
 
-        public T ExecuteScalar<T> ()
-        {
-            if (_conn.Trace) {
-                _conn.Tracer?.Invoke ("Executing Query: " + this);
-            }
+		public T ExecuteScalar<T> ()
+		{
+			if (_conn.Trace) {
+				_conn.Tracer?.Invoke ("Executing Query: " + this);
+			}
 
-            T val = default (T);
+			T val = default (T);
 
-            var stmt = Prepare ();
+			var stmt = Prepare ();
 
-            try {
-                var r = SQLite3.Step (stmt);
-                if (r == SQLite3.Result.Row) {
-                    var colType = SQLite3.ColumnType (stmt, 0);
-                    var colval = ReadCol (stmt, 0, colType, typeof (T));
-                    if (colval != null) {
-                        val = (T)colval;
-                    }
-                }
-                else if (r == SQLite3.Result.Done) {
-                }
-                else {
-                    throw SQLiteException.New (r, SQLite3.GetErrmsg (_conn.Handle));
-                }
-            }
-            finally {
-                Finalize (stmt);
-            }
+			try {
+				var r = SQLite3.Step (stmt);
+				if (r == SQLite3.Result.Row) {
+					var colType = SQLite3.ColumnType (stmt, 0);
+					var colval = ReadCol (stmt, 0, colType, typeof (T));
+					if (colval != null) {
+						val = (T)colval;
+					}
+				}
+				else if (r == SQLite3.Result.Done) {
+				}
+				else {
+					throw SQLiteException.New (r, SQLite3.GetErrmsg (_conn.Handle));
+				}
+			}
+			finally {
+				Finalize (stmt);
+			}
 
-            return val;
-        }
+			return val;
+		}
 
-        public IEnumerable<T> ExecuteQueryScalars<T> ()
-        {
-            if (_conn.Trace) {
-                _conn.Tracer?.Invoke ("Executing Query: " + this);
-            }
-            var stmt = Prepare ();
-            try {
-                if (SQLite3.ColumnCount (stmt) < 1) {
-                    throw new InvalidOperationException ("QueryScalars should return at least one column");
-                }
-                while (SQLite3.Step (stmt) == SQLite3.Result.Row) {
-                    var colType = SQLite3.ColumnType (stmt, 0);
-                    var val = ReadCol (stmt, 0, colType, typeof (T));
-                    if (val == null) {
-                        yield return default (T);
-                    }
-                    else {
-                        yield return (T)val;
-                    }
-                }
-            }
-            finally {
-                Finalize (stmt);
-            }
-        }
+		public IEnumerable<T> ExecuteQueryScalars<T> ()
+		{
+			if (_conn.Trace) {
+				_conn.Tracer?.Invoke ("Executing Query: " + this);
+			}
+			var stmt = Prepare ();
+			try {
+				if (SQLite3.ColumnCount (stmt) < 1) {
+					throw new InvalidOperationException ("QueryScalars should return at least one column");
+				}
+				while (SQLite3.Step (stmt) == SQLite3.Result.Row) {
+					var colType = SQLite3.ColumnType (stmt, 0);
+					var val = ReadCol (stmt, 0, colType, typeof (T));
+					if (val == null) {
+						yield return default (T);
+					}
+					else {
+						yield return (T)val;
+					}
+				}
+			}
+			finally {
+				Finalize (stmt);
+			}
+		}
 
-        public void Bind (string name, object val)
-        {
-            _bindings.Add (new Binding {
-                Name = name,
-                Value = val
-            });
-        }
+		public void Bind (string name, object val)
+		{
+			_bindings.Add (new Binding {
+				Name = name,
+				Value = val
+			});
+		}
 
-        public void Bind (object val)
-        {
-            Bind (null, val);
-        }
+		public void Bind (object val)
+		{
+			Bind (null, val);
+		}
 
-        public override string ToString ()
-        {
-            var parts = new string[1 + _bindings.Count];
-            parts[0] = CommandText;
-            var i = 1;
-            foreach (var b in _bindings) {
-                parts[i] = string.Format ("  {0}: {1}", i - 1, b.Value);
-                i++;
-            }
-            return string.Join (Environment.NewLine, parts);
-        }
+		public override string ToString ()
+		{
+			var parts = new string[1 + _bindings.Count];
+			parts[0] = CommandText;
+			var i = 1;
+			foreach (var b in _bindings) {
+				parts[i] = string.Format ("  {0}: {1}", i - 1, b.Value);
+				i++;
+			}
+			return string.Join (Environment.NewLine, parts);
+		}
 
-        Sqlite3Statement Prepare ()
-        {
-            var stmt = SQLite3.Prepare2 (_conn.Handle, CommandText);
-            BindAll (stmt);
-            return stmt;
-        }
+		Sqlite3Statement Prepare ()
+		{
+			var stmt = SQLite3.Prepare2 (_conn.Handle, CommandText);
+			BindAll (stmt);
+			return stmt;
+		}
 
-        void Finalize (Sqlite3Statement stmt)
-        {
-            SQLite3.Finalize (stmt);
-        }
+		void Finalize (Sqlite3Statement stmt)
+		{
+			SQLite3.Finalize (stmt);
+		}
 
-        void BindAll (Sqlite3Statement stmt)
-        {
-            int nextIdx = 1;
-            foreach (var b in _bindings) {
-                if (b.Name != null) {
-                    b.Index = SQLite3.BindParameterIndex (stmt, b.Name);
-                }
-                else {
-                    b.Index = nextIdx++;
-                }
+		void BindAll (Sqlite3Statement stmt)
+		{
+			int nextIdx = 1;
+			foreach (var b in _bindings) {
+				if (b.Name != null) {
+					b.Index = SQLite3.BindParameterIndex (stmt, b.Name);
+				}
+				else {
+					b.Index = nextIdx++;
+				}
 
-                BindParameter (stmt, b.Index, b.Value, _conn.StoreDateTimeAsTicks, _conn.DateTimeStringFormat, _conn.StoreTimeSpanAsTicks);
-            }
-        }
+				BindParameter (stmt, b.Index, b.Value, _conn.StoreDateTimeAsTicks, _conn.DateTimeStringFormat, _conn.StoreTimeSpanAsTicks);
+			}
+		}
 
-        static IntPtr NegativePointer = new IntPtr (-1);
+		static IntPtr NegativePointer = new IntPtr (-1);
 
-        internal static void BindParameter (Sqlite3Statement stmt, int index, object value, bool storeDateTimeAsTicks, string dateTimeStringFormat, bool storeTimeSpanAsTicks)
-        {
-            if (value == null) {
-                SQLite3.BindNull (stmt, index);
-            }
-            else {
-                if (value is Int32) {
-                    SQLite3.BindInt (stmt, index, (int)value);
-                }
-                else if (value is String) {
-                    SQLite3.BindText (stmt, index, (string)value, -1, NegativePointer);
-                }
-                else if (value is Byte || value is UInt16 || value is SByte || value is Int16) {
-                    SQLite3.BindInt (stmt, index, Convert.ToInt32 (value));
-                }
-                else if (value is Boolean) {
-                    SQLite3.BindInt (stmt, index, (bool)value ? 1 : 0);
-                }
-                else if (value is UInt32 || value is Int64 || value is UInt64) {
-                    SQLite3.BindInt64 (stmt, index, Convert.ToInt64 (value));
-                }
-                else if (value is Single || value is Double || value is Decimal) {
-                    SQLite3.BindDouble (stmt, index, Convert.ToDouble (value));
-                }
-                else if (value is TimeSpan) {
-                    if (storeTimeSpanAsTicks) {
-                        SQLite3.BindInt64 (stmt, index, ((TimeSpan)value).Ticks);
-                    }
-                    else {
-                        SQLite3.BindText (stmt, index, ((TimeSpan)value).ToString (), -1, NegativePointer);
-                    }
-                }
-                else if (value is DateTime) {
-                    if (storeDateTimeAsTicks) {
-                        SQLite3.BindInt64 (stmt, index, ((DateTime)value).Ticks);
-                    }
-                    else {
-                        SQLite3.BindText (stmt, index, ((DateTime)value).ToString (dateTimeStringFormat, System.Globalization.CultureInfo.InvariantCulture), -1, NegativePointer);
-                    }
-                }
-                else if (value is DateTimeOffset) {
-                    SQLite3.BindInt64 (stmt, index, ((DateTimeOffset)value).UtcTicks);
-                }
-                else if (value is byte[]) {
-                    SQLite3.BindBlob (stmt, index, (byte[])value, ((byte[])value).Length, NegativePointer);
-                }
-                else if (value is Guid) {
-                    SQLite3.BindText (stmt, index, ((Guid)value).ToString (), 72, NegativePointer);
-                }
-                else if (value is Uri) {
-                    SQLite3.BindText (stmt, index, ((Uri)value).ToString (), -1, NegativePointer);
-                }
-                else if (value is StringBuilder) {
-                    SQLite3.BindText (stmt, index, ((StringBuilder)value).ToString (), -1, NegativePointer);
-                }
-                else if (value is UriBuilder) {
-                    SQLite3.BindText (stmt, index, ((UriBuilder)value).ToString (), -1, NegativePointer);
-                }
-                else {
-                    // Now we could possibly get an enum, retrieve cached info
-                    var valueType = value.GetType ();
-                    var enumInfo = EnumCache.GetInfo (valueType);
-                    if (enumInfo.IsEnum) {
-                        var enumIntValue = Convert.ToInt32 (value);
-                        if (enumInfo.StoreAsText)
-                            SQLite3.BindText (stmt, index, enumInfo.EnumValues[enumIntValue], -1, NegativePointer);
-                        else
-                            SQLite3.BindInt (stmt, index, enumIntValue);
-                    }
-                    else {
-                        throw new NotSupportedException ("Cannot store type: " + Orm.GetType (value));
-                    }
-                }
-            }
-        }
+		internal static void BindParameter (Sqlite3Statement stmt, int index, object value, bool storeDateTimeAsTicks, string dateTimeStringFormat, bool storeTimeSpanAsTicks)
+		{
+			if (value == null) {
+				SQLite3.BindNull (stmt, index);
+			}
+			else {
+				if (value is Int32) {
+					SQLite3.BindInt (stmt, index, (int)value);
+				}
+				else if (value is String) {
+					SQLite3.BindText (stmt, index, (string)value, -1, NegativePointer);
+				}
+				else if (value is Byte || value is UInt16 || value is SByte || value is Int16) {
+					SQLite3.BindInt (stmt, index, Convert.ToInt32 (value));
+				}
+				else if (value is Boolean) {
+					SQLite3.BindInt (stmt, index, (bool)value ? 1 : 0);
+				}
+				else if (value is UInt32 || value is Int64 || value is UInt64) {
+					SQLite3.BindInt64 (stmt, index, Convert.ToInt64 (value));
+				}
+				else if (value is Single || value is Double || value is Decimal) {
+					SQLite3.BindDouble (stmt, index, Convert.ToDouble (value));
+				}
+				else if (value is TimeSpan) {
+					if (storeTimeSpanAsTicks) {
+						SQLite3.BindInt64 (stmt, index, ((TimeSpan)value).Ticks);
+					}
+					else {
+						SQLite3.BindText (stmt, index, ((TimeSpan)value).ToString (), -1, NegativePointer);
+					}
+				}
+				else if (value is DateTime) {
+					if (storeDateTimeAsTicks) {
+						SQLite3.BindInt64 (stmt, index, ((DateTime)value).Ticks);
+					}
+					else {
+						SQLite3.BindText (stmt, index, ((DateTime)value).ToString (dateTimeStringFormat, System.Globalization.CultureInfo.InvariantCulture), -1, NegativePointer);
+					}
+				}
+				else if (value is DateTimeOffset) {
+					SQLite3.BindInt64 (stmt, index, ((DateTimeOffset)value).UtcTicks);
+				}
+				else if (value is byte[]) {
+					SQLite3.BindBlob (stmt, index, (byte[])value, ((byte[])value).Length, NegativePointer);
+				}
+				else if (value is Guid) {
+					SQLite3.BindText (stmt, index, ((Guid)value).ToString (), 72, NegativePointer);
+				}
+				else if (value is Uri) {
+					SQLite3.BindText (stmt, index, ((Uri)value).ToString (), -1, NegativePointer);
+				}
+				else if (value is StringBuilder) {
+					SQLite3.BindText (stmt, index, ((StringBuilder)value).ToString (), -1, NegativePointer);
+				}
+				else if (value is UriBuilder) {
+					SQLite3.BindText (stmt, index, ((UriBuilder)value).ToString (), -1, NegativePointer);
+				}
+				else {
+					// Now we could possibly get an enum, retrieve cached info
+					var valueType = value.GetType ();
+					var enumInfo = EnumCache.GetInfo (valueType);
+					if (enumInfo.IsEnum) {
+						var enumIntValue = Convert.ToInt32 (value);
+						if (enumInfo.StoreAsText)
+							SQLite3.BindText (stmt, index, enumInfo.EnumValues[enumIntValue], -1, NegativePointer);
+						else
+							SQLite3.BindInt (stmt, index, enumIntValue);
+					}
+					else {
+						throw new NotSupportedException ("Cannot store type: " + Orm.GetType (value));
+					}
+				}
+			}
+		}
 
-        class Binding
-        {
-            public string Name { get; set; }
+		class Binding
+		{
+			public string Name { get; set; }
 
-            public object Value { get; set; }
+			public object Value { get; set; }
 
-            public int Index { get; set; }
-        }
+			public int Index { get; set; }
+		}
 
-        object ReadCol (Sqlite3Statement stmt, int index, SQLite3.ColType type, Type clrType)
-        {
-            if (type == SQLite3.ColType.Null) {
-                return null;
-            }
-            else {
-                var clrTypeInfo = clrType.GetTypeInfo ();
-                if (clrTypeInfo.IsGenericType && clrTypeInfo.GetGenericTypeDefinition () == typeof (Nullable<>)) {
-                    clrType = clrTypeInfo.GenericTypeArguments[0];
-                    clrTypeInfo = clrType.GetTypeInfo ();
-                }
+		object ReadCol (Sqlite3Statement stmt, int index, SQLite3.ColType type, Type clrType)
+		{
+			if (type == SQLite3.ColType.Null) {
+				return null;
+			}
+			else {
+				var clrTypeInfo = clrType.GetTypeInfo ();
+				if (clrTypeInfo.IsGenericType && clrTypeInfo.GetGenericTypeDefinition () == typeof (Nullable<>)) {
+					clrType = clrTypeInfo.GenericTypeArguments[0];
+					clrTypeInfo = clrType.GetTypeInfo ();
+				}
 
-                if (clrType == typeof (String)) {
-                    return SQLite3.ColumnString (stmt, index);
-                }
-                else if (clrType == typeof (Int32)) {
-                    return (int)SQLite3.ColumnInt (stmt, index);
-                }
-                else if (clrType == typeof (Boolean)) {
-                    return SQLite3.ColumnInt (stmt, index) == 1;
-                }
-                else if (clrType == typeof (double)) {
-                    return SQLite3.ColumnDouble (stmt, index);
-                }
-                else if (clrType == typeof (float)) {
-                    return (float)SQLite3.ColumnDouble (stmt, index);
-                }
-                else if (clrType == typeof (TimeSpan)) {
-                    if (_conn.StoreTimeSpanAsTicks) {
-                        return new TimeSpan (SQLite3.ColumnInt64 (stmt, index));
-                    }
-                    else {
-                        var text = SQLite3.ColumnString (stmt, index);
-                        TimeSpan resultTime;
-                        if (!TimeSpan.TryParseExact (text, "c", System.Globalization.CultureInfo.InvariantCulture, System.Globalization.TimeSpanStyles.None, out resultTime)) {
-                            resultTime = TimeSpan.Parse (text);
-                        }
-                        return resultTime;
-                    }
-                }
-                else if (clrType == typeof (DateTime)) {
-                    if (_conn.StoreDateTimeAsTicks) {
-                        return new DateTime (SQLite3.ColumnInt64 (stmt, index));
-                    }
-                    else {
-                        var text = SQLite3.ColumnString (stmt, index);
-                        DateTime resultDate;
-                        if (!DateTime.TryParseExact (text, _conn.DateTimeStringFormat, System.Globalization.CultureInfo.InvariantCulture, _conn.DateTimeStyle, out resultDate)) {
-                            resultDate = DateTime.Parse (text);
-                        }
-                        return resultDate;
-                    }
-                }
-                else if (clrType == typeof (DateTimeOffset)) {
-                    return new DateTimeOffset (SQLite3.ColumnInt64 (stmt, index), TimeSpan.Zero);
-                }
-                else if (clrTypeInfo.IsEnum) {
-                    if (type == SQLite3.ColType.Text) {
-                        var value = SQLite3.ColumnString (stmt, index);
-                        return Enum.Parse (clrType, value.ToString (), true);
-                    }
-                    else
-                        return SQLite3.ColumnInt (stmt, index);
-                }
-                else if (clrType == typeof (Int64)) {
-                    return SQLite3.ColumnInt64 (stmt, index);
-                }
-                else if (clrType == typeof (UInt64)) {
-                    return (ulong)SQLite3.ColumnInt64 (stmt, index);
-                }
-                else if (clrType == typeof (UInt32)) {
-                    return (uint)SQLite3.ColumnInt64 (stmt, index);
-                }
-                else if (clrType == typeof (decimal)) {
-                    return (decimal)SQLite3.ColumnDouble (stmt, index);
-                }
-                else if (clrType == typeof (Byte)) {
-                    return (byte)SQLite3.ColumnInt (stmt, index);
-                }
-                else if (clrType == typeof (UInt16)) {
-                    return (ushort)SQLite3.ColumnInt (stmt, index);
-                }
-                else if (clrType == typeof (Int16)) {
-                    return (short)SQLite3.ColumnInt (stmt, index);
-                }
-                else if (clrType == typeof (sbyte)) {
-                    return (sbyte)SQLite3.ColumnInt (stmt, index);
-                }
-                else if (clrType == typeof (byte[])) {
-                    return SQLite3.ColumnByteArray (stmt, index);
-                }
-                else if (clrType == typeof (Guid)) {
-                    var text = SQLite3.ColumnString (stmt, index);
-                    return new Guid (text);
-                }
-                else if (clrType == typeof (Uri)) {
-                    var text = SQLite3.ColumnString (stmt, index);
-                    return new Uri (text);
-                }
-                else if (clrType == typeof (StringBuilder)) {
-                    var text = SQLite3.ColumnString (stmt, index);
-                    return new StringBuilder (text);
-                }
-                else if (clrType == typeof (UriBuilder)) {
-                    var text = SQLite3.ColumnString (stmt, index);
-                    return new UriBuilder (text);
-                }
-                else {
-                    throw new NotSupportedException ("Don't know how to read " + clrType);
-                }
-            }
-        }
-    }
+				if (clrType == typeof (String)) {
+					return SQLite3.ColumnString (stmt, index);
+				}
+				else if (clrType == typeof (Int32)) {
+					return (int)SQLite3.ColumnInt (stmt, index);
+				}
+				else if (clrType == typeof (Boolean)) {
+					return SQLite3.ColumnInt (stmt, index) == 1;
+				}
+				else if (clrType == typeof (double)) {
+					return SQLite3.ColumnDouble (stmt, index);
+				}
+				else if (clrType == typeof (float)) {
+					return (float)SQLite3.ColumnDouble (stmt, index);
+				}
+				else if (clrType == typeof (TimeSpan)) {
+					if (_conn.StoreTimeSpanAsTicks) {
+						return new TimeSpan (SQLite3.ColumnInt64 (stmt, index));
+					}
+					else {
+						var text = SQLite3.ColumnString (stmt, index);
+						TimeSpan resultTime;
+						if (!TimeSpan.TryParseExact (text, "c", System.Globalization.CultureInfo.InvariantCulture, System.Globalization.TimeSpanStyles.None, out resultTime)) {
+							resultTime = TimeSpan.Parse (text);
+						}
+						return resultTime;
+					}
+				}
+				else if (clrType == typeof (DateTime)) {
+					if (_conn.StoreDateTimeAsTicks) {
+						return new DateTime (SQLite3.ColumnInt64 (stmt, index));
+					}
+					else {
+						var text = SQLite3.ColumnString (stmt, index);
+						DateTime resultDate;
+						if (!DateTime.TryParseExact (text, _conn.DateTimeStringFormat, System.Globalization.CultureInfo.InvariantCulture, _conn.DateTimeStyle, out resultDate)) {
+							resultDate = DateTime.Parse (text);
+						}
+						return resultDate;
+					}
+				}
+				else if (clrType == typeof (DateTimeOffset)) {
+					return new DateTimeOffset (SQLite3.ColumnInt64 (stmt, index), TimeSpan.Zero);
+				}
+				else if (clrTypeInfo.IsEnum) {
+					if (type == SQLite3.ColType.Text) {
+						var value = SQLite3.ColumnString (stmt, index);
+						return Enum.Parse (clrType, value.ToString (), true);
+					}
+					else
+						return SQLite3.ColumnInt (stmt, index);
+				}
+				else if (clrType == typeof (Int64)) {
+					return SQLite3.ColumnInt64 (stmt, index);
+				}
+				else if (clrType == typeof (UInt64)) {
+					return (ulong)SQLite3.ColumnInt64 (stmt, index);
+				}
+				else if (clrType == typeof (UInt32)) {
+					return (uint)SQLite3.ColumnInt64 (stmt, index);
+				}
+				else if (clrType == typeof (decimal)) {
+					return (decimal)SQLite3.ColumnDouble (stmt, index);
+				}
+				else if (clrType == typeof (Byte)) {
+					return (byte)SQLite3.ColumnInt (stmt, index);
+				}
+				else if (clrType == typeof (UInt16)) {
+					return (ushort)SQLite3.ColumnInt (stmt, index);
+				}
+				else if (clrType == typeof (Int16)) {
+					return (short)SQLite3.ColumnInt (stmt, index);
+				}
+				else if (clrType == typeof (sbyte)) {
+					return (sbyte)SQLite3.ColumnInt (stmt, index);
+				}
+				else if (clrType == typeof (byte[])) {
+					return SQLite3.ColumnByteArray (stmt, index);
+				}
+				else if (clrType == typeof (Guid)) {
+					var text = SQLite3.ColumnString (stmt, index);
+					return new Guid (text);
+				}
+				else if (clrType == typeof (Uri)) {
+					var text = SQLite3.ColumnString (stmt, index);
+					return new Uri (text);
+				}
+				else if (clrType == typeof (StringBuilder)) {
+					var text = SQLite3.ColumnString (stmt, index);
+					return new StringBuilder (text);
+				}
+				else if (clrType == typeof (UriBuilder)) {
+					var text = SQLite3.ColumnString (stmt, index);
+					return new UriBuilder (text);
+				}
+				else {
+					throw new NotSupportedException ("Don't know how to read " + clrType);
+				}
+			}
+		}
+	}
 
-    internal class FastColumnSetter
-    {
+	internal class FastColumnSetter
+	{
 		/// <summary>
 		/// Gets a <see cref="MethodInfo"/> for a generic <see cref="GetFastSetterMethodInfoUnsafe"/> method, suppressing AOT warnings.
 		/// </summary>
@@ -3944,1493 +3944,1493 @@ namespace SQLite
 		/// If no fast setter is available for the requested column (enums in particular cause headache), then this function returns null.
 		/// </returns>
 		internal static Action<object, Sqlite3Statement, int> GetFastSetter<T> (SQLiteConnection conn, TableMapping.Column column)
-        {
-            Action<object, Sqlite3Statement, int> fastSetter = null;
+		{
+			Action<object, Sqlite3Statement, int> fastSetter = null;
 
-            Type clrType = column.PropertyInfo.PropertyType;
+			Type clrType = column.PropertyInfo.PropertyType;
 
-            var clrTypeInfo = clrType.GetTypeInfo ();
-            if (clrTypeInfo.IsGenericType && clrTypeInfo.GetGenericTypeDefinition () == typeof (Nullable<>)) {
-                clrType = clrTypeInfo.GenericTypeArguments[0];
-                clrTypeInfo = clrType.GetTypeInfo ();
-            }
+			var clrTypeInfo = clrType.GetTypeInfo ();
+			if (clrTypeInfo.IsGenericType && clrTypeInfo.GetGenericTypeDefinition () == typeof (Nullable<>)) {
+				clrType = clrTypeInfo.GenericTypeArguments[0];
+				clrTypeInfo = clrType.GetTypeInfo ();
+			}
 
-            if (clrType == typeof (String)) {
-                fastSetter = CreateTypedSetterDelegate<T, string> (column, (stmt, index) => {
-                    return SQLite3.ColumnString (stmt, index);
-                });
-            }
-            else if (clrType == typeof (Int32)) {
-                fastSetter = CreateNullableTypedSetterDelegate<T, int> (column, (stmt, index)=>{
-                    return SQLite3.ColumnInt (stmt, index);
-                });
-            }
-            else if (clrType == typeof (Boolean)) {
-                fastSetter = CreateNullableTypedSetterDelegate<T, bool> (column, (stmt, index) => {
-                    return SQLite3.ColumnInt (stmt, index) == 1;
-                });
-            }
-            else if (clrType == typeof (double)) {
-                fastSetter = CreateNullableTypedSetterDelegate<T, double> (column, (stmt, index) => {
-                    return SQLite3.ColumnDouble (stmt, index);
-                });
-            }
-            else if (clrType == typeof (float)) {
-                fastSetter = CreateNullableTypedSetterDelegate<T, float> (column, (stmt, index) => {
-                    return (float) SQLite3.ColumnDouble (stmt, index);
-                });
-            }
-            else if (clrType == typeof (TimeSpan)) {
-                if (conn.StoreTimeSpanAsTicks) {
-                    fastSetter = CreateNullableTypedSetterDelegate<T, TimeSpan> (column, (stmt, index) => {
-                        return new TimeSpan (SQLite3.ColumnInt64 (stmt, index));
-                    });
-                }
-                else {
-                    fastSetter = CreateNullableTypedSetterDelegate<T, TimeSpan> (column, (stmt, index) => {
-                        var text = SQLite3.ColumnString (stmt, index);
-                        TimeSpan resultTime;
-                        if (!TimeSpan.TryParseExact (text, "c", System.Globalization.CultureInfo.InvariantCulture, System.Globalization.TimeSpanStyles.None, out resultTime)) {
-                            resultTime = TimeSpan.Parse (text);
-                        }
-                        return resultTime;
-                    });
-                }
-            }
-            else if (clrType == typeof (DateTime)) {
-                if (conn.StoreDateTimeAsTicks) {
-                    fastSetter = CreateNullableTypedSetterDelegate<T, DateTime> (column, (stmt, index) => {
-                        return new DateTime (SQLite3.ColumnInt64 (stmt, index));
-                    });
-                }
-                else {
-                    fastSetter = CreateNullableTypedSetterDelegate<T, DateTime> (column, (stmt, index) => {
-                        var text = SQLite3.ColumnString (stmt, index);
-                        DateTime resultDate;
-                        if (!DateTime.TryParseExact (text, conn.DateTimeStringFormat, System.Globalization.CultureInfo.InvariantCulture, conn.DateTimeStyle, out resultDate)) {
-                            resultDate = DateTime.Parse (text);
-                        }
-                        return resultDate;
-                    });
-                }
-            }
-            else if (clrType == typeof (DateTimeOffset)) {
-                fastSetter = CreateNullableTypedSetterDelegate<T, DateTimeOffset> (column, (stmt, index) => {
-                    return new DateTimeOffset (SQLite3.ColumnInt64 (stmt, index), TimeSpan.Zero);
-                });
-            }
-            else if (clrTypeInfo.IsEnum) {
-                // NOTE: Not sure of a good way (if any?) to do a strongly-typed fast setter like this for enumerated types -- for now, return null and column sets will revert back to the safe (but slow) Reflection-based method of column prop.Set()
-            }
-            else if (clrType == typeof (Int64)) {
-                fastSetter = CreateNullableTypedSetterDelegate<T, Int64> (column, (stmt, index) => {
-                    return SQLite3.ColumnInt64 (stmt, index);
-                });
-            }
-            else if (clrType == typeof(UInt64))
-            {
-                fastSetter = CreateNullableTypedSetterDelegate<T, UInt64>(column, (stmt, index) => {
-                    return (ulong)SQLite3.ColumnInt64(stmt, index);
-                });
-            }
-            else if (clrType == typeof (UInt32)) {
-                fastSetter = CreateNullableTypedSetterDelegate<T, UInt32> (column, (stmt, index) => {
-                    return (uint)SQLite3.ColumnInt64 (stmt, index);
-                });
-            }
-            else if (clrType == typeof (decimal)) {
-                fastSetter = CreateNullableTypedSetterDelegate<T, decimal> (column, (stmt, index) => {
-                    return (decimal)SQLite3.ColumnDouble (stmt, index);
-                });
-            }
-            else if (clrType == typeof (Byte)) {
-                fastSetter = CreateNullableTypedSetterDelegate<T, Byte> (column, (stmt, index) => {
-                    return (byte)SQLite3.ColumnInt (stmt, index);
-                });
-            }
-            else if (clrType == typeof (UInt16)) {
-                fastSetter = CreateNullableTypedSetterDelegate<T, UInt16> (column, (stmt, index) => {
-                    return (ushort)SQLite3.ColumnInt (stmt, index);
-                });
-            }
-            else if (clrType == typeof (Int16)) {
-                fastSetter = CreateNullableTypedSetterDelegate<T, Int16> (column, (stmt, index) => {
-                    return (short)SQLite3.ColumnInt (stmt, index);
-                });
-            }
-            else if (clrType == typeof (sbyte)) {
-                fastSetter = CreateNullableTypedSetterDelegate<T, sbyte> (column, (stmt, index) => {
-                    return (sbyte)SQLite3.ColumnInt (stmt, index);
-                });
-            }
-            else if (clrType == typeof (byte[])) {
-                fastSetter = CreateTypedSetterDelegate<T, byte[]> (column, (stmt, index) => {
-                    return SQLite3.ColumnByteArray (stmt, index);
-                });
-            }
-            else if (clrType == typeof (Guid)) {
-                fastSetter = CreateNullableTypedSetterDelegate<T, Guid> (column, (stmt, index) => {
-                    var text = SQLite3.ColumnString (stmt, index);
-                    return new Guid (text);
-                });
-            }
-            else if (clrType == typeof (Uri)) {
-                fastSetter = CreateTypedSetterDelegate<T, Uri> (column, (stmt, index) => {
-                    var text = SQLite3.ColumnString (stmt, index);
-                    return new Uri (text);
-                });
-            }
-            else if (clrType == typeof (StringBuilder)) {
-                fastSetter = CreateTypedSetterDelegate<T, StringBuilder> (column, (stmt, index) => {
-                    var text = SQLite3.ColumnString (stmt, index);
-                    return new StringBuilder (text);
-                });
-            }
-            else if (clrType == typeof (UriBuilder)) {
-                fastSetter = CreateTypedSetterDelegate<T, UriBuilder> (column, (stmt, index) => {
-                    var text = SQLite3.ColumnString (stmt, index);
-                    return new UriBuilder (text);
-                });
-            }
-            else {
-                // NOTE: Will fall back to the slow setter method in the event that we are unable to create a fast setter delegate for a particular column type
-            }
-            return fastSetter;
-        }
+			if (clrType == typeof (String)) {
+				fastSetter = CreateTypedSetterDelegate<T, string> (column, (stmt, index) => {
+					return SQLite3.ColumnString (stmt, index);
+				});
+			}
+			else if (clrType == typeof (Int32)) {
+				fastSetter = CreateNullableTypedSetterDelegate<T, int> (column, (stmt, index)=>{
+					return SQLite3.ColumnInt (stmt, index);
+				});
+			}
+			else if (clrType == typeof (Boolean)) {
+				fastSetter = CreateNullableTypedSetterDelegate<T, bool> (column, (stmt, index) => {
+					return SQLite3.ColumnInt (stmt, index) == 1;
+				});
+			}
+			else if (clrType == typeof (double)) {
+				fastSetter = CreateNullableTypedSetterDelegate<T, double> (column, (stmt, index) => {
+					return SQLite3.ColumnDouble (stmt, index);
+				});
+			}
+			else if (clrType == typeof (float)) {
+				fastSetter = CreateNullableTypedSetterDelegate<T, float> (column, (stmt, index) => {
+					return (float) SQLite3.ColumnDouble (stmt, index);
+				});
+			}
+			else if (clrType == typeof (TimeSpan)) {
+				if (conn.StoreTimeSpanAsTicks) {
+					fastSetter = CreateNullableTypedSetterDelegate<T, TimeSpan> (column, (stmt, index) => {
+						return new TimeSpan (SQLite3.ColumnInt64 (stmt, index));
+					});
+				}
+				else {
+					fastSetter = CreateNullableTypedSetterDelegate<T, TimeSpan> (column, (stmt, index) => {
+						var text = SQLite3.ColumnString (stmt, index);
+						TimeSpan resultTime;
+						if (!TimeSpan.TryParseExact (text, "c", System.Globalization.CultureInfo.InvariantCulture, System.Globalization.TimeSpanStyles.None, out resultTime)) {
+							resultTime = TimeSpan.Parse (text);
+						}
+						return resultTime;
+					});
+				}
+			}
+			else if (clrType == typeof (DateTime)) {
+				if (conn.StoreDateTimeAsTicks) {
+					fastSetter = CreateNullableTypedSetterDelegate<T, DateTime> (column, (stmt, index) => {
+						return new DateTime (SQLite3.ColumnInt64 (stmt, index));
+					});
+				}
+				else {
+					fastSetter = CreateNullableTypedSetterDelegate<T, DateTime> (column, (stmt, index) => {
+						var text = SQLite3.ColumnString (stmt, index);
+						DateTime resultDate;
+						if (!DateTime.TryParseExact (text, conn.DateTimeStringFormat, System.Globalization.CultureInfo.InvariantCulture, conn.DateTimeStyle, out resultDate)) {
+							resultDate = DateTime.Parse (text);
+						}
+						return resultDate;
+					});
+				}
+			}
+			else if (clrType == typeof (DateTimeOffset)) {
+				fastSetter = CreateNullableTypedSetterDelegate<T, DateTimeOffset> (column, (stmt, index) => {
+					return new DateTimeOffset (SQLite3.ColumnInt64 (stmt, index), TimeSpan.Zero);
+				});
+			}
+			else if (clrTypeInfo.IsEnum) {
+				// NOTE: Not sure of a good way (if any?) to do a strongly-typed fast setter like this for enumerated types -- for now, return null and column sets will revert back to the safe (but slow) Reflection-based method of column prop.Set()
+			}
+			else if (clrType == typeof (Int64)) {
+				fastSetter = CreateNullableTypedSetterDelegate<T, Int64> (column, (stmt, index) => {
+					return SQLite3.ColumnInt64 (stmt, index);
+				});
+			}
+			else if (clrType == typeof(UInt64))
+			{
+				fastSetter = CreateNullableTypedSetterDelegate<T, UInt64>(column, (stmt, index) => {
+					return (ulong)SQLite3.ColumnInt64(stmt, index);
+				});
+			}
+			else if (clrType == typeof (UInt32)) {
+				fastSetter = CreateNullableTypedSetterDelegate<T, UInt32> (column, (stmt, index) => {
+					return (uint)SQLite3.ColumnInt64 (stmt, index);
+				});
+			}
+			else if (clrType == typeof (decimal)) {
+				fastSetter = CreateNullableTypedSetterDelegate<T, decimal> (column, (stmt, index) => {
+					return (decimal)SQLite3.ColumnDouble (stmt, index);
+				});
+			}
+			else if (clrType == typeof (Byte)) {
+				fastSetter = CreateNullableTypedSetterDelegate<T, Byte> (column, (stmt, index) => {
+					return (byte)SQLite3.ColumnInt (stmt, index);
+				});
+			}
+			else if (clrType == typeof (UInt16)) {
+				fastSetter = CreateNullableTypedSetterDelegate<T, UInt16> (column, (stmt, index) => {
+					return (ushort)SQLite3.ColumnInt (stmt, index);
+				});
+			}
+			else if (clrType == typeof (Int16)) {
+				fastSetter = CreateNullableTypedSetterDelegate<T, Int16> (column, (stmt, index) => {
+					return (short)SQLite3.ColumnInt (stmt, index);
+				});
+			}
+			else if (clrType == typeof (sbyte)) {
+				fastSetter = CreateNullableTypedSetterDelegate<T, sbyte> (column, (stmt, index) => {
+					return (sbyte)SQLite3.ColumnInt (stmt, index);
+				});
+			}
+			else if (clrType == typeof (byte[])) {
+				fastSetter = CreateTypedSetterDelegate<T, byte[]> (column, (stmt, index) => {
+					return SQLite3.ColumnByteArray (stmt, index);
+				});
+			}
+			else if (clrType == typeof (Guid)) {
+				fastSetter = CreateNullableTypedSetterDelegate<T, Guid> (column, (stmt, index) => {
+					var text = SQLite3.ColumnString (stmt, index);
+					return new Guid (text);
+				});
+			}
+			else if (clrType == typeof (Uri)) {
+				fastSetter = CreateTypedSetterDelegate<T, Uri> (column, (stmt, index) => {
+					var text = SQLite3.ColumnString (stmt, index);
+					return new Uri (text);
+				});
+			}
+			else if (clrType == typeof (StringBuilder)) {
+				fastSetter = CreateTypedSetterDelegate<T, StringBuilder> (column, (stmt, index) => {
+					var text = SQLite3.ColumnString (stmt, index);
+					return new StringBuilder (text);
+				});
+			}
+			else if (clrType == typeof (UriBuilder)) {
+				fastSetter = CreateTypedSetterDelegate<T, UriBuilder> (column, (stmt, index) => {
+					var text = SQLite3.ColumnString (stmt, index);
+					return new UriBuilder (text);
+				});
+			}
+			else {
+				// NOTE: Will fall back to the slow setter method in the event that we are unable to create a fast setter delegate for a particular column type
+			}
+			return fastSetter;
+		}
 
-        /// <summary>
-        /// This creates a strongly typed delegate that will permit fast setting of column values given a Sqlite3Statement and a column index.
-        ///
-        /// Note that this is identical to CreateTypedSetterDelegate(), but has an extra check to see if it should create a nullable version of the delegate.
-        /// </summary>
-        /// <typeparam name="ObjectType">The type of the object whose member column is being set</typeparam>
-        /// <typeparam name="ColumnMemberType">The CLR type of the member in the object which corresponds to the given SQLite columnn</typeparam>
-        /// <param name="column">The column mapping that identifies the target member of the destination object</param>
-        /// <param name="getColumnValue">A lambda that can be used to retrieve the column value at query-time</param>
-        /// <returns>A strongly-typed delegate</returns>
-        private static Action<object, Sqlite3Statement, int> CreateNullableTypedSetterDelegate<ObjectType, ColumnMemberType> (TableMapping.Column column, Func<Sqlite3Statement, int, ColumnMemberType> getColumnValue) where ColumnMemberType : struct
-        {
-            var clrTypeInfo = column.PropertyInfo.PropertyType.GetTypeInfo();
-            bool isNullable = false;
+		/// <summary>
+		/// This creates a strongly typed delegate that will permit fast setting of column values given a Sqlite3Statement and a column index.
+		///
+		/// Note that this is identical to CreateTypedSetterDelegate(), but has an extra check to see if it should create a nullable version of the delegate.
+		/// </summary>
+		/// <typeparam name="ObjectType">The type of the object whose member column is being set</typeparam>
+		/// <typeparam name="ColumnMemberType">The CLR type of the member in the object which corresponds to the given SQLite columnn</typeparam>
+		/// <param name="column">The column mapping that identifies the target member of the destination object</param>
+		/// <param name="getColumnValue">A lambda that can be used to retrieve the column value at query-time</param>
+		/// <returns>A strongly-typed delegate</returns>
+		private static Action<object, Sqlite3Statement, int> CreateNullableTypedSetterDelegate<ObjectType, ColumnMemberType> (TableMapping.Column column, Func<Sqlite3Statement, int, ColumnMemberType> getColumnValue) where ColumnMemberType : struct
+		{
+			var clrTypeInfo = column.PropertyInfo.PropertyType.GetTypeInfo();
+			bool isNullable = false;
 
-            if (clrTypeInfo.IsGenericType && clrTypeInfo.GetGenericTypeDefinition () == typeof (Nullable<>)) {
-                isNullable = true;
-            }
+			if (clrTypeInfo.IsGenericType && clrTypeInfo.GetGenericTypeDefinition () == typeof (Nullable<>)) {
+				isNullable = true;
+			}
 
-            if (isNullable) {
-                var setProperty = (Action<ObjectType, ColumnMemberType?>)Delegate.CreateDelegate (
-                        typeof (Action<ObjectType, ColumnMemberType?>), null,
-                        column.PropertyInfo.GetSetMethod ());
+			if (isNullable) {
+				var setProperty = (Action<ObjectType, ColumnMemberType?>)Delegate.CreateDelegate (
+						typeof (Action<ObjectType, ColumnMemberType?>), null,
+						column.PropertyInfo.GetSetMethod ());
 
-                return (o, stmt, i) => {
-                    var colType = SQLite3.ColumnType (stmt, i);
-                    if (colType != SQLite3.ColType.Null)
-                        setProperty.Invoke ((ObjectType)o, getColumnValue.Invoke (stmt, i));
-                };
-            }
+				return (o, stmt, i) => {
+					var colType = SQLite3.ColumnType (stmt, i);
+					if (colType != SQLite3.ColType.Null)
+						setProperty.Invoke ((ObjectType)o, getColumnValue.Invoke (stmt, i));
+				};
+			}
 
-            return CreateTypedSetterDelegate<ObjectType, ColumnMemberType> (column, getColumnValue);
-        }
+			return CreateTypedSetterDelegate<ObjectType, ColumnMemberType> (column, getColumnValue);
+		}
 
-        /// <summary>
-        /// This creates a strongly typed delegate that will permit fast setting of column values given a Sqlite3Statement and a column index.
-        /// </summary>
-        /// <typeparam name="ObjectType">The type of the object whose member column is being set</typeparam>
-        /// <typeparam name="ColumnMemberType">The CLR type of the member in the object which corresponds to the given SQLite columnn</typeparam>
-        /// <param name="column">The column mapping that identifies the target member of the destination object</param>
-        /// <param name="getColumnValue">A lambda that can be used to retrieve the column value at query-time</param>
-        /// <returns>A strongly-typed delegate</returns>
-        private static Action<object, Sqlite3Statement, int> CreateTypedSetterDelegate<ObjectType, ColumnMemberType> (TableMapping.Column column, Func<Sqlite3Statement, int, ColumnMemberType> getColumnValue)
-        {
-            var setProperty = (Action<ObjectType, ColumnMemberType>)Delegate.CreateDelegate (
-                    typeof (Action<ObjectType, ColumnMemberType>), null,
-                    column.PropertyInfo.GetSetMethod ());
+		/// <summary>
+		/// This creates a strongly typed delegate that will permit fast setting of column values given a Sqlite3Statement and a column index.
+		/// </summary>
+		/// <typeparam name="ObjectType">The type of the object whose member column is being set</typeparam>
+		/// <typeparam name="ColumnMemberType">The CLR type of the member in the object which corresponds to the given SQLite columnn</typeparam>
+		/// <param name="column">The column mapping that identifies the target member of the destination object</param>
+		/// <param name="getColumnValue">A lambda that can be used to retrieve the column value at query-time</param>
+		/// <returns>A strongly-typed delegate</returns>
+		private static Action<object, Sqlite3Statement, int> CreateTypedSetterDelegate<ObjectType, ColumnMemberType> (TableMapping.Column column, Func<Sqlite3Statement, int, ColumnMemberType> getColumnValue)
+		{
+			var setProperty = (Action<ObjectType, ColumnMemberType>)Delegate.CreateDelegate (
+					typeof (Action<ObjectType, ColumnMemberType>), null,
+					column.PropertyInfo.GetSetMethod ());
 
-            return (o, stmt, i) => {
-                var colType = SQLite3.ColumnType (stmt, i);
-                if (colType != SQLite3.ColType.Null)
-                    setProperty.Invoke ((ObjectType)o, getColumnValue.Invoke (stmt, i));
-            };
-        }
-    }
+			return (o, stmt, i) => {
+				var colType = SQLite3.ColumnType (stmt, i);
+				if (colType != SQLite3.ColType.Null)
+					setProperty.Invoke ((ObjectType)o, getColumnValue.Invoke (stmt, i));
+			};
+		}
+	}
 
-    /// <summary>
-    /// Since the insert never changed, we only need to prepare once.
-    /// </summary>
-    class PreparedSqlLiteInsertCommand : IDisposable
-    {
-        bool Initialized;
+	/// <summary>
+	/// Since the insert never changed, we only need to prepare once.
+	/// </summary>
+	class PreparedSqlLiteInsertCommand : IDisposable
+	{
+		bool Initialized;
 
-        SQLiteConnection Connection;
+		SQLiteConnection Connection;
 
-        string CommandText;
+		string CommandText;
 
-        Sqlite3Statement Statement;
-        static readonly Sqlite3Statement NullStatement = default (Sqlite3Statement);
+		Sqlite3Statement Statement;
+		static readonly Sqlite3Statement NullStatement = default (Sqlite3Statement);
 
-        public PreparedSqlLiteInsertCommand (SQLiteConnection conn, string commandText)
-        {
-            Connection = conn;
-            CommandText = commandText;
-        }
+		public PreparedSqlLiteInsertCommand (SQLiteConnection conn, string commandText)
+		{
+			Connection = conn;
+			CommandText = commandText;
+		}
 
-        public int ExecuteNonQuery (object[] source)
-        {
-            if (Initialized && Statement == NullStatement) {
-                throw new ObjectDisposedException (nameof (PreparedSqlLiteInsertCommand));
-            }
+		public int ExecuteNonQuery (object[] source)
+		{
+			if (Initialized && Statement == NullStatement) {
+				throw new ObjectDisposedException (nameof (PreparedSqlLiteInsertCommand));
+			}
 
-            if (Connection.Trace) {
-                Connection.Tracer?.Invoke ("Executing: " + CommandText);
-            }
+			if (Connection.Trace) {
+				Connection.Tracer?.Invoke ("Executing: " + CommandText);
+			}
 
-            var r = SQLite3.Result.OK;
+			var r = SQLite3.Result.OK;
 
-            if (!Initialized) {
-                Statement = SQLite3.Prepare2 (Connection.Handle, CommandText);
-                Initialized = true;
-            }
+			if (!Initialized) {
+				Statement = SQLite3.Prepare2 (Connection.Handle, CommandText);
+				Initialized = true;
+			}
 
-            //bind the values.
-            if (source != null) {
-                for (int i = 0; i < source.Length; i++) {
-                    SQLiteCommand.BindParameter (Statement, i + 1, source[i], Connection.StoreDateTimeAsTicks, Connection.DateTimeStringFormat, Connection.StoreTimeSpanAsTicks);
-                }
-            }
-            r = SQLite3.Step (Statement);
+			//bind the values.
+			if (source != null) {
+				for (int i = 0; i < source.Length; i++) {
+					SQLiteCommand.BindParameter (Statement, i + 1, source[i], Connection.StoreDateTimeAsTicks, Connection.DateTimeStringFormat, Connection.StoreTimeSpanAsTicks);
+				}
+			}
+			r = SQLite3.Step (Statement);
 
-            if (r == SQLite3.Result.Done) {
-                int rowsAffected = SQLite3.Changes (Connection.Handle);
-                SQLite3.Reset (Statement);
-                return rowsAffected;
-            }
-            else if (r == SQLite3.Result.Error) {
-                string msg = SQLite3.GetErrmsg (Connection.Handle);
-                SQLite3.Reset (Statement);
-                throw SQLiteException.New (r, msg);
-            }
-            else if (r == SQLite3.Result.Constraint && SQLite3.ExtendedErrCode (Connection.Handle) == SQLite3.ExtendedResult.ConstraintNotNull) {
-                SQLite3.Reset (Statement);
-                throw NotNullConstraintViolationException.New (r, SQLite3.GetErrmsg (Connection.Handle));
-            }
-            else {
-                SQLite3.Reset (Statement);
-                throw SQLiteException.New (r, SQLite3.GetErrmsg (Connection.Handle));
-            }
-        }
+			if (r == SQLite3.Result.Done) {
+				int rowsAffected = SQLite3.Changes (Connection.Handle);
+				SQLite3.Reset (Statement);
+				return rowsAffected;
+			}
+			else if (r == SQLite3.Result.Error) {
+				string msg = SQLite3.GetErrmsg (Connection.Handle);
+				SQLite3.Reset (Statement);
+				throw SQLiteException.New (r, msg);
+			}
+			else if (r == SQLite3.Result.Constraint && SQLite3.ExtendedErrCode (Connection.Handle) == SQLite3.ExtendedResult.ConstraintNotNull) {
+				SQLite3.Reset (Statement);
+				throw NotNullConstraintViolationException.New (r, SQLite3.GetErrmsg (Connection.Handle));
+			}
+			else {
+				SQLite3.Reset (Statement);
+				throw SQLiteException.New (r, SQLite3.GetErrmsg (Connection.Handle));
+			}
+		}
 
-        public void Dispose ()
-        {
-            Dispose (true);
-            GC.SuppressFinalize (this);
-        }
+		public void Dispose ()
+		{
+			Dispose (true);
+			GC.SuppressFinalize (this);
+		}
 
-        void Dispose (bool disposing)
-        {
-            var s = Statement;
-            Statement = NullStatement;
-            Connection = null;
-            if (s != NullStatement) {
-                SQLite3.Finalize (s);
-            }
-        }
+		void Dispose (bool disposing)
+		{
+			var s = Statement;
+			Statement = NullStatement;
+			Connection = null;
+			if (s != NullStatement) {
+				SQLite3.Finalize (s);
+			}
+		}
 
-        ~PreparedSqlLiteInsertCommand ()
-        {
-            Dispose (false);
-        }
-    }
+		~PreparedSqlLiteInsertCommand ()
+		{
+			Dispose (false);
+		}
+	}
 
-    public enum CreateTableResult
-    {
-        Created,
-        Migrated,
-    }
+	public enum CreateTableResult
+	{
+		Created,
+		Migrated,
+	}
 
-    public class CreateTablesResult
-    {
-        public Dictionary<Type, CreateTableResult> Results { get; private set; }
+	public class CreateTablesResult
+	{
+		public Dictionary<Type, CreateTableResult> Results { get; private set; }
 
-        public CreateTablesResult ()
-        {
-            Results = new Dictionary<Type, CreateTableResult> ();
-        }
-    }
+		public CreateTablesResult ()
+		{
+			Results = new Dictionary<Type, CreateTableResult> ();
+		}
+	}
 
-    public abstract class BaseTableQuery
-    {
-        protected class Ordering
-        {
-            public string ColumnName { get; set; }
-            public bool Ascending { get; set; }
-        }
-    }
+	public abstract class BaseTableQuery
+	{
+		protected class Ordering
+		{
+			public string ColumnName { get; set; }
+			public bool Ascending { get; set; }
+		}
+	}
 
-    public class TableQuery<
+	public class TableQuery<
 #if NET8_0_OR_GREATER
 		[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
 #endif
 		T> : BaseTableQuery, IEnumerable<T>
-    {
-        public SQLiteConnection Connection { get; private set; }
+	{
+		public SQLiteConnection Connection { get; private set; }
 
-        public TableMapping Table { get; private set; }
+		public TableMapping Table { get; private set; }
 
-        Expression _where;
-        List<Ordering> _orderBys;
-        int? _limit;
-        int? _offset;
+		Expression _where;
+		List<Ordering> _orderBys;
+		int? _limit;
+		int? _offset;
 
-        BaseTableQuery _joinInner;
-        Expression _joinInnerKeySelector;
-        BaseTableQuery _joinOuter;
-        Expression _joinOuterKeySelector;
-        Expression _joinSelector;
+		BaseTableQuery _joinInner;
+		Expression _joinInnerKeySelector;
+		BaseTableQuery _joinOuter;
+		Expression _joinOuterKeySelector;
+		Expression _joinSelector;
 
-        Expression _selector;
+		Expression _selector;
 
-        TableQuery (SQLiteConnection conn, TableMapping table)
-        {
-            Connection = conn;
-            Table = table;
-        }
+		TableQuery (SQLiteConnection conn, TableMapping table)
+		{
+			Connection = conn;
+			Table = table;
+		}
 
-        public TableQuery (SQLiteConnection conn)
-        {
-            Connection = conn;
-            Table = Connection.GetMapping (typeof (T));
-        }
+		public TableQuery (SQLiteConnection conn)
+		{
+			Connection = conn;
+			Table = Connection.GetMapping (typeof (T));
+		}
 
-        public TableQuery<U> Clone<
+		public TableQuery<U> Clone<
 #if NET8_0_OR_GREATER
 			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
 #endif
 			U> ()
-        {
-            var q = new TableQuery<U> (Connection, Table);
-            q._where = _where;
-            q._deferred = _deferred;
-            if (_orderBys != null) {
-                q._orderBys = new List<Ordering> (_orderBys);
-            }
-            q._limit = _limit;
-            q._offset = _offset;
-            q._joinInner = _joinInner;
-            q._joinInnerKeySelector = _joinInnerKeySelector;
-            q._joinOuter = _joinOuter;
-            q._joinOuterKeySelector = _joinOuterKeySelector;
-            q._joinSelector = _joinSelector;
-            q._selector = _selector;
-            return q;
-        }
+		{
+			var q = new TableQuery<U> (Connection, Table);
+			q._where = _where;
+			q._deferred = _deferred;
+			if (_orderBys != null) {
+				q._orderBys = new List<Ordering> (_orderBys);
+			}
+			q._limit = _limit;
+			q._offset = _offset;
+			q._joinInner = _joinInner;
+			q._joinInnerKeySelector = _joinInnerKeySelector;
+			q._joinOuter = _joinOuter;
+			q._joinOuterKeySelector = _joinOuterKeySelector;
+			q._joinSelector = _joinSelector;
+			q._selector = _selector;
+			return q;
+		}
 
-        /// <summary>
-        /// Filters the query based on a predicate.
-        /// </summary>
-        public TableQuery<T> Where (Expression<Func<T, bool>> predExpr)
-        {
-            if (predExpr.NodeType == ExpressionType.Lambda) {
-                var lambda = (LambdaExpression)predExpr;
-                var pred = lambda.Body;
-                var q = Clone<T> ();
-                q.AddWhere (pred);
-                return q;
-            }
-            else {
-                throw new NotSupportedException ("Must be a predicate");
-            }
-        }
+		/// <summary>
+		/// Filters the query based on a predicate.
+		/// </summary>
+		public TableQuery<T> Where (Expression<Func<T, bool>> predExpr)
+		{
+			if (predExpr.NodeType == ExpressionType.Lambda) {
+				var lambda = (LambdaExpression)predExpr;
+				var pred = lambda.Body;
+				var q = Clone<T> ();
+				q.AddWhere (pred);
+				return q;
+			}
+			else {
+				throw new NotSupportedException ("Must be a predicate");
+			}
+		}
 
-        /// <summary>
-        /// Delete all the rows that match this query.
-        /// </summary>
-        public int Delete ()
-        {
-            return Delete (null);
-        }
+		/// <summary>
+		/// Delete all the rows that match this query.
+		/// </summary>
+		public int Delete ()
+		{
+			return Delete (null);
+		}
 
-        /// <summary>
-        /// Delete all the rows that match this query and the given predicate.
-        /// </summary>
-        public int Delete (Expression<Func<T, bool>> predExpr)
-        {
-            if (_limit.HasValue || _offset.HasValue)
-                throw new InvalidOperationException ("Cannot delete with limits or offsets");
+		/// <summary>
+		/// Delete all the rows that match this query and the given predicate.
+		/// </summary>
+		public int Delete (Expression<Func<T, bool>> predExpr)
+		{
+			if (_limit.HasValue || _offset.HasValue)
+				throw new InvalidOperationException ("Cannot delete with limits or offsets");
 
-            if (_where == null && predExpr == null)
-                throw new InvalidOperationException ("No condition specified");
+			if (_where == null && predExpr == null)
+				throw new InvalidOperationException ("No condition specified");
 
-            var pred = _where;
+			var pred = _where;
 
-            if (predExpr != null && predExpr.NodeType == ExpressionType.Lambda) {
-                var lambda = (LambdaExpression)predExpr;
-                pred = pred != null ? Expression.AndAlso (pred, lambda.Body) : lambda.Body;
-            }
+			if (predExpr != null && predExpr.NodeType == ExpressionType.Lambda) {
+				var lambda = (LambdaExpression)predExpr;
+				pred = pred != null ? Expression.AndAlso (pred, lambda.Body) : lambda.Body;
+			}
 
-            var args = new List<object> ();
-            var cmdText = "delete from \"" + Table.TableName + "\"";
-            var w = CompileExpr (pred, args);
-            cmdText += " where " + w.CommandText;
+			var args = new List<object> ();
+			var cmdText = "delete from \"" + Table.TableName + "\"";
+			var w = CompileExpr (pred, args);
+			cmdText += " where " + w.CommandText;
 
-            var command = Connection.CreateCommand (cmdText, args.ToArray ());
+			var command = Connection.CreateCommand (cmdText, args.ToArray ());
 
-            int result = command.ExecuteNonQuery ();
-            return result;
-        }
+			int result = command.ExecuteNonQuery ();
+			return result;
+		}
 
-        /// <summary>
-        /// Yields a given number of elements from the query and then skips the remainder.
-        /// </summary>
-        public TableQuery<T> Take (int n)
-        {
-            var q = Clone<T> ();
-            q._limit = n;
-            return q;
-        }
+		/// <summary>
+		/// Yields a given number of elements from the query and then skips the remainder.
+		/// </summary>
+		public TableQuery<T> Take (int n)
+		{
+			var q = Clone<T> ();
+			q._limit = n;
+			return q;
+		}
 
-        /// <summary>
-        /// Skips a given number of elements from the query and then yields the remainder.
-        /// </summary>
-        public TableQuery<T> Skip (int n)
-        {
-            var q = Clone<T> ();
-            q._offset = n;
-            return q;
-        }
+		/// <summary>
+		/// Skips a given number of elements from the query and then yields the remainder.
+		/// </summary>
+		public TableQuery<T> Skip (int n)
+		{
+			var q = Clone<T> ();
+			q._offset = n;
+			return q;
+		}
 
-        /// <summary>
-        /// Returns the element at a given index
-        /// </summary>
-        public T ElementAt (int index)
-        {
-            return Skip (index).Take (1).First ();
-        }
+		/// <summary>
+		/// Returns the element at a given index
+		/// </summary>
+		public T ElementAt (int index)
+		{
+			return Skip (index).Take (1).First ();
+		}
 
-        bool _deferred;
-        public TableQuery<T> Deferred ()
-        {
-            var q = Clone<T> ();
-            q._deferred = true;
-            return q;
-        }
+		bool _deferred;
+		public TableQuery<T> Deferred ()
+		{
+			var q = Clone<T> ();
+			q._deferred = true;
+			return q;
+		}
 
-        /// <summary>
-        /// Order the query results according to a key.
-        /// </summary>
-        public TableQuery<T> OrderBy<U> (Expression<Func<T, U>> orderExpr)
-        {
-            return AddOrderBy<U> (orderExpr, true);
-        }
+		/// <summary>
+		/// Order the query results according to a key.
+		/// </summary>
+		public TableQuery<T> OrderBy<U> (Expression<Func<T, U>> orderExpr)
+		{
+			return AddOrderBy<U> (orderExpr, true);
+		}
 
-        /// <summary>
-        /// Order the query results according to a key.
-        /// </summary>
-        public TableQuery<T> OrderByDescending<U> (Expression<Func<T, U>> orderExpr)
-        {
-            return AddOrderBy<U> (orderExpr, false);
-        }
+		/// <summary>
+		/// Order the query results according to a key.
+		/// </summary>
+		public TableQuery<T> OrderByDescending<U> (Expression<Func<T, U>> orderExpr)
+		{
+			return AddOrderBy<U> (orderExpr, false);
+		}
 
-        /// <summary>
-        /// Order the query results according to a key.
-        /// </summary>
-        public TableQuery<T> ThenBy<U> (Expression<Func<T, U>> orderExpr)
-        {
-            return AddOrderBy<U> (orderExpr, true);
-        }
+		/// <summary>
+		/// Order the query results according to a key.
+		/// </summary>
+		public TableQuery<T> ThenBy<U> (Expression<Func<T, U>> orderExpr)
+		{
+			return AddOrderBy<U> (orderExpr, true);
+		}
 
-        /// <summary>
-        /// Order the query results according to a key.
-        /// </summary>
-        public TableQuery<T> ThenByDescending<U> (Expression<Func<T, U>> orderExpr)
-        {
-            return AddOrderBy<U> (orderExpr, false);
-        }
+		/// <summary>
+		/// Order the query results according to a key.
+		/// </summary>
+		public TableQuery<T> ThenByDescending<U> (Expression<Func<T, U>> orderExpr)
+		{
+			return AddOrderBy<U> (orderExpr, false);
+		}
 
-        TableQuery<T> AddOrderBy<U> (Expression<Func<T, U>> orderExpr, bool asc)
-        {
-            if (orderExpr.NodeType == ExpressionType.Lambda) {
-                var lambda = (LambdaExpression)orderExpr;
+		TableQuery<T> AddOrderBy<U> (Expression<Func<T, U>> orderExpr, bool asc)
+		{
+			if (orderExpr.NodeType == ExpressionType.Lambda) {
+				var lambda = (LambdaExpression)orderExpr;
 
-                MemberExpression mem = null;
+				MemberExpression mem = null;
 
-                var unary = lambda.Body as UnaryExpression;
-                if (unary != null && unary.NodeType == ExpressionType.Convert) {
-                    mem = unary.Operand as MemberExpression;
-                }
-                else {
-                    mem = lambda.Body as MemberExpression;
-                }
+				var unary = lambda.Body as UnaryExpression;
+				if (unary != null && unary.NodeType == ExpressionType.Convert) {
+					mem = unary.Operand as MemberExpression;
+				}
+				else {
+					mem = lambda.Body as MemberExpression;
+				}
 
-                if (mem != null && (mem.Expression.NodeType == ExpressionType.Parameter)) {
-                    var q = Clone<T> ();
-                    if (q._orderBys == null) {
-                        q._orderBys = new List<Ordering> ();
-                    }
-                    q._orderBys.Add (new Ordering {
-                        ColumnName = Table.FindColumnWithPropertyName (mem.Member.Name).Name,
-                        Ascending = asc
-                    });
-                    return q;
-                }
-                else {
-                    throw new NotSupportedException ("Order By does not support: " + orderExpr);
-                }
-            }
-            else {
-                throw new NotSupportedException ("Must be a predicate");
-            }
-        }
+				if (mem != null && (mem.Expression.NodeType == ExpressionType.Parameter)) {
+					var q = Clone<T> ();
+					if (q._orderBys == null) {
+						q._orderBys = new List<Ordering> ();
+					}
+					q._orderBys.Add (new Ordering {
+						ColumnName = Table.FindColumnWithPropertyName (mem.Member.Name).Name,
+						Ascending = asc
+					});
+					return q;
+				}
+				else {
+					throw new NotSupportedException ("Order By does not support: " + orderExpr);
+				}
+			}
+			else {
+				throw new NotSupportedException ("Must be a predicate");
+			}
+		}
 
-        private void AddWhere (Expression pred)
-        {
-            if (_where == null) {
-                _where = pred;
-            }
-            else {
-                _where = Expression.AndAlso (_where, pred);
-            }
-        }
+		private void AddWhere (Expression pred)
+		{
+			if (_where == null) {
+				_where = pred;
+			}
+			else {
+				_where = Expression.AndAlso (_where, pred);
+			}
+		}
 
-        ///// <summary>
-        ///// Performs an inner join of two queries based on matching keys extracted from the elements.
-        ///// </summary>
-        //public TableQuery<TResult> Join<TInner, TKey, TResult> (
-        //	TableQuery<TInner> inner,
-        //	Expression<Func<T, TKey>> outerKeySelector,
-        //	Expression<Func<TInner, TKey>> innerKeySelector,
-        //	Expression<Func<T, TInner, TResult>> resultSelector)
-        //{
-        //	var q = new TableQuery<TResult> (Connection, Connection.GetMapping (typeof (TResult))) {
-        //		_joinOuter = this,
-        //		_joinOuterKeySelector = outerKeySelector,
-        //		_joinInner = inner,
-        //		_joinInnerKeySelector = innerKeySelector,
-        //		_joinSelector = resultSelector,
-        //	};
-        //	return q;
-        //}
+		///// <summary>
+		///// Performs an inner join of two queries based on matching keys extracted from the elements.
+		///// </summary>
+		//public TableQuery<TResult> Join<TInner, TKey, TResult> (
+		//	TableQuery<TInner> inner,
+		//	Expression<Func<T, TKey>> outerKeySelector,
+		//	Expression<Func<TInner, TKey>> innerKeySelector,
+		//	Expression<Func<T, TInner, TResult>> resultSelector)
+		//{
+		//	var q = new TableQuery<TResult> (Connection, Connection.GetMapping (typeof (TResult))) {
+		//		_joinOuter = this,
+		//		_joinOuterKeySelector = outerKeySelector,
+		//		_joinInner = inner,
+		//		_joinInnerKeySelector = innerKeySelector,
+		//		_joinSelector = resultSelector,
+		//	};
+		//	return q;
+		//}
 
-        // Not needed until Joins are supported
-        // Keeping this commented out forces the default Linq to objects processor to run
-        //public TableQuery<TResult> Select<TResult> (Expression<Func<T, TResult>> selector)
-        //{
-        //	var q = Clone<TResult> ();
-        //	q._selector = selector;
-        //	return q;
-        //}
+		// Not needed until Joins are supported
+		// Keeping this commented out forces the default Linq to objects processor to run
+		//public TableQuery<TResult> Select<TResult> (Expression<Func<T, TResult>> selector)
+		//{
+		//	var q = Clone<TResult> ();
+		//	q._selector = selector;
+		//	return q;
+		//}
 
-        private SQLiteCommand GenerateCommand (string selectionList)
-        {
-            if (_joinInner != null && _joinOuter != null) {
-                throw new NotSupportedException ("Joins are not supported.");
-            }
-            else {
-                var cmdText = "select " + selectionList + " from \"" + Table.TableName + "\"";
-                var args = new List<object> ();
-                if (_where != null) {
-                    var w = CompileExpr (_where, args);
-                    cmdText += " where " + w.CommandText;
-                }
-                if ((_orderBys != null) && (_orderBys.Count > 0)) {
-                    var t = string.Join (", ", _orderBys.Select (o => "\"" + o.ColumnName + "\"" + (o.Ascending ? "" : " desc")).ToArray ());
-                    cmdText += " order by " + t;
-                }
-                if (_limit.HasValue) {
-                    cmdText += " limit " + _limit.Value;
-                }
-                if (_offset.HasValue) {
-                    if (!_limit.HasValue) {
-                        cmdText += " limit -1 ";
-                    }
-                    cmdText += " offset " + _offset.Value;
-                }
-                return Connection.CreateCommand (cmdText, args.ToArray ());
-            }
-        }
+		private SQLiteCommand GenerateCommand (string selectionList)
+		{
+			if (_joinInner != null && _joinOuter != null) {
+				throw new NotSupportedException ("Joins are not supported.");
+			}
+			else {
+				var cmdText = "select " + selectionList + " from \"" + Table.TableName + "\"";
+				var args = new List<object> ();
+				if (_where != null) {
+					var w = CompileExpr (_where, args);
+					cmdText += " where " + w.CommandText;
+				}
+				if ((_orderBys != null) && (_orderBys.Count > 0)) {
+					var t = string.Join (", ", _orderBys.Select (o => "\"" + o.ColumnName + "\"" + (o.Ascending ? "" : " desc")).ToArray ());
+					cmdText += " order by " + t;
+				}
+				if (_limit.HasValue) {
+					cmdText += " limit " + _limit.Value;
+				}
+				if (_offset.HasValue) {
+					if (!_limit.HasValue) {
+						cmdText += " limit -1 ";
+					}
+					cmdText += " offset " + _offset.Value;
+				}
+				return Connection.CreateCommand (cmdText, args.ToArray ());
+			}
+		}
 
-        class CompileResult
-        {
-            public string CommandText { get; set; }
+		class CompileResult
+		{
+			public string CommandText { get; set; }
 
-            public object Value { get; set; }
-        }
+			public object Value { get; set; }
+		}
 
-        private CompileResult CompileExpr (Expression expr, List<object> queryArgs)
-        {
-            if (expr == null) {
-                throw new NotSupportedException ("Expression is NULL");
-            }
-            else if (expr is BinaryExpression) {
-                var bin = (BinaryExpression)expr;
+		private CompileResult CompileExpr (Expression expr, List<object> queryArgs)
+		{
+			if (expr == null) {
+				throw new NotSupportedException ("Expression is NULL");
+			}
+			else if (expr is BinaryExpression) {
+				var bin = (BinaryExpression)expr;
 
-                // VB turns 'x=="foo"' into 'CompareString(x,"foo",true/false)==0', so we need to unwrap it
-                // http://blogs.msdn.com/b/vbteam/archive/2007/09/18/vb-expression-trees-string-comparisons.aspx
-                if (bin.Left.NodeType == ExpressionType.Call) {
-                    var call = (MethodCallExpression)bin.Left;
-                    if (call.Method.DeclaringType.FullName == "Microsoft.VisualBasic.CompilerServices.Operators"
-                        && call.Method.Name == "CompareString")
-                        bin = Expression.MakeBinary (bin.NodeType, call.Arguments[0], call.Arguments[1]);
-                }
-
-
-                var leftr = CompileExpr (bin.Left, queryArgs);
-                var rightr = CompileExpr (bin.Right, queryArgs);
-
-                //If either side is a parameter and is null, then handle the other side specially (for "is null"/"is not null")
-                string text;
-                if (leftr.CommandText == "?" && leftr.Value == null)
-                    text = CompileNullBinaryExpression (bin, rightr);
-                else if (rightr.CommandText == "?" && rightr.Value == null)
-                    text = CompileNullBinaryExpression (bin, leftr);
-                else
-                    text = "(" + leftr.CommandText + " " + GetSqlName (bin) + " " + rightr.CommandText + ")";
-                return new CompileResult { CommandText = text };
-            }
-            else if (expr.NodeType == ExpressionType.Not) {
-                var operandExpr = ((UnaryExpression)expr).Operand;
-                var opr = CompileExpr (operandExpr, queryArgs);
-                object val = opr.Value;
-                if (val is bool)
-                    val = !((bool)val);
-                return new CompileResult {
-                    CommandText = "NOT(" + opr.CommandText + ")",
-                    Value = val
-                };
-            }
-            else if (expr.NodeType == ExpressionType.Call) {
-
-                var call = (MethodCallExpression)expr;
-                var args = new CompileResult[call.Arguments.Count];
-                var obj = call.Object != null ? CompileExpr (call.Object, queryArgs) : null;
-
-                for (var i = 0; i < args.Length; i++) {
-                    args[i] = CompileExpr (call.Arguments[i], queryArgs);
-                }
-
-                var sqlCall = "";
-
-                if (call.Method.Name == "Like" && args.Length == 2) {
-                    sqlCall = "(" + args[0].CommandText + " like " + args[1].CommandText + ")";
-                }
-                else if (call.Method.Name == "Contains" && args.Length == 2) {
-                    sqlCall = "(" + args[1].CommandText + " in " + args[0].CommandText + ")";
-                }
-                else if (call.Method.Name == "Contains" && args.Length == 1) {
-                    if (call.Object != null && call.Object.Type == typeof (string)) {
-                        sqlCall = "( instr(" + obj.CommandText + "," + args[0].CommandText + ") >0 )";
-                    }
-                    else {
-                        sqlCall = "(" + args[0].CommandText + " in " + obj.CommandText + ")";
-                    }
-                }
-                else if (call.Method.Name == "StartsWith" && args.Length >= 1) {
-                    var startsWithCmpOp = StringComparison.CurrentCulture;
-                    if (args.Length == 2) {
-                        startsWithCmpOp = (StringComparison)args[1].Value;
-                    }
-                    switch (startsWithCmpOp) {
-                        case StringComparison.Ordinal:
-                        case StringComparison.CurrentCulture:
-                            sqlCall = "( substr(" + obj.CommandText + ", 1, " + args[0].Value.ToString ().Length + ") =  " + args[0].CommandText + ")";
-                            break;
-                        case StringComparison.OrdinalIgnoreCase:
-                        case StringComparison.CurrentCultureIgnoreCase:
-                            sqlCall = "(" + obj.CommandText + " like (" + args[0].CommandText + " || '%'))";
-                            break;
-                    }
-
-                }
-                else if (call.Method.Name == "EndsWith" && args.Length >= 1) {
-                    var endsWithCmpOp = StringComparison.CurrentCulture;
-                    if (args.Length == 2) {
-                        endsWithCmpOp = (StringComparison)args[1].Value;
-                    }
-                    switch (endsWithCmpOp) {
-                        case StringComparison.Ordinal:
-                        case StringComparison.CurrentCulture:
-                            sqlCall = "( substr(" + obj.CommandText + ", length(" + obj.CommandText + ") - " + args[0].Value.ToString ().Length + "+1, " + args[0].Value.ToString ().Length + ") =  " + args[0].CommandText + ")";
-                            break;
-                        case StringComparison.OrdinalIgnoreCase:
-                        case StringComparison.CurrentCultureIgnoreCase:
-                            sqlCall = "(" + obj.CommandText + " like ('%' || " + args[0].CommandText + "))";
-                            break;
-                    }
-                }
-                else if (call.Method.Name == "Equals" && args.Length == 1) {
-                    sqlCall = "(" + obj.CommandText + " = (" + args[0].CommandText + "))";
-                }
-                else if (call.Method.Name == "ToLower") {
-                    sqlCall = "(lower(" + obj.CommandText + "))";
-                }
-                else if (call.Method.Name == "ToUpper") {
-                    sqlCall = "(upper(" + obj.CommandText + "))";
-                }
-                else if (call.Method.Name == "Replace" && args.Length == 2) {
-                    sqlCall = "(replace(" + obj.CommandText + "," + args[0].CommandText + "," + args[1].CommandText + "))";
-                }
-                else if (call.Method.Name == "IsNullOrEmpty" && args.Length == 1) {
-                    sqlCall = "(" + args[0].CommandText + " is null or" + args[0].CommandText + " ='' )";
-                }
-                else {
-                    sqlCall = call.Method.Name.ToLower () + "(" + string.Join (",", args.Select (a => a.CommandText).ToArray ()) + ")";
-                }
-                return new CompileResult { CommandText = sqlCall };
-
-            }
-            else if (expr.NodeType == ExpressionType.Constant) {
-                var c = (ConstantExpression)expr;
-                queryArgs.Add (c.Value);
-                return new CompileResult {
-                    CommandText = "?",
-                    Value = c.Value
-                };
-            }
-            else if (expr.NodeType == ExpressionType.Convert) {
-                var u = (UnaryExpression)expr;
-                var ty = u.Type;
-                var valr = CompileExpr (u.Operand, queryArgs);
-                return new CompileResult {
-                    CommandText = valr.CommandText,
-                    Value = valr.Value != null ? ConvertTo (valr.Value, ty) : null
-                };
-            }
-            else if (expr.NodeType == ExpressionType.MemberAccess) {
-                var mem = (MemberExpression)expr;
-
-                var paramExpr = mem.Expression as ParameterExpression;
-                if (paramExpr == null) {
-                    var convert = mem.Expression as UnaryExpression;
-                    if (convert != null && convert.NodeType == ExpressionType.Convert) {
-                        paramExpr = convert.Operand as ParameterExpression;
-                    }
-                }
-
-                if (paramExpr != null) {
-                    //
-                    // This is a column of our table, output just the column name
-                    // Need to translate it if that column name is mapped
-                    //
-                    var columnName = Table.FindColumnWithPropertyName (mem.Member.Name).Name;
-                    return new CompileResult { CommandText = "\"" + columnName + "\"" };
-                }
-                else {
-                    object obj = null;
-                    if (mem.Expression != null) {
-                        var r = CompileExpr (mem.Expression, queryArgs);
-                        if (r.Value == null) {
-                            throw new NotSupportedException ("Member access failed to compile expression");
-                        }
-                        if (r.CommandText == "?") {
-                            queryArgs.RemoveAt (queryArgs.Count - 1);
-                        }
-                        obj = r.Value;
-                    }
-
-                    //
-                    // Get the member value
-                    //
-                    object val = null;
-
-                    if (mem.Member is PropertyInfo) {
-                        var m = (PropertyInfo)mem.Member;
-                        val = m.GetValue (obj, null);
-                    }
-                    else if (mem.Member is FieldInfo) {
-                        var m = (FieldInfo)mem.Member;
-                        val = m.GetValue (obj);
-                    }
-                    else {
-                        throw new NotSupportedException ("MemberExpr: " + mem.Member.GetType ());
-                    }
-
-                    //
-                    // Work special magic for enumerables
-                    //
-                    if (val != null && val is System.Collections.IEnumerable && !(val is string) && !(val is System.Collections.Generic.IEnumerable<byte>)) {
-                        var sb = new System.Text.StringBuilder ();
-                        sb.Append ("(");
-                        var head = "";
-                        foreach (var a in (System.Collections.IEnumerable)val) {
-                            queryArgs.Add (a);
-                            sb.Append (head);
-                            sb.Append ("?");
-                            head = ",";
-                        }
-                        sb.Append (")");
-                        return new CompileResult {
-                            CommandText = sb.ToString (),
-                            Value = val
-                        };
-                    }
-                    else {
-                        queryArgs.Add (val);
-                        return new CompileResult {
-                            CommandText = "?",
-                            Value = val
-                        };
-                    }
-                }
-            }
-            throw new NotSupportedException ("Cannot compile: " + expr.NodeType.ToString ());
-        }
-
-        static object ConvertTo (object obj, Type t)
-        {
-            Type nut = Nullable.GetUnderlyingType (t);
-
-            if (nut != null) {
-                if (obj == null)
-                    return null;
-                return Convert.ChangeType (obj, nut);
-            }
-            else {
-                return Convert.ChangeType (obj, t);
-            }
-        }
-
-        /// <summary>
-        /// Compiles a BinaryExpression where one of the parameters is null.
-        /// </summary>
-        /// <param name="expression">The expression to compile</param>
-        /// <param name="parameter">The non-null parameter</param>
-        private string CompileNullBinaryExpression (BinaryExpression expression, CompileResult parameter)
-        {
-            if (expression.NodeType == ExpressionType.Equal)
-                return "(" + parameter.CommandText + " is ?)";
-            else if (expression.NodeType == ExpressionType.NotEqual)
-                return "(" + parameter.CommandText + " is not ?)";
-            else if (expression.NodeType == ExpressionType.GreaterThan
-                || expression.NodeType == ExpressionType.GreaterThanOrEqual
-                || expression.NodeType == ExpressionType.LessThan
-                || expression.NodeType == ExpressionType.LessThanOrEqual)
-                return "(" + parameter.CommandText + " < ?)"; // always false
-            else
-                throw new NotSupportedException ("Cannot compile Null-BinaryExpression with type " + expression.NodeType.ToString ());
-        }
-
-        string GetSqlName (Expression expr)
-        {
-            var n = expr.NodeType;
-            if (n == ExpressionType.GreaterThan)
-                return ">";
-            else if (n == ExpressionType.GreaterThanOrEqual) {
-                return ">=";
-            }
-            else if (n == ExpressionType.LessThan) {
-                return "<";
-            }
-            else if (n == ExpressionType.LessThanOrEqual) {
-                return "<=";
-            }
-            else if (n == ExpressionType.And) {
-                return "&";
-            }
-            else if (n == ExpressionType.AndAlso) {
-                return "and";
-            }
-            else if (n == ExpressionType.Or) {
-                return "|";
-            }
-            else if (n == ExpressionType.OrElse) {
-                return "or";
-            }
-            else if (n == ExpressionType.Equal) {
-                return "=";
-            }
-            else if (n == ExpressionType.NotEqual) {
-                return "!=";
-            }
-            else {
-                throw new NotSupportedException ("Cannot get SQL for: " + n);
-            }
-        }
-
-        /// <summary>
-        /// Execute SELECT COUNT(*) on the query
-        /// </summary>
-        public int Count ()
-        {
-            return GenerateCommand ("count(*)").ExecuteScalar<int> ();
-        }
-
-        /// <summary>
-        /// Execute SELECT COUNT(*) on the query with an additional WHERE clause.
-        /// </summary>
-        public int Count (Expression<Func<T, bool>> predExpr)
-        {
-            return Where (predExpr).Count ();
-        }
-
-        public IEnumerator<T> GetEnumerator ()
-        {
-            if (!_deferred)
-                return GenerateCommand ("*").ExecuteQuery<T> ().GetEnumerator ();
-
-            return GenerateCommand ("*").ExecuteDeferredQuery<T> ().GetEnumerator ();
-        }
-
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator ()
-        {
-            return GetEnumerator ();
-        }
-
-        /// <summary>
-        /// Queries the database and returns the results as a List.
-        /// </summary>
-        public List<T> ToList ()
-        {
-            return GenerateCommand ("*").ExecuteQuery<T> ();
-        }
-
-        /// <summary>
-        /// Queries the database and returns the results as an array.
-        /// </summary>
-        public T[] ToArray ()
-        {
-            return GenerateCommand ("*").ExecuteQuery<T> ().ToArray ();
-        }
-
-        /// <summary>
-        /// Returns the first element of this query.
-        /// </summary>
-        public T First ()
-        {
-            var query = Take (1);
-            return query.ToList ().First ();
-        }
-
-        /// <summary>
-        /// Returns the first element of this query, or null if no element is found.
-        /// </summary>
-        public T FirstOrDefault ()
-        {
-            var query = Take (1);
-            return query.ToList ().FirstOrDefault ();
-        }
-
-        /// <summary>
-        /// Returns the first element of this query that matches the predicate.
-        /// </summary>
-        public T First (Expression<Func<T, bool>> predExpr)
-        {
-            return Where (predExpr).First ();
-        }
-
-        /// <summary>
-        /// Returns the first element of this query that matches the predicate, or null
-        /// if no element is found.
-        /// </summary>
-        public T FirstOrDefault (Expression<Func<T, bool>> predExpr)
-        {
-            return Where (predExpr).FirstOrDefault ();
-        }
-    }
-
-    public static class SQLite3
-    {
-        public enum Result : int
-        {
-            OK = 0,
-            Error = 1,
-            Internal = 2,
-            Perm = 3,
-            Abort = 4,
-            Busy = 5,
-            Locked = 6,
-            NoMem = 7,
-            ReadOnly = 8,
-            Interrupt = 9,
-            IOError = 10,
-            Corrupt = 11,
-            NotFound = 12,
-            Full = 13,
-            CannotOpen = 14,
-            LockErr = 15,
-            Empty = 16,
-            SchemaChngd = 17,
-            TooBig = 18,
-            Constraint = 19,
-            Mismatch = 20,
-            Misuse = 21,
-            NotImplementedLFS = 22,
-            AccessDenied = 23,
-            Format = 24,
-            Range = 25,
-            NonDBFile = 26,
-            Notice = 27,
-            Warning = 28,
-            Row = 100,
-            Done = 101
-        }
-
-        public enum ExtendedResult : int
-        {
-            IOErrorRead = (Result.IOError | (1 << 8)),
-            IOErrorShortRead = (Result.IOError | (2 << 8)),
-            IOErrorWrite = (Result.IOError | (3 << 8)),
-            IOErrorFsync = (Result.IOError | (4 << 8)),
-            IOErrorDirFSync = (Result.IOError | (5 << 8)),
-            IOErrorTruncate = (Result.IOError | (6 << 8)),
-            IOErrorFStat = (Result.IOError | (7 << 8)),
-            IOErrorUnlock = (Result.IOError | (8 << 8)),
-            IOErrorRdlock = (Result.IOError | (9 << 8)),
-            IOErrorDelete = (Result.IOError | (10 << 8)),
-            IOErrorBlocked = (Result.IOError | (11 << 8)),
-            IOErrorNoMem = (Result.IOError | (12 << 8)),
-            IOErrorAccess = (Result.IOError | (13 << 8)),
-            IOErrorCheckReservedLock = (Result.IOError | (14 << 8)),
-            IOErrorLock = (Result.IOError | (15 << 8)),
-            IOErrorClose = (Result.IOError | (16 << 8)),
-            IOErrorDirClose = (Result.IOError | (17 << 8)),
-            IOErrorSHMOpen = (Result.IOError | (18 << 8)),
-            IOErrorSHMSize = (Result.IOError | (19 << 8)),
-            IOErrorSHMLock = (Result.IOError | (20 << 8)),
-            IOErrorSHMMap = (Result.IOError | (21 << 8)),
-            IOErrorSeek = (Result.IOError | (22 << 8)),
-            IOErrorDeleteNoEnt = (Result.IOError | (23 << 8)),
-            IOErrorMMap = (Result.IOError | (24 << 8)),
-            LockedSharedcache = (Result.Locked | (1 << 8)),
-            BusyRecovery = (Result.Busy | (1 << 8)),
-            CannottOpenNoTempDir = (Result.CannotOpen | (1 << 8)),
-            CannotOpenIsDir = (Result.CannotOpen | (2 << 8)),
-            CannotOpenFullPath = (Result.CannotOpen | (3 << 8)),
-            CorruptVTab = (Result.Corrupt | (1 << 8)),
-            ReadonlyRecovery = (Result.ReadOnly | (1 << 8)),
-            ReadonlyCannotLock = (Result.ReadOnly | (2 << 8)),
-            ReadonlyRollback = (Result.ReadOnly | (3 << 8)),
-            AbortRollback = (Result.Abort | (2 << 8)),
-            ConstraintCheck = (Result.Constraint | (1 << 8)),
-            ConstraintCommitHook = (Result.Constraint | (2 << 8)),
-            ConstraintForeignKey = (Result.Constraint | (3 << 8)),
-            ConstraintFunction = (Result.Constraint | (4 << 8)),
-            ConstraintNotNull = (Result.Constraint | (5 << 8)),
-            ConstraintPrimaryKey = (Result.Constraint | (6 << 8)),
-            ConstraintTrigger = (Result.Constraint | (7 << 8)),
-            ConstraintUnique = (Result.Constraint | (8 << 8)),
-            ConstraintVTab = (Result.Constraint | (9 << 8)),
-            NoticeRecoverWAL = (Result.Notice | (1 << 8)),
-            NoticeRecoverRollback = (Result.Notice | (2 << 8))
-        }
+				// VB turns 'x=="foo"' into 'CompareString(x,"foo",true/false)==0', so we need to unwrap it
+				// http://blogs.msdn.com/b/vbteam/archive/2007/09/18/vb-expression-trees-string-comparisons.aspx
+				if (bin.Left.NodeType == ExpressionType.Call) {
+					var call = (MethodCallExpression)bin.Left;
+					if (call.Method.DeclaringType.FullName == "Microsoft.VisualBasic.CompilerServices.Operators"
+						&& call.Method.Name == "CompareString")
+						bin = Expression.MakeBinary (bin.NodeType, call.Arguments[0], call.Arguments[1]);
+				}
 
 
-        public enum ConfigOption : int
-        {
-            SingleThread = 1,
-            MultiThread = 2,
-            Serialized = 3
-        }
+				var leftr = CompileExpr (bin.Left, queryArgs);
+				var rightr = CompileExpr (bin.Right, queryArgs);
 
-        const string LibraryPath = "sqlite3";
+				//If either side is a parameter and is null, then handle the other side specially (for "is null"/"is not null")
+				string text;
+				if (leftr.CommandText == "?" && leftr.Value == null)
+					text = CompileNullBinaryExpression (bin, rightr);
+				else if (rightr.CommandText == "?" && rightr.Value == null)
+					text = CompileNullBinaryExpression (bin, leftr);
+				else
+					text = "(" + leftr.CommandText + " " + GetSqlName (bin) + " " + rightr.CommandText + ")";
+				return new CompileResult { CommandText = text };
+			}
+			else if (expr.NodeType == ExpressionType.Not) {
+				var operandExpr = ((UnaryExpression)expr).Operand;
+				var opr = CompileExpr (operandExpr, queryArgs);
+				object val = opr.Value;
+				if (val is bool)
+					val = !((bool)val);
+				return new CompileResult {
+					CommandText = "NOT(" + opr.CommandText + ")",
+					Value = val
+				};
+			}
+			else if (expr.NodeType == ExpressionType.Call) {
+
+				var call = (MethodCallExpression)expr;
+				var args = new CompileResult[call.Arguments.Count];
+				var obj = call.Object != null ? CompileExpr (call.Object, queryArgs) : null;
+
+				for (var i = 0; i < args.Length; i++) {
+					args[i] = CompileExpr (call.Arguments[i], queryArgs);
+				}
+
+				var sqlCall = "";
+
+				if (call.Method.Name == "Like" && args.Length == 2) {
+					sqlCall = "(" + args[0].CommandText + " like " + args[1].CommandText + ")";
+				}
+				else if (call.Method.Name == "Contains" && args.Length == 2) {
+					sqlCall = "(" + args[1].CommandText + " in " + args[0].CommandText + ")";
+				}
+				else if (call.Method.Name == "Contains" && args.Length == 1) {
+					if (call.Object != null && call.Object.Type == typeof (string)) {
+						sqlCall = "( instr(" + obj.CommandText + "," + args[0].CommandText + ") >0 )";
+					}
+					else {
+						sqlCall = "(" + args[0].CommandText + " in " + obj.CommandText + ")";
+					}
+				}
+				else if (call.Method.Name == "StartsWith" && args.Length >= 1) {
+					var startsWithCmpOp = StringComparison.CurrentCulture;
+					if (args.Length == 2) {
+						startsWithCmpOp = (StringComparison)args[1].Value;
+					}
+					switch (startsWithCmpOp) {
+						case StringComparison.Ordinal:
+						case StringComparison.CurrentCulture:
+							sqlCall = "( substr(" + obj.CommandText + ", 1, " + args[0].Value.ToString ().Length + ") =  " + args[0].CommandText + ")";
+							break;
+						case StringComparison.OrdinalIgnoreCase:
+						case StringComparison.CurrentCultureIgnoreCase:
+							sqlCall = "(" + obj.CommandText + " like (" + args[0].CommandText + " || '%'))";
+							break;
+					}
+
+				}
+				else if (call.Method.Name == "EndsWith" && args.Length >= 1) {
+					var endsWithCmpOp = StringComparison.CurrentCulture;
+					if (args.Length == 2) {
+						endsWithCmpOp = (StringComparison)args[1].Value;
+					}
+					switch (endsWithCmpOp) {
+						case StringComparison.Ordinal:
+						case StringComparison.CurrentCulture:
+							sqlCall = "( substr(" + obj.CommandText + ", length(" + obj.CommandText + ") - " + args[0].Value.ToString ().Length + "+1, " + args[0].Value.ToString ().Length + ") =  " + args[0].CommandText + ")";
+							break;
+						case StringComparison.OrdinalIgnoreCase:
+						case StringComparison.CurrentCultureIgnoreCase:
+							sqlCall = "(" + obj.CommandText + " like ('%' || " + args[0].CommandText + "))";
+							break;
+					}
+				}
+				else if (call.Method.Name == "Equals" && args.Length == 1) {
+					sqlCall = "(" + obj.CommandText + " = (" + args[0].CommandText + "))";
+				}
+				else if (call.Method.Name == "ToLower") {
+					sqlCall = "(lower(" + obj.CommandText + "))";
+				}
+				else if (call.Method.Name == "ToUpper") {
+					sqlCall = "(upper(" + obj.CommandText + "))";
+				}
+				else if (call.Method.Name == "Replace" && args.Length == 2) {
+					sqlCall = "(replace(" + obj.CommandText + "," + args[0].CommandText + "," + args[1].CommandText + "))";
+				}
+				else if (call.Method.Name == "IsNullOrEmpty" && args.Length == 1) {
+					sqlCall = "(" + args[0].CommandText + " is null or" + args[0].CommandText + " ='' )";
+				}
+				else {
+					sqlCall = call.Method.Name.ToLower () + "(" + string.Join (",", args.Select (a => a.CommandText).ToArray ()) + ")";
+				}
+				return new CompileResult { CommandText = sqlCall };
+
+			}
+			else if (expr.NodeType == ExpressionType.Constant) {
+				var c = (ConstantExpression)expr;
+				queryArgs.Add (c.Value);
+				return new CompileResult {
+					CommandText = "?",
+					Value = c.Value
+				};
+			}
+			else if (expr.NodeType == ExpressionType.Convert) {
+				var u = (UnaryExpression)expr;
+				var ty = u.Type;
+				var valr = CompileExpr (u.Operand, queryArgs);
+				return new CompileResult {
+					CommandText = valr.CommandText,
+					Value = valr.Value != null ? ConvertTo (valr.Value, ty) : null
+				};
+			}
+			else if (expr.NodeType == ExpressionType.MemberAccess) {
+				var mem = (MemberExpression)expr;
+
+				var paramExpr = mem.Expression as ParameterExpression;
+				if (paramExpr == null) {
+					var convert = mem.Expression as UnaryExpression;
+					if (convert != null && convert.NodeType == ExpressionType.Convert) {
+						paramExpr = convert.Operand as ParameterExpression;
+					}
+				}
+
+				if (paramExpr != null) {
+					//
+					// This is a column of our table, output just the column name
+					// Need to translate it if that column name is mapped
+					//
+					var columnName = Table.FindColumnWithPropertyName (mem.Member.Name).Name;
+					return new CompileResult { CommandText = "\"" + columnName + "\"" };
+				}
+				else {
+					object obj = null;
+					if (mem.Expression != null) {
+						var r = CompileExpr (mem.Expression, queryArgs);
+						if (r.Value == null) {
+							throw new NotSupportedException ("Member access failed to compile expression");
+						}
+						if (r.CommandText == "?") {
+							queryArgs.RemoveAt (queryArgs.Count - 1);
+						}
+						obj = r.Value;
+					}
+
+					//
+					// Get the member value
+					//
+					object val = null;
+
+					if (mem.Member is PropertyInfo) {
+						var m = (PropertyInfo)mem.Member;
+						val = m.GetValue (obj, null);
+					}
+					else if (mem.Member is FieldInfo) {
+						var m = (FieldInfo)mem.Member;
+						val = m.GetValue (obj);
+					}
+					else {
+						throw new NotSupportedException ("MemberExpr: " + mem.Member.GetType ());
+					}
+
+					//
+					// Work special magic for enumerables
+					//
+					if (val != null && val is System.Collections.IEnumerable && !(val is string) && !(val is System.Collections.Generic.IEnumerable<byte>)) {
+						var sb = new System.Text.StringBuilder ();
+						sb.Append ("(");
+						var head = "";
+						foreach (var a in (System.Collections.IEnumerable)val) {
+							queryArgs.Add (a);
+							sb.Append (head);
+							sb.Append ("?");
+							head = ",";
+						}
+						sb.Append (")");
+						return new CompileResult {
+							CommandText = sb.ToString (),
+							Value = val
+						};
+					}
+					else {
+						queryArgs.Add (val);
+						return new CompileResult {
+							CommandText = "?",
+							Value = val
+						};
+					}
+				}
+			}
+			throw new NotSupportedException ("Cannot compile: " + expr.NodeType.ToString ());
+		}
+
+		static object ConvertTo (object obj, Type t)
+		{
+			Type nut = Nullable.GetUnderlyingType (t);
+
+			if (nut != null) {
+				if (obj == null)
+					return null;
+				return Convert.ChangeType (obj, nut);
+			}
+			else {
+				return Convert.ChangeType (obj, t);
+			}
+		}
+
+		/// <summary>
+		/// Compiles a BinaryExpression where one of the parameters is null.
+		/// </summary>
+		/// <param name="expression">The expression to compile</param>
+		/// <param name="parameter">The non-null parameter</param>
+		private string CompileNullBinaryExpression (BinaryExpression expression, CompileResult parameter)
+		{
+			if (expression.NodeType == ExpressionType.Equal)
+				return "(" + parameter.CommandText + " is ?)";
+			else if (expression.NodeType == ExpressionType.NotEqual)
+				return "(" + parameter.CommandText + " is not ?)";
+			else if (expression.NodeType == ExpressionType.GreaterThan
+				|| expression.NodeType == ExpressionType.GreaterThanOrEqual
+				|| expression.NodeType == ExpressionType.LessThan
+				|| expression.NodeType == ExpressionType.LessThanOrEqual)
+				return "(" + parameter.CommandText + " < ?)"; // always false
+			else
+				throw new NotSupportedException ("Cannot compile Null-BinaryExpression with type " + expression.NodeType.ToString ());
+		}
+
+		string GetSqlName (Expression expr)
+		{
+			var n = expr.NodeType;
+			if (n == ExpressionType.GreaterThan)
+				return ">";
+			else if (n == ExpressionType.GreaterThanOrEqual) {
+				return ">=";
+			}
+			else if (n == ExpressionType.LessThan) {
+				return "<";
+			}
+			else if (n == ExpressionType.LessThanOrEqual) {
+				return "<=";
+			}
+			else if (n == ExpressionType.And) {
+				return "&";
+			}
+			else if (n == ExpressionType.AndAlso) {
+				return "and";
+			}
+			else if (n == ExpressionType.Or) {
+				return "|";
+			}
+			else if (n == ExpressionType.OrElse) {
+				return "or";
+			}
+			else if (n == ExpressionType.Equal) {
+				return "=";
+			}
+			else if (n == ExpressionType.NotEqual) {
+				return "!=";
+			}
+			else {
+				throw new NotSupportedException ("Cannot get SQL for: " + n);
+			}
+		}
+
+		/// <summary>
+		/// Execute SELECT COUNT(*) on the query
+		/// </summary>
+		public int Count ()
+		{
+			return GenerateCommand ("count(*)").ExecuteScalar<int> ();
+		}
+
+		/// <summary>
+		/// Execute SELECT COUNT(*) on the query with an additional WHERE clause.
+		/// </summary>
+		public int Count (Expression<Func<T, bool>> predExpr)
+		{
+			return Where (predExpr).Count ();
+		}
+
+		public IEnumerator<T> GetEnumerator ()
+		{
+			if (!_deferred)
+				return GenerateCommand ("*").ExecuteQuery<T> ().GetEnumerator ();
+
+			return GenerateCommand ("*").ExecuteDeferredQuery<T> ().GetEnumerator ();
+		}
+
+		System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator ()
+		{
+			return GetEnumerator ();
+		}
+
+		/// <summary>
+		/// Queries the database and returns the results as a List.
+		/// </summary>
+		public List<T> ToList ()
+		{
+			return GenerateCommand ("*").ExecuteQuery<T> ();
+		}
+
+		/// <summary>
+		/// Queries the database and returns the results as an array.
+		/// </summary>
+		public T[] ToArray ()
+		{
+			return GenerateCommand ("*").ExecuteQuery<T> ().ToArray ();
+		}
+
+		/// <summary>
+		/// Returns the first element of this query.
+		/// </summary>
+		public T First ()
+		{
+			var query = Take (1);
+			return query.ToList ().First ();
+		}
+
+		/// <summary>
+		/// Returns the first element of this query, or null if no element is found.
+		/// </summary>
+		public T FirstOrDefault ()
+		{
+			var query = Take (1);
+			return query.ToList ().FirstOrDefault ();
+		}
+
+		/// <summary>
+		/// Returns the first element of this query that matches the predicate.
+		/// </summary>
+		public T First (Expression<Func<T, bool>> predExpr)
+		{
+			return Where (predExpr).First ();
+		}
+
+		/// <summary>
+		/// Returns the first element of this query that matches the predicate, or null
+		/// if no element is found.
+		/// </summary>
+		public T FirstOrDefault (Expression<Func<T, bool>> predExpr)
+		{
+			return Where (predExpr).FirstOrDefault ();
+		}
+	}
+
+	public static class SQLite3
+	{
+		public enum Result : int
+		{
+			OK = 0,
+			Error = 1,
+			Internal = 2,
+			Perm = 3,
+			Abort = 4,
+			Busy = 5,
+			Locked = 6,
+			NoMem = 7,
+			ReadOnly = 8,
+			Interrupt = 9,
+			IOError = 10,
+			Corrupt = 11,
+			NotFound = 12,
+			Full = 13,
+			CannotOpen = 14,
+			LockErr = 15,
+			Empty = 16,
+			SchemaChngd = 17,
+			TooBig = 18,
+			Constraint = 19,
+			Mismatch = 20,
+			Misuse = 21,
+			NotImplementedLFS = 22,
+			AccessDenied = 23,
+			Format = 24,
+			Range = 25,
+			NonDBFile = 26,
+			Notice = 27,
+			Warning = 28,
+			Row = 100,
+			Done = 101
+		}
+
+		public enum ExtendedResult : int
+		{
+			IOErrorRead = (Result.IOError | (1 << 8)),
+			IOErrorShortRead = (Result.IOError | (2 << 8)),
+			IOErrorWrite = (Result.IOError | (3 << 8)),
+			IOErrorFsync = (Result.IOError | (4 << 8)),
+			IOErrorDirFSync = (Result.IOError | (5 << 8)),
+			IOErrorTruncate = (Result.IOError | (6 << 8)),
+			IOErrorFStat = (Result.IOError | (7 << 8)),
+			IOErrorUnlock = (Result.IOError | (8 << 8)),
+			IOErrorRdlock = (Result.IOError | (9 << 8)),
+			IOErrorDelete = (Result.IOError | (10 << 8)),
+			IOErrorBlocked = (Result.IOError | (11 << 8)),
+			IOErrorNoMem = (Result.IOError | (12 << 8)),
+			IOErrorAccess = (Result.IOError | (13 << 8)),
+			IOErrorCheckReservedLock = (Result.IOError | (14 << 8)),
+			IOErrorLock = (Result.IOError | (15 << 8)),
+			IOErrorClose = (Result.IOError | (16 << 8)),
+			IOErrorDirClose = (Result.IOError | (17 << 8)),
+			IOErrorSHMOpen = (Result.IOError | (18 << 8)),
+			IOErrorSHMSize = (Result.IOError | (19 << 8)),
+			IOErrorSHMLock = (Result.IOError | (20 << 8)),
+			IOErrorSHMMap = (Result.IOError | (21 << 8)),
+			IOErrorSeek = (Result.IOError | (22 << 8)),
+			IOErrorDeleteNoEnt = (Result.IOError | (23 << 8)),
+			IOErrorMMap = (Result.IOError | (24 << 8)),
+			LockedSharedcache = (Result.Locked | (1 << 8)),
+			BusyRecovery = (Result.Busy | (1 << 8)),
+			CannottOpenNoTempDir = (Result.CannotOpen | (1 << 8)),
+			CannotOpenIsDir = (Result.CannotOpen | (2 << 8)),
+			CannotOpenFullPath = (Result.CannotOpen | (3 << 8)),
+			CorruptVTab = (Result.Corrupt | (1 << 8)),
+			ReadonlyRecovery = (Result.ReadOnly | (1 << 8)),
+			ReadonlyCannotLock = (Result.ReadOnly | (2 << 8)),
+			ReadonlyRollback = (Result.ReadOnly | (3 << 8)),
+			AbortRollback = (Result.Abort | (2 << 8)),
+			ConstraintCheck = (Result.Constraint | (1 << 8)),
+			ConstraintCommitHook = (Result.Constraint | (2 << 8)),
+			ConstraintForeignKey = (Result.Constraint | (3 << 8)),
+			ConstraintFunction = (Result.Constraint | (4 << 8)),
+			ConstraintNotNull = (Result.Constraint | (5 << 8)),
+			ConstraintPrimaryKey = (Result.Constraint | (6 << 8)),
+			ConstraintTrigger = (Result.Constraint | (7 << 8)),
+			ConstraintUnique = (Result.Constraint | (8 << 8)),
+			ConstraintVTab = (Result.Constraint | (9 << 8)),
+			NoticeRecoverWAL = (Result.Notice | (1 << 8)),
+			NoticeRecoverRollback = (Result.Notice | (2 << 8))
+		}
+
+
+		public enum ConfigOption : int
+		{
+			SingleThread = 1,
+			MultiThread = 2,
+			Serialized = 3
+		}
+
+		const string LibraryPath = "sqlite3";
 
 #if !USE_CSHARP_SQLITE && !USE_WP8_NATIVE_SQLITE && !USE_SQLITEPCL_RAW
-        [DllImport(LibraryPath, EntryPoint = "sqlite3_threadsafe", CallingConvention=CallingConvention.Cdecl)]
-        public static extern int Threadsafe ();
+		[DllImport(LibraryPath, EntryPoint = "sqlite3_threadsafe", CallingConvention=CallingConvention.Cdecl)]
+		public static extern int Threadsafe ();
 
-        [DllImport(LibraryPath, EntryPoint = "sqlite3_open", CallingConvention=CallingConvention.Cdecl)]
-        public static extern Result Open ([MarshalAs(UnmanagedType.LPStr)] string filename, out IntPtr db);
+		[DllImport(LibraryPath, EntryPoint = "sqlite3_open", CallingConvention=CallingConvention.Cdecl)]
+		public static extern Result Open ([MarshalAs(UnmanagedType.LPStr)] string filename, out IntPtr db);
 
-        [DllImport(LibraryPath, EntryPoint = "sqlite3_open_v2", CallingConvention=CallingConvention.Cdecl)]
-        public static extern Result Open ([MarshalAs(UnmanagedType.LPStr)] string filename, out IntPtr db, int flags, [MarshalAs (UnmanagedType.LPStr)] string zvfs);
+		[DllImport(LibraryPath, EntryPoint = "sqlite3_open_v2", CallingConvention=CallingConvention.Cdecl)]
+		public static extern Result Open ([MarshalAs(UnmanagedType.LPStr)] string filename, out IntPtr db, int flags, [MarshalAs (UnmanagedType.LPStr)] string zvfs);
 
-        [DllImport(LibraryPath, EntryPoint = "sqlite3_open_v2", CallingConvention = CallingConvention.Cdecl)]
-        public static extern Result Open(byte[] filename, out IntPtr db, int flags, [MarshalAs (UnmanagedType.LPStr)] string zvfs);
+		[DllImport(LibraryPath, EntryPoint = "sqlite3_open_v2", CallingConvention = CallingConvention.Cdecl)]
+		public static extern Result Open(byte[] filename, out IntPtr db, int flags, [MarshalAs (UnmanagedType.LPStr)] string zvfs);
 
-        [DllImport(LibraryPath, EntryPoint = "sqlite3_open16", CallingConvention = CallingConvention.Cdecl)]
-        public static extern Result Open16([MarshalAs(UnmanagedType.LPWStr)] string filename, out IntPtr db);
+		[DllImport(LibraryPath, EntryPoint = "sqlite3_open16", CallingConvention = CallingConvention.Cdecl)]
+		public static extern Result Open16([MarshalAs(UnmanagedType.LPWStr)] string filename, out IntPtr db);
 
-        [DllImport(LibraryPath, EntryPoint = "sqlite3_enable_load_extension", CallingConvention=CallingConvention.Cdecl)]
-        public static extern Result EnableLoadExtension (IntPtr db, int onoff);
+		[DllImport(LibraryPath, EntryPoint = "sqlite3_enable_load_extension", CallingConvention=CallingConvention.Cdecl)]
+		public static extern Result EnableLoadExtension (IntPtr db, int onoff);
 
-        [DllImport(LibraryPath, EntryPoint = "sqlite3_close", CallingConvention=CallingConvention.Cdecl)]
-        public static extern Result Close (IntPtr db);
+		[DllImport(LibraryPath, EntryPoint = "sqlite3_close", CallingConvention=CallingConvention.Cdecl)]
+		public static extern Result Close (IntPtr db);
 
-        [DllImport(LibraryPath, EntryPoint = "sqlite3_close_v2", CallingConvention = CallingConvention.Cdecl)]
-        public static extern Result Close2(IntPtr db);
+		[DllImport(LibraryPath, EntryPoint = "sqlite3_close_v2", CallingConvention = CallingConvention.Cdecl)]
+		public static extern Result Close2(IntPtr db);
 
-        [DllImport(LibraryPath, EntryPoint = "sqlite3_initialize", CallingConvention=CallingConvention.Cdecl)]
-        public static extern Result Initialize();
+		[DllImport(LibraryPath, EntryPoint = "sqlite3_initialize", CallingConvention=CallingConvention.Cdecl)]
+		public static extern Result Initialize();
 
-        [DllImport(LibraryPath, EntryPoint = "sqlite3_shutdown", CallingConvention=CallingConvention.Cdecl)]
-        public static extern Result Shutdown();
+		[DllImport(LibraryPath, EntryPoint = "sqlite3_shutdown", CallingConvention=CallingConvention.Cdecl)]
+		public static extern Result Shutdown();
 
-        [DllImport(LibraryPath, EntryPoint = "sqlite3_config", CallingConvention=CallingConvention.Cdecl)]
-        public static extern Result Config (ConfigOption option);
+		[DllImport(LibraryPath, EntryPoint = "sqlite3_config", CallingConvention=CallingConvention.Cdecl)]
+		public static extern Result Config (ConfigOption option);
 
-        [DllImport(LibraryPath, EntryPoint = "sqlite3_win32_set_directory", CallingConvention=CallingConvention.Cdecl, CharSet=CharSet.Unicode)]
-        public static extern int SetDirectory (uint directoryType, string directoryPath);
+		[DllImport(LibraryPath, EntryPoint = "sqlite3_win32_set_directory", CallingConvention=CallingConvention.Cdecl, CharSet=CharSet.Unicode)]
+		public static extern int SetDirectory (uint directoryType, string directoryPath);
 
-        [DllImport(LibraryPath, EntryPoint = "sqlite3_busy_timeout", CallingConvention=CallingConvention.Cdecl)]
-        public static extern Result BusyTimeout (IntPtr db, int milliseconds);
+		[DllImport(LibraryPath, EntryPoint = "sqlite3_busy_timeout", CallingConvention=CallingConvention.Cdecl)]
+		public static extern Result BusyTimeout (IntPtr db, int milliseconds);
 
-        [DllImport(LibraryPath, EntryPoint = "sqlite3_changes", CallingConvention=CallingConvention.Cdecl)]
-        public static extern int Changes (IntPtr db);
+		[DllImport(LibraryPath, EntryPoint = "sqlite3_changes", CallingConvention=CallingConvention.Cdecl)]
+		public static extern int Changes (IntPtr db);
 
-        [DllImport(LibraryPath, EntryPoint = "sqlite3_prepare_v2", CallingConvention=CallingConvention.Cdecl)]
-        public static extern Result Prepare2 (IntPtr db, [MarshalAs(UnmanagedType.LPStr)] string sql, int numBytes, out IntPtr stmt, IntPtr pzTail);
+		[DllImport(LibraryPath, EntryPoint = "sqlite3_prepare_v2", CallingConvention=CallingConvention.Cdecl)]
+		public static extern Result Prepare2 (IntPtr db, [MarshalAs(UnmanagedType.LPStr)] string sql, int numBytes, out IntPtr stmt, IntPtr pzTail);
 
 #if NETFX_CORE
-        [DllImport (LibraryPath, EntryPoint = "sqlite3_prepare_v2", CallingConvention = CallingConvention.Cdecl)]
-        public static extern Result Prepare2 (IntPtr db, byte[] queryBytes, int numBytes, out IntPtr stmt, IntPtr pzTail);
+		[DllImport (LibraryPath, EntryPoint = "sqlite3_prepare_v2", CallingConvention = CallingConvention.Cdecl)]
+		public static extern Result Prepare2 (IntPtr db, byte[] queryBytes, int numBytes, out IntPtr stmt, IntPtr pzTail);
 #endif
 
-        public static IntPtr Prepare2 (IntPtr db, string query)
-        {
-            IntPtr stmt;
+		public static IntPtr Prepare2 (IntPtr db, string query)
+		{
+			IntPtr stmt;
 #if NETFX_CORE
-            byte[] queryBytes = System.Text.UTF8Encoding.UTF8.GetBytes (query);
-            var r = Prepare2 (db, queryBytes, queryBytes.Length, out stmt, IntPtr.Zero);
+			byte[] queryBytes = System.Text.UTF8Encoding.UTF8.GetBytes (query);
+			var r = Prepare2 (db, queryBytes, queryBytes.Length, out stmt, IntPtr.Zero);
 #else
-            var r = Prepare2 (db, query, System.Text.UTF8Encoding.UTF8.GetByteCount (query), out stmt, IntPtr.Zero);
+			var r = Prepare2 (db, query, System.Text.UTF8Encoding.UTF8.GetByteCount (query), out stmt, IntPtr.Zero);
 #endif
-            if (r != Result.OK) {
-                throw SQLiteException.New (r, GetErrmsg (db));
-            }
-            return stmt;
-        }
+			if (r != Result.OK) {
+				throw SQLiteException.New (r, GetErrmsg (db));
+			}
+			return stmt;
+		}
 
-        [DllImport(LibraryPath, EntryPoint = "sqlite3_step", CallingConvention=CallingConvention.Cdecl)]
-        public static extern Result Step (IntPtr stmt);
+		[DllImport(LibraryPath, EntryPoint = "sqlite3_step", CallingConvention=CallingConvention.Cdecl)]
+		public static extern Result Step (IntPtr stmt);
 
-        [DllImport(LibraryPath, EntryPoint = "sqlite3_reset", CallingConvention=CallingConvention.Cdecl)]
-        public static extern Result Reset (IntPtr stmt);
+		[DllImport(LibraryPath, EntryPoint = "sqlite3_reset", CallingConvention=CallingConvention.Cdecl)]
+		public static extern Result Reset (IntPtr stmt);
 
-        [DllImport(LibraryPath, EntryPoint = "sqlite3_finalize", CallingConvention=CallingConvention.Cdecl)]
-        public static extern Result Finalize (IntPtr stmt);
+		[DllImport(LibraryPath, EntryPoint = "sqlite3_finalize", CallingConvention=CallingConvention.Cdecl)]
+		public static extern Result Finalize (IntPtr stmt);
 
-        [DllImport(LibraryPath, EntryPoint = "sqlite3_last_insert_rowid", CallingConvention=CallingConvention.Cdecl)]
-        public static extern long LastInsertRowid (IntPtr db);
+		[DllImport(LibraryPath, EntryPoint = "sqlite3_last_insert_rowid", CallingConvention=CallingConvention.Cdecl)]
+		public static extern long LastInsertRowid (IntPtr db);
 
-        [DllImport(LibraryPath, EntryPoint = "sqlite3_errmsg16", CallingConvention=CallingConvention.Cdecl)]
-        public static extern IntPtr Errmsg (IntPtr db);
+		[DllImport(LibraryPath, EntryPoint = "sqlite3_errmsg16", CallingConvention=CallingConvention.Cdecl)]
+		public static extern IntPtr Errmsg (IntPtr db);
 
-        public static string GetErrmsg (IntPtr db)
-        {
-            return Marshal.PtrToStringUni (Errmsg (db));
-        }
+		public static string GetErrmsg (IntPtr db)
+		{
+			return Marshal.PtrToStringUni (Errmsg (db));
+		}
 
-        [DllImport(LibraryPath, EntryPoint = "sqlite3_bind_parameter_index", CallingConvention=CallingConvention.Cdecl)]
-        public static extern int BindParameterIndex (IntPtr stmt, [MarshalAs(UnmanagedType.LPStr)] string name);
+		[DllImport(LibraryPath, EntryPoint = "sqlite3_bind_parameter_index", CallingConvention=CallingConvention.Cdecl)]
+		public static extern int BindParameterIndex (IntPtr stmt, [MarshalAs(UnmanagedType.LPStr)] string name);
 
-        [DllImport(LibraryPath, EntryPoint = "sqlite3_bind_null", CallingConvention=CallingConvention.Cdecl)]
-        public static extern int BindNull (IntPtr stmt, int index);
+		[DllImport(LibraryPath, EntryPoint = "sqlite3_bind_null", CallingConvention=CallingConvention.Cdecl)]
+		public static extern int BindNull (IntPtr stmt, int index);
 
-        [DllImport(LibraryPath, EntryPoint = "sqlite3_bind_int", CallingConvention=CallingConvention.Cdecl)]
-        public static extern int BindInt (IntPtr stmt, int index, int val);
+		[DllImport(LibraryPath, EntryPoint = "sqlite3_bind_int", CallingConvention=CallingConvention.Cdecl)]
+		public static extern int BindInt (IntPtr stmt, int index, int val);
 
-        [DllImport(LibraryPath, EntryPoint = "sqlite3_bind_int64", CallingConvention=CallingConvention.Cdecl)]
-        public static extern int BindInt64 (IntPtr stmt, int index, long val);
+		[DllImport(LibraryPath, EntryPoint = "sqlite3_bind_int64", CallingConvention=CallingConvention.Cdecl)]
+		public static extern int BindInt64 (IntPtr stmt, int index, long val);
 
-        [DllImport(LibraryPath, EntryPoint = "sqlite3_bind_double", CallingConvention=CallingConvention.Cdecl)]
-        public static extern int BindDouble (IntPtr stmt, int index, double val);
+		[DllImport(LibraryPath, EntryPoint = "sqlite3_bind_double", CallingConvention=CallingConvention.Cdecl)]
+		public static extern int BindDouble (IntPtr stmt, int index, double val);
 
-        [DllImport(LibraryPath, EntryPoint = "sqlite3_bind_text16", CallingConvention=CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
-        public static extern int BindText (IntPtr stmt, int index, [MarshalAs(UnmanagedType.LPWStr)] string val, int n, IntPtr free);
+		[DllImport(LibraryPath, EntryPoint = "sqlite3_bind_text16", CallingConvention=CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
+		public static extern int BindText (IntPtr stmt, int index, [MarshalAs(UnmanagedType.LPWStr)] string val, int n, IntPtr free);
 
-        [DllImport(LibraryPath, EntryPoint = "sqlite3_bind_blob", CallingConvention=CallingConvention.Cdecl)]
-        public static extern int BindBlob (IntPtr stmt, int index, byte[] val, int n, IntPtr free);
+		[DllImport(LibraryPath, EntryPoint = "sqlite3_bind_blob", CallingConvention=CallingConvention.Cdecl)]
+		public static extern int BindBlob (IntPtr stmt, int index, byte[] val, int n, IntPtr free);
 
-        [DllImport(LibraryPath, EntryPoint = "sqlite3_column_count", CallingConvention=CallingConvention.Cdecl)]
-        public static extern int ColumnCount (IntPtr stmt);
+		[DllImport(LibraryPath, EntryPoint = "sqlite3_column_count", CallingConvention=CallingConvention.Cdecl)]
+		public static extern int ColumnCount (IntPtr stmt);
 
-        [DllImport(LibraryPath, EntryPoint = "sqlite3_column_name", CallingConvention=CallingConvention.Cdecl)]
-        public static extern IntPtr ColumnName (IntPtr stmt, int index);
+		[DllImport(LibraryPath, EntryPoint = "sqlite3_column_name", CallingConvention=CallingConvention.Cdecl)]
+		public static extern IntPtr ColumnName (IntPtr stmt, int index);
 
-        [DllImport(LibraryPath, EntryPoint = "sqlite3_column_name16", CallingConvention=CallingConvention.Cdecl)]
-        static extern IntPtr ColumnName16Internal (IntPtr stmt, int index);
-        public static string ColumnName16(IntPtr stmt, int index)
-        {
-            return Marshal.PtrToStringUni(ColumnName16Internal(stmt, index));
-        }
+		[DllImport(LibraryPath, EntryPoint = "sqlite3_column_name16", CallingConvention=CallingConvention.Cdecl)]
+		static extern IntPtr ColumnName16Internal (IntPtr stmt, int index);
+		public static string ColumnName16(IntPtr stmt, int index)
+		{
+			return Marshal.PtrToStringUni(ColumnName16Internal(stmt, index));
+		}
 
-        [DllImport(LibraryPath, EntryPoint = "sqlite3_column_type", CallingConvention=CallingConvention.Cdecl)]
-        public static extern ColType ColumnType (IntPtr stmt, int index);
+		[DllImport(LibraryPath, EntryPoint = "sqlite3_column_type", CallingConvention=CallingConvention.Cdecl)]
+		public static extern ColType ColumnType (IntPtr stmt, int index);
 
-        [DllImport(LibraryPath, EntryPoint = "sqlite3_column_int", CallingConvention=CallingConvention.Cdecl)]
-        public static extern int ColumnInt (IntPtr stmt, int index);
+		[DllImport(LibraryPath, EntryPoint = "sqlite3_column_int", CallingConvention=CallingConvention.Cdecl)]
+		public static extern int ColumnInt (IntPtr stmt, int index);
 
-        [DllImport(LibraryPath, EntryPoint = "sqlite3_column_int64", CallingConvention=CallingConvention.Cdecl)]
-        public static extern long ColumnInt64 (IntPtr stmt, int index);
+		[DllImport(LibraryPath, EntryPoint = "sqlite3_column_int64", CallingConvention=CallingConvention.Cdecl)]
+		public static extern long ColumnInt64 (IntPtr stmt, int index);
 
-        [DllImport(LibraryPath, EntryPoint = "sqlite3_column_double", CallingConvention=CallingConvention.Cdecl)]
-        public static extern double ColumnDouble (IntPtr stmt, int index);
+		[DllImport(LibraryPath, EntryPoint = "sqlite3_column_double", CallingConvention=CallingConvention.Cdecl)]
+		public static extern double ColumnDouble (IntPtr stmt, int index);
 
-        [DllImport(LibraryPath, EntryPoint = "sqlite3_column_text", CallingConvention=CallingConvention.Cdecl)]
-        public static extern IntPtr ColumnText (IntPtr stmt, int index);
+		[DllImport(LibraryPath, EntryPoint = "sqlite3_column_text", CallingConvention=CallingConvention.Cdecl)]
+		public static extern IntPtr ColumnText (IntPtr stmt, int index);
 
-        [DllImport(LibraryPath, EntryPoint = "sqlite3_column_text16", CallingConvention=CallingConvention.Cdecl)]
-        public static extern IntPtr ColumnText16 (IntPtr stmt, int index);
+		[DllImport(LibraryPath, EntryPoint = "sqlite3_column_text16", CallingConvention=CallingConvention.Cdecl)]
+		public static extern IntPtr ColumnText16 (IntPtr stmt, int index);
 
-        [DllImport(LibraryPath, EntryPoint = "sqlite3_column_blob", CallingConvention=CallingConvention.Cdecl)]
-        public static extern IntPtr ColumnBlob (IntPtr stmt, int index);
+		[DllImport(LibraryPath, EntryPoint = "sqlite3_column_blob", CallingConvention=CallingConvention.Cdecl)]
+		public static extern IntPtr ColumnBlob (IntPtr stmt, int index);
 
-        [DllImport(LibraryPath, EntryPoint = "sqlite3_column_bytes", CallingConvention=CallingConvention.Cdecl)]
-        public static extern int ColumnBytes (IntPtr stmt, int index);
+		[DllImport(LibraryPath, EntryPoint = "sqlite3_column_bytes", CallingConvention=CallingConvention.Cdecl)]
+		public static extern int ColumnBytes (IntPtr stmt, int index);
 
-        public static string ColumnString (IntPtr stmt, int index)
-        {
-            return Marshal.PtrToStringUni (SQLite3.ColumnText16 (stmt, index));
-        }
+		public static string ColumnString (IntPtr stmt, int index)
+		{
+			return Marshal.PtrToStringUni (SQLite3.ColumnText16 (stmt, index));
+		}
 
-        public static byte[] ColumnByteArray (IntPtr stmt, int index)
-        {
-            int length = ColumnBytes (stmt, index);
-            var result = new byte[length];
-            if (length > 0)
-                Marshal.Copy (ColumnBlob (stmt, index), result, 0, length);
-            return result;
-        }
+		public static byte[] ColumnByteArray (IntPtr stmt, int index)
+		{
+			int length = ColumnBytes (stmt, index);
+			var result = new byte[length];
+			if (length > 0)
+				Marshal.Copy (ColumnBlob (stmt, index), result, 0, length);
+			return result;
+		}
 
-        [DllImport (LibraryPath, EntryPoint = "sqlite3_errcode", CallingConvention = CallingConvention.Cdecl)]
-        public static extern Result GetResult (Sqlite3DatabaseHandle db);
+		[DllImport (LibraryPath, EntryPoint = "sqlite3_errcode", CallingConvention = CallingConvention.Cdecl)]
+		public static extern Result GetResult (Sqlite3DatabaseHandle db);
 
-        [DllImport (LibraryPath, EntryPoint = "sqlite3_extended_errcode", CallingConvention = CallingConvention.Cdecl)]
-        public static extern ExtendedResult ExtendedErrCode (IntPtr db);
+		[DllImport (LibraryPath, EntryPoint = "sqlite3_extended_errcode", CallingConvention = CallingConvention.Cdecl)]
+		public static extern ExtendedResult ExtendedErrCode (IntPtr db);
 
-        [DllImport (LibraryPath, EntryPoint = "sqlite3_libversion_number", CallingConvention = CallingConvention.Cdecl)]
-        public static extern int LibVersionNumber ();
+		[DllImport (LibraryPath, EntryPoint = "sqlite3_libversion_number", CallingConvention = CallingConvention.Cdecl)]
+		public static extern int LibVersionNumber ();
 
-        [DllImport (LibraryPath, EntryPoint = "sqlite3_backup_init", CallingConvention = CallingConvention.Cdecl)]
-        public static extern Sqlite3BackupHandle BackupInit (Sqlite3DatabaseHandle destDb, [MarshalAs (UnmanagedType.LPStr)] string destName, Sqlite3DatabaseHandle sourceDb, [MarshalAs (UnmanagedType.LPStr)] string sourceName);
+		[DllImport (LibraryPath, EntryPoint = "sqlite3_backup_init", CallingConvention = CallingConvention.Cdecl)]
+		public static extern Sqlite3BackupHandle BackupInit (Sqlite3DatabaseHandle destDb, [MarshalAs (UnmanagedType.LPStr)] string destName, Sqlite3DatabaseHandle sourceDb, [MarshalAs (UnmanagedType.LPStr)] string sourceName);
 
-        [DllImport (LibraryPath, EntryPoint = "sqlite3_backup_step", CallingConvention = CallingConvention.Cdecl)]
-        public static extern Result BackupStep (Sqlite3BackupHandle backup, int numPages);
+		[DllImport (LibraryPath, EntryPoint = "sqlite3_backup_step", CallingConvention = CallingConvention.Cdecl)]
+		public static extern Result BackupStep (Sqlite3BackupHandle backup, int numPages);
 
-        [DllImport (LibraryPath, EntryPoint = "sqlite3_backup_finish", CallingConvention = CallingConvention.Cdecl)]
-        public static extern Result BackupFinish (Sqlite3BackupHandle backup);
+		[DllImport (LibraryPath, EntryPoint = "sqlite3_backup_finish", CallingConvention = CallingConvention.Cdecl)]
+		public static extern Result BackupFinish (Sqlite3BackupHandle backup);
 #else
-        public static Result Open (string filename, out Sqlite3DatabaseHandle db)
-        {
-            return (Result)Sqlite3.sqlite3_open (filename, out db);
-        }
+		public static Result Open (string filename, out Sqlite3DatabaseHandle db)
+		{
+			return (Result)Sqlite3.sqlite3_open (filename, out db);
+		}
 
-        public static Result Open (string filename, out Sqlite3DatabaseHandle db, int flags, string vfsName)
-        {
+		public static Result Open (string filename, out Sqlite3DatabaseHandle db, int flags, string vfsName)
+		{
 #if USE_WP8_NATIVE_SQLITE
-            return (Result)Sqlite3.sqlite3_open_v2(filename, out db, flags, vfsName ?? "");
+			return (Result)Sqlite3.sqlite3_open_v2(filename, out db, flags, vfsName ?? "");
 #else
-            return (Result)Sqlite3.sqlite3_open_v2 (filename, out db, flags, vfsName);
+			return (Result)Sqlite3.sqlite3_open_v2 (filename, out db, flags, vfsName);
 #endif
-        }
+		}
 
-        public static Result Close (Sqlite3DatabaseHandle db)
-        {
-            return (Result)Sqlite3.sqlite3_close (db);
-        }
+		public static Result Close (Sqlite3DatabaseHandle db)
+		{
+			return (Result)Sqlite3.sqlite3_close (db);
+		}
 
-        public static Result Close2 (Sqlite3DatabaseHandle db)
-        {
-            return (Result)Sqlite3.sqlite3_close_v2 (db);
-        }
+		public static Result Close2 (Sqlite3DatabaseHandle db)
+		{
+			return (Result)Sqlite3.sqlite3_close_v2 (db);
+		}
 
-        public static Result BusyTimeout (Sqlite3DatabaseHandle db, int milliseconds)
-        {
-            return (Result)Sqlite3.sqlite3_busy_timeout (db, milliseconds);
-        }
+		public static Result BusyTimeout (Sqlite3DatabaseHandle db, int milliseconds)
+		{
+			return (Result)Sqlite3.sqlite3_busy_timeout (db, milliseconds);
+		}
 
-        public static int Changes (Sqlite3DatabaseHandle db)
-        {
-            return Sqlite3.sqlite3_changes (db);
-        }
+		public static int Changes (Sqlite3DatabaseHandle db)
+		{
+			return Sqlite3.sqlite3_changes (db);
+		}
 
-        public static Sqlite3Statement Prepare2 (Sqlite3DatabaseHandle db, string query)
-        {
-            Sqlite3Statement stmt = default (Sqlite3Statement);
+		public static Sqlite3Statement Prepare2 (Sqlite3DatabaseHandle db, string query)
+		{
+			Sqlite3Statement stmt = default (Sqlite3Statement);
 #if USE_WP8_NATIVE_SQLITE || USE_SQLITEPCL_RAW
-            var r = Sqlite3.sqlite3_prepare_v2 (db, query, out stmt);
+			var r = Sqlite3.sqlite3_prepare_v2 (db, query, out stmt);
 #else
-            stmt = new Sqlite3Statement();
-            var r = Sqlite3.sqlite3_prepare_v2(db, query, -1, ref stmt, 0);
+			stmt = new Sqlite3Statement();
+			var r = Sqlite3.sqlite3_prepare_v2(db, query, -1, ref stmt, 0);
 #endif
-            if (r != 0) {
-                throw SQLiteException.New ((Result)r, GetErrmsg (db));
-            }
-            return stmt;
-        }
+			if (r != 0) {
+				throw SQLiteException.New ((Result)r, GetErrmsg (db));
+			}
+			return stmt;
+		}
 
-        public static Result Step (Sqlite3Statement stmt)
-        {
-            return (Result)Sqlite3.sqlite3_step (stmt);
-        }
+		public static Result Step (Sqlite3Statement stmt)
+		{
+			return (Result)Sqlite3.sqlite3_step (stmt);
+		}
 
-        public static Result Reset (Sqlite3Statement stmt)
-        {
-            return (Result)Sqlite3.sqlite3_reset (stmt);
-        }
+		public static Result Reset (Sqlite3Statement stmt)
+		{
+			return (Result)Sqlite3.sqlite3_reset (stmt);
+		}
 
-        public static Result Finalize (Sqlite3Statement stmt)
-        {
-            return (Result)Sqlite3.sqlite3_finalize (stmt);
-        }
+		public static Result Finalize (Sqlite3Statement stmt)
+		{
+			return (Result)Sqlite3.sqlite3_finalize (stmt);
+		}
 
-        public static long LastInsertRowid (Sqlite3DatabaseHandle db)
-        {
-            return Sqlite3.sqlite3_last_insert_rowid (db);
-        }
+		public static long LastInsertRowid (Sqlite3DatabaseHandle db)
+		{
+			return Sqlite3.sqlite3_last_insert_rowid (db);
+		}
 
-        public static string GetErrmsg (Sqlite3DatabaseHandle db)
-        {
-            return Sqlite3.sqlite3_errmsg (db).utf8_to_string ();
-        }
+		public static string GetErrmsg (Sqlite3DatabaseHandle db)
+		{
+			return Sqlite3.sqlite3_errmsg (db).utf8_to_string ();
+		}
 
-        public static int BindParameterIndex (Sqlite3Statement stmt, string name)
-        {
-            return Sqlite3.sqlite3_bind_parameter_index (stmt, name);
-        }
+		public static int BindParameterIndex (Sqlite3Statement stmt, string name)
+		{
+			return Sqlite3.sqlite3_bind_parameter_index (stmt, name);
+		}
 
-        public static int BindNull (Sqlite3Statement stmt, int index)
-        {
-            return Sqlite3.sqlite3_bind_null (stmt, index);
-        }
+		public static int BindNull (Sqlite3Statement stmt, int index)
+		{
+			return Sqlite3.sqlite3_bind_null (stmt, index);
+		}
 
-        public static int BindInt (Sqlite3Statement stmt, int index, int val)
-        {
-            return Sqlite3.sqlite3_bind_int (stmt, index, val);
-        }
+		public static int BindInt (Sqlite3Statement stmt, int index, int val)
+		{
+			return Sqlite3.sqlite3_bind_int (stmt, index, val);
+		}
 
-        public static int BindInt64 (Sqlite3Statement stmt, int index, long val)
-        {
-            return Sqlite3.sqlite3_bind_int64 (stmt, index, val);
-        }
+		public static int BindInt64 (Sqlite3Statement stmt, int index, long val)
+		{
+			return Sqlite3.sqlite3_bind_int64 (stmt, index, val);
+		}
 
-        public static int BindDouble (Sqlite3Statement stmt, int index, double val)
-        {
-            return Sqlite3.sqlite3_bind_double (stmt, index, val);
-        }
+		public static int BindDouble (Sqlite3Statement stmt, int index, double val)
+		{
+			return Sqlite3.sqlite3_bind_double (stmt, index, val);
+		}
 
-        public static int BindText (Sqlite3Statement stmt, int index, string val, int n, IntPtr free)
-        {
+		public static int BindText (Sqlite3Statement stmt, int index, string val, int n, IntPtr free)
+		{
 #if USE_WP8_NATIVE_SQLITE
-            return Sqlite3.sqlite3_bind_text(stmt, index, val, n);
+			return Sqlite3.sqlite3_bind_text(stmt, index, val, n);
 #elif USE_SQLITEPCL_RAW
-            return Sqlite3.sqlite3_bind_text (stmt, index, val);
+			return Sqlite3.sqlite3_bind_text (stmt, index, val);
 #else
-            return Sqlite3.sqlite3_bind_text(stmt, index, val, n, null);
+			return Sqlite3.sqlite3_bind_text(stmt, index, val, n, null);
 #endif
-        }
+		}
 
-        public static int BindBlob (Sqlite3Statement stmt, int index, byte[] val, int n, IntPtr free)
-        {
+		public static int BindBlob (Sqlite3Statement stmt, int index, byte[] val, int n, IntPtr free)
+		{
 #if USE_WP8_NATIVE_SQLITE
-            return Sqlite3.sqlite3_bind_blob(stmt, index, val, n);
+			return Sqlite3.sqlite3_bind_blob(stmt, index, val, n);
 #elif USE_SQLITEPCL_RAW
-            return Sqlite3.sqlite3_bind_blob (stmt, index, val);
+			return Sqlite3.sqlite3_bind_blob (stmt, index, val);
 #else
-            return Sqlite3.sqlite3_bind_blob(stmt, index, val, n, null);
+			return Sqlite3.sqlite3_bind_blob(stmt, index, val, n, null);
 #endif
-        }
+		}
 
-        public static int ColumnCount (Sqlite3Statement stmt)
-        {
-            return Sqlite3.sqlite3_column_count (stmt);
-        }
+		public static int ColumnCount (Sqlite3Statement stmt)
+		{
+			return Sqlite3.sqlite3_column_count (stmt);
+		}
 
-        public static string ColumnName (Sqlite3Statement stmt, int index)
-        {
-            return Sqlite3.sqlite3_column_name (stmt, index).utf8_to_string ();
-        }
+		public static string ColumnName (Sqlite3Statement stmt, int index)
+		{
+			return Sqlite3.sqlite3_column_name (stmt, index).utf8_to_string ();
+		}
 
-        public static string ColumnName16 (Sqlite3Statement stmt, int index)
-        {
-            return Sqlite3.sqlite3_column_name (stmt, index).utf8_to_string ();
-        }
+		public static string ColumnName16 (Sqlite3Statement stmt, int index)
+		{
+			return Sqlite3.sqlite3_column_name (stmt, index).utf8_to_string ();
+		}
 
-        public static ColType ColumnType (Sqlite3Statement stmt, int index)
-        {
-            return (ColType)Sqlite3.sqlite3_column_type (stmt, index);
-        }
+		public static ColType ColumnType (Sqlite3Statement stmt, int index)
+		{
+			return (ColType)Sqlite3.sqlite3_column_type (stmt, index);
+		}
 
-        public static int ColumnInt (Sqlite3Statement stmt, int index)
-        {
-            return Sqlite3.sqlite3_column_int (stmt, index);
-        }
+		public static int ColumnInt (Sqlite3Statement stmt, int index)
+		{
+			return Sqlite3.sqlite3_column_int (stmt, index);
+		}
 
-        public static long ColumnInt64 (Sqlite3Statement stmt, int index)
-        {
-            return Sqlite3.sqlite3_column_int64 (stmt, index);
-        }
+		public static long ColumnInt64 (Sqlite3Statement stmt, int index)
+		{
+			return Sqlite3.sqlite3_column_int64 (stmt, index);
+		}
 
-        public static double ColumnDouble (Sqlite3Statement stmt, int index)
-        {
-            return Sqlite3.sqlite3_column_double (stmt, index);
-        }
+		public static double ColumnDouble (Sqlite3Statement stmt, int index)
+		{
+			return Sqlite3.sqlite3_column_double (stmt, index);
+		}
 
-        public static string ColumnText (Sqlite3Statement stmt, int index)
-        {
-            return Sqlite3.sqlite3_column_text (stmt, index).utf8_to_string ();
-        }
+		public static string ColumnText (Sqlite3Statement stmt, int index)
+		{
+			return Sqlite3.sqlite3_column_text (stmt, index).utf8_to_string ();
+		}
 
-        public static string ColumnText16 (Sqlite3Statement stmt, int index)
-        {
-            return Sqlite3.sqlite3_column_text (stmt, index).utf8_to_string ();
-        }
+		public static string ColumnText16 (Sqlite3Statement stmt, int index)
+		{
+			return Sqlite3.sqlite3_column_text (stmt, index).utf8_to_string ();
+		}
 
-        public static byte[] ColumnBlob (Sqlite3Statement stmt, int index)
-        {
-            return Sqlite3.sqlite3_column_blob (stmt, index).ToArray ();
-        }
+		public static byte[] ColumnBlob (Sqlite3Statement stmt, int index)
+		{
+			return Sqlite3.sqlite3_column_blob (stmt, index).ToArray ();
+		}
 
-        public static int ColumnBytes (Sqlite3Statement stmt, int index)
-        {
-            return Sqlite3.sqlite3_column_bytes (stmt, index);
-        }
+		public static int ColumnBytes (Sqlite3Statement stmt, int index)
+		{
+			return Sqlite3.sqlite3_column_bytes (stmt, index);
+		}
 
-        public static string ColumnString (Sqlite3Statement stmt, int index)
-        {
-            return Sqlite3.sqlite3_column_text (stmt, index).utf8_to_string ();
-        }
+		public static string ColumnString (Sqlite3Statement stmt, int index)
+		{
+			return Sqlite3.sqlite3_column_text (stmt, index).utf8_to_string ();
+		}
 
-        public static byte[] ColumnByteArray (Sqlite3Statement stmt, int index)
-        {
-            int length = ColumnBytes (stmt, index);
-            if (length > 0) {
-                return ColumnBlob (stmt, index);
-            }
-            return new byte[0];
-        }
+		public static byte[] ColumnByteArray (Sqlite3Statement stmt, int index)
+		{
+			int length = ColumnBytes (stmt, index);
+			if (length > 0) {
+				return ColumnBlob (stmt, index);
+			}
+			return new byte[0];
+		}
 
-        public static Result EnableLoadExtension (Sqlite3DatabaseHandle db, int onoff)
-        {
-            return (Result)Sqlite3.sqlite3_enable_load_extension (db, onoff);
-        }
+		public static Result EnableLoadExtension (Sqlite3DatabaseHandle db, int onoff)
+		{
+			return (Result)Sqlite3.sqlite3_enable_load_extension (db, onoff);
+		}
 
-        public static int LibVersionNumber ()
-        {
-            return Sqlite3.sqlite3_libversion_number ();
-        }
+		public static int LibVersionNumber ()
+		{
+			return Sqlite3.sqlite3_libversion_number ();
+		}
 
-        public static Result GetResult (Sqlite3DatabaseHandle db)
-        {
-            return (Result)Sqlite3.sqlite3_errcode (db);
-        }
+		public static Result GetResult (Sqlite3DatabaseHandle db)
+		{
+			return (Result)Sqlite3.sqlite3_errcode (db);
+		}
 
-        public static ExtendedResult ExtendedErrCode (Sqlite3DatabaseHandle db)
-        {
-            return (ExtendedResult)Sqlite3.sqlite3_extended_errcode (db);
-        }
+		public static ExtendedResult ExtendedErrCode (Sqlite3DatabaseHandle db)
+		{
+			return (ExtendedResult)Sqlite3.sqlite3_extended_errcode (db);
+		}
 
-        public static Sqlite3BackupHandle BackupInit (Sqlite3DatabaseHandle destDb, string destName, Sqlite3DatabaseHandle sourceDb, string sourceName)
-        {
-            return Sqlite3.sqlite3_backup_init (destDb, destName, sourceDb, sourceName);
-        }
+		public static Sqlite3BackupHandle BackupInit (Sqlite3DatabaseHandle destDb, string destName, Sqlite3DatabaseHandle sourceDb, string sourceName)
+		{
+			return Sqlite3.sqlite3_backup_init (destDb, destName, sourceDb, sourceName);
+		}
 
-        public static Result BackupStep (Sqlite3BackupHandle backup, int numPages)
-        {
-            return (Result)Sqlite3.sqlite3_backup_step (backup, numPages);
-        }
+		public static Result BackupStep (Sqlite3BackupHandle backup, int numPages)
+		{
+			return (Result)Sqlite3.sqlite3_backup_step (backup, numPages);
+		}
 
-        public static Result BackupFinish (Sqlite3BackupHandle backup)
-        {
-            return (Result)Sqlite3.sqlite3_backup_finish (backup);
-        }
+		public static Result BackupFinish (Sqlite3BackupHandle backup)
+		{
+			return (Result)Sqlite3.sqlite3_backup_finish (backup);
+		}
 #endif
 
-        public enum ColType : int
-        {
-            Integer = 1,
-            Float = 2,
-            Text = 3,
-            Blob = 4,
-            Null = 5
-        }
-    }
+		public enum ColType : int
+		{
+			Integer = 1,
+			Float = 2,
+			Text = 3,
+			Blob = 4,
+			Null = 5
+		}
+	}
 }

--- a/src/SQLite.cs
+++ b/src/SQLite.cs
@@ -26,6 +26,9 @@
 using System;
 using System.Collections;
 using System.Diagnostics;
+#if NET8_0_OR_GREATER
+using System.Diagnostics.CodeAnalysis;
+#endif
 #if !USE_SQLITEPCL_RAW
 using System.Runtime.InteropServices;
 #endif
@@ -187,62 +190,199 @@ namespace SQLite
         int CreateIndex (string indexName, string tableName, string columnName, bool unique = false);
         int CreateIndex (string tableName, string columnName, bool unique = false);
         int CreateIndex (string tableName, string[] columnNames, bool unique = false);
-        int CreateIndex<T> (Expression<Func<T, object>> property, bool unique = false);
-        CreateTableResult CreateTable<T> (CreateFlags createFlags = CreateFlags.None);
-        CreateTableResult CreateTable (Type ty, CreateFlags createFlags = CreateFlags.None);
-        CreateTablesResult CreateTables<T, T2> (CreateFlags createFlags = CreateFlags.None)
+        int CreateIndex<
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+#endif
+			T> (Expression<Func<T, object>> property, bool unique = false);
+        CreateTableResult CreateTable<
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+#endif
+			T> (CreateFlags createFlags = CreateFlags.None);
+        CreateTableResult CreateTable (
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+#endif
+			Type ty, CreateFlags createFlags = CreateFlags.None);
+        CreateTablesResult CreateTables<
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+#endif
+			T,
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+#endif
+			T2> (CreateFlags createFlags = CreateFlags.None)
             where T : new()
             where T2 : new();
-        CreateTablesResult CreateTables<T, T2, T3> (CreateFlags createFlags = CreateFlags.None)
+        CreateTablesResult CreateTables<
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+#endif
+			T,
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+#endif
+			T2,
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+#endif
+			T3> (CreateFlags createFlags = CreateFlags.None)
             where T : new()
             where T2 : new()
             where T3 : new();
-        CreateTablesResult CreateTables<T, T2, T3, T4> (CreateFlags createFlags = CreateFlags.None)
+        CreateTablesResult CreateTables<
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+#endif
+			T,
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+#endif
+			T2,
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+#endif
+			T3,
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+#endif
+			T4> (CreateFlags createFlags = CreateFlags.None)
             where T : new()
             where T2 : new()
             where T3 : new()
             where T4 : new();
-        CreateTablesResult CreateTables<T, T2, T3, T4, T5> (CreateFlags createFlags = CreateFlags.None)
+        CreateTablesResult CreateTables<
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+#endif
+			T,
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+#endif
+			T2,
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+#endif
+			T3,
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+#endif
+			T4,
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+#endif
+			T5> (CreateFlags createFlags = CreateFlags.None)
             where T : new()
             where T2 : new()
             where T3 : new()
             where T4 : new()
             where T5 : new();
-        CreateTablesResult CreateTables (CreateFlags createFlags = CreateFlags.None, params Type[] types);
-        IEnumerable<T> DeferredQuery<T> (string query, params object[] args) where T : new();
+#if NET
+		[RequiresUnreferencedCode ("This method requires 'DynamicallyAccessedMemberTypes.All' on each input 'Type' instance.")]
+#endif
+		CreateTablesResult CreateTables (CreateFlags createFlags = CreateFlags.None, params Type[] types);
+        IEnumerable<T> DeferredQuery<
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+#endif
+			T> (string query, params object[] args) where T : new();
         IEnumerable<object> DeferredQuery (TableMapping map, string query, params object[] args);
         int Delete (object objectToDelete);
-        int Delete<T> (object primaryKey);
+        int Delete<
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+#endif
+			T> (object primaryKey);
         int Delete (object primaryKey, TableMapping map);
         int DeleteAll<T> ();
         int DeleteAll (TableMapping map);
-        int DropTable<T> ();
+        int DropTable<
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+#endif
+			T> ();
         int DropTable (TableMapping map);
         void EnableLoadExtension (bool enabled);
         void EnableWriteAheadLogging ();
         int Execute (string query, params object[] args);
         T ExecuteScalar<T> (string query, params object[] args);
-        T Find<T> (object pk) where T : new();
+        T Find<
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+#endif
+			T> (object pk) where T : new();
         object Find (object pk, TableMapping map);
-        T Find<T> (Expression<Func<T, bool>> predicate) where T : new();
-        T FindWithQuery<T> (string query, params object[] args) where T : new();
+        T Find<
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+#endif
+			T> (Expression<Func<T, bool>> predicate) where T : new();
+        T FindWithQuery<
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+#endif
+			T> (string query, params object[] args) where T : new();
         object FindWithQuery (TableMapping map, string query, params object[] args);
-        T Get<T> (object pk) where T : new();
+        T Get<
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+#endif
+			T> (object pk) where T : new();
         object Get (object pk, TableMapping map);
-        T Get<T> (Expression<Func<T, bool>> predicate) where T : new();
-        TableMapping GetMapping (Type type, CreateFlags createFlags = CreateFlags.None);
-        TableMapping GetMapping<T> (CreateFlags createFlags = CreateFlags.None);
+        T Get<
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+#endif
+			T> (Expression<Func<T, bool>> predicate) where T : new();
+        TableMapping GetMapping (
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+#endif
+			Type type, CreateFlags createFlags = CreateFlags.None);
+        TableMapping GetMapping<
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+#endif
+			T> (CreateFlags createFlags = CreateFlags.None);
         List<SQLiteConnection.ColumnInfo> GetTableInfo (string tableName);
         int Insert (object obj);
-        int Insert (object obj, Type objType);
+        int Insert (
+			object obj,
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+#endif
+			Type objType);
         int Insert (object obj, string extra);
-        int Insert (object obj, string extra, Type objType);
+        int Insert (
+			object obj,
+			string extra,
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+#endif
+			Type objType);
         int InsertAll (IEnumerable objects, bool runInTransaction = true);
         int InsertAll (IEnumerable objects, string extra, bool runInTransaction = true);
-        int InsertAll (IEnumerable objects, Type objType, bool runInTransaction = true);
+        int InsertAll (
+			IEnumerable objects,
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+#endif
+			Type objType,
+			bool runInTransaction = true);
         int InsertOrReplace (object obj);
-        int InsertOrReplace (object obj, Type objType);
-        List<T> Query<T> (string query, params object[] args) where T : new();
+        int InsertOrReplace (
+			object obj,
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+#endif
+			Type objType);
+        List<T> Query<
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+#endif
+			T> (string query, params object[] args) where T : new();
         List<object> Query (TableMapping map, string query, params object[] args);
         List<T> QueryScalars<T> (string query, params object[] args);
         void ReKey (string key);
@@ -252,9 +392,18 @@ namespace SQLite
         void RollbackTo (string savepoint);
         void RunInTransaction (Action action);
         string SaveTransactionPoint ();
-        TableQuery<T> Table<T> () where T : new();
+        TableQuery<T> Table<
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+#endif
+			T> () where T : new();
         int Update (object obj);
-        int Update (object obj, Type objType);
+        int Update (
+			object obj,
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+#endif
+			Type objType);
         int UpdateAll (IEnumerable objects, bool runInTransaction = true);
     }
 
@@ -576,7 +725,12 @@ namespace SQLite
         /// The mapping represents the schema of the columns of the database and contains
         /// methods to set and get properties of objects.
         /// </returns>
-        public TableMapping GetMapping (Type type, CreateFlags createFlags = CreateFlags.None)
+        public TableMapping GetMapping (
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+#endif
+			Type type,
+			CreateFlags createFlags = CreateFlags.None)
         {
             TableMapping map;
             var key = type.FullName;
@@ -605,7 +759,11 @@ namespace SQLite
         /// The mapping represents the schema of the columns of the database and contains
         /// methods to set and get properties of objects.
         /// </returns>
-        public TableMapping GetMapping<T> (CreateFlags createFlags = CreateFlags.None)
+        public TableMapping GetMapping<
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+#endif
+			T> (CreateFlags createFlags = CreateFlags.None)
         {
             return GetMapping (typeof (T), createFlags);
         }
@@ -627,7 +785,11 @@ namespace SQLite
         /// <summary>
         /// Executes a "drop table" on the database.  This is non-recoverable.
         /// </summary>
-        public int DropTable<T> ()
+        public int DropTable<
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+#endif
+			T> ()
         {
             return DropTable (GetMapping (typeof (T)));
         }
@@ -653,7 +815,11 @@ namespace SQLite
         /// <returns>
         /// Whether the table was created or migrated.
         /// </returns>
-        public CreateTableResult CreateTable<T> (CreateFlags createFlags = CreateFlags.None)
+        public CreateTableResult CreateTable<
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+#endif
+			T> (CreateFlags createFlags = CreateFlags.None)
         {
             return CreateTable (typeof (T), createFlags);
         }
@@ -669,7 +835,11 @@ namespace SQLite
         /// <returns>
         /// Whether the table was created or migrated.
         /// </returns>
-        public CreateTableResult CreateTable (Type ty, CreateFlags createFlags = CreateFlags.None)
+        public CreateTableResult CreateTable (
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+#endif
+			Type ty, CreateFlags createFlags = CreateFlags.None)
         {
             var map = GetMapping (ty, createFlags);
 
@@ -743,50 +913,95 @@ namespace SQLite
             return result;
         }
 
-        /// <summary>
-        /// Executes a "create table if not exists" on the database for each type. It also
-        /// creates any specified indexes on the columns of the table. It uses
-        /// a schema automatically generated from the specified type. You can
-        /// later access this schema by calling GetMapping.
-        /// </summary>
-        /// <returns>
-        /// Whether the table was created or migrated for each type.
-        /// </returns>
-        public CreateTablesResult CreateTables<T, T2> (CreateFlags createFlags = CreateFlags.None)
+		/// <summary>
+		/// Executes a "create table if not exists" on the database for each type. It also
+		/// creates any specified indexes on the columns of the table. It uses
+		/// a schema automatically generated from the specified type. You can
+		/// later access this schema by calling GetMapping.
+		/// </summary>
+		/// <returns>
+		/// Whether the table was created or migrated for each type.
+		/// </returns>
+#if NET8_0_OR_GREATER
+		[UnconditionalSuppressMessage ("Trimming", "IL2026", Justification = "This method preserves metata for all type arguments.")]
+#endif
+		public CreateTablesResult CreateTables<
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+#endif
+			T,
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+#endif
+			T2> (CreateFlags createFlags = CreateFlags.None)
             where T : new()
             where T2 : new()
         {
             return CreateTables (createFlags, typeof (T), typeof (T2));
         }
 
-        /// <summary>
-        /// Executes a "create table if not exists" on the database for each type. It also
-        /// creates any specified indexes on the columns of the table. It uses
-        /// a schema automatically generated from the specified type. You can
-        /// later access this schema by calling GetMapping.
-        /// </summary>
-        /// <returns>
-        /// Whether the table was created or migrated for each type.
-        /// </returns>
-        public CreateTablesResult CreateTables<T, T2, T3> (CreateFlags createFlags = CreateFlags.None)
-            where T : new()
+		/// <summary>
+		/// Executes a "create table if not exists" on the database for each type. It also
+		/// creates any specified indexes on the columns of the table. It uses
+		/// a schema automatically generated from the specified type. You can
+		/// later access this schema by calling GetMapping.
+		/// </summary>
+		/// <returns>
+		/// Whether the table was created or migrated for each type.
+		/// </returns>
+#if NET8_0_OR_GREATER
+		[UnconditionalSuppressMessage ("Trimming", "IL2026", Justification = "This method preserves metata for all type arguments.")]
+#endif
+		public CreateTablesResult CreateTables<
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+#endif
+			T,
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+# endif
+			T2,
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+#endif
+			T3> (CreateFlags createFlags = CreateFlags.None)
+			where T : new()
             where T2 : new()
             where T3 : new()
         {
             return CreateTables (createFlags, typeof (T), typeof (T2), typeof (T3));
         }
 
-        /// <summary>
-        /// Executes a "create table if not exists" on the database for each type. It also
-        /// creates any specified indexes on the columns of the table. It uses
-        /// a schema automatically generated from the specified type. You can
-        /// later access this schema by calling GetMapping.
-        /// </summary>
-        /// <returns>
-        /// Whether the table was created or migrated for each type.
-        /// </returns>
-        public CreateTablesResult CreateTables<T, T2, T3, T4> (CreateFlags createFlags = CreateFlags.None)
-            where T : new()
+		/// <summary>
+		/// Executes a "create table if not exists" on the database for each type. It also
+		/// creates any specified indexes on the columns of the table. It uses
+		/// a schema automatically generated from the specified type. You can
+		/// later access this schema by calling GetMapping.
+		/// </summary>
+		/// <returns>
+		/// Whether the table was created or migrated for each type.
+		/// </returns>
+#if NET8_0_OR_GREATER
+		[UnconditionalSuppressMessage ("Trimming", "IL2026", Justification = "This method preserves metata for all type arguments.")]
+#endif
+		public CreateTablesResult CreateTables<
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+# endif
+			T,
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+# endif
+			T2,
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+# endif
+			T3,
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+# endif
+			T4> (CreateFlags createFlags = CreateFlags.None)
+			where T : new()
             where T2 : new()
             where T3 : new()
             where T4 : new()
@@ -794,17 +1009,40 @@ namespace SQLite
             return CreateTables (createFlags, typeof (T), typeof (T2), typeof (T3), typeof (T4));
         }
 
-        /// <summary>
-        /// Executes a "create table if not exists" on the database for each type. It also
-        /// creates any specified indexes on the columns of the table. It uses
-        /// a schema automatically generated from the specified type. You can
-        /// later access this schema by calling GetMapping.
-        /// </summary>
-        /// <returns>
-        /// Whether the table was created or migrated for each type.
-        /// </returns>
-        public CreateTablesResult CreateTables<T, T2, T3, T4, T5> (CreateFlags createFlags = CreateFlags.None)
-            where T : new()
+		/// <summary>
+		/// Executes a "create table if not exists" on the database for each type. It also
+		/// creates any specified indexes on the columns of the table. It uses
+		/// a schema automatically generated from the specified type. You can
+		/// later access this schema by calling GetMapping.
+		/// </summary>
+		/// <returns>
+		/// Whether the table was created or migrated for each type.
+		/// </returns>
+#if NET8_0_OR_GREATER
+		[UnconditionalSuppressMessage ("Trimming", "IL2026", Justification = "This method preserves metata for all type arguments.")]
+#endif
+		public CreateTablesResult CreateTables<
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+# endif
+			T,
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+# endif
+			T2,
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+# endif
+			T3,
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+# endif
+			T4,
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+# endif
+			T5> (CreateFlags createFlags = CreateFlags.None)
+			where T : new()
             where T2 : new()
             where T3 : new()
             where T4 : new()
@@ -813,16 +1051,19 @@ namespace SQLite
             return CreateTables (createFlags, typeof (T), typeof (T2), typeof (T3), typeof (T4), typeof (T5));
         }
 
-        /// <summary>
-        /// Executes a "create table if not exists" on the database for each type. It also
-        /// creates any specified indexes on the columns of the table. It uses
-        /// a schema automatically generated from the specified type. You can
-        /// later access this schema by calling GetMapping.
-        /// </summary>
-        /// <returns>
-        /// Whether the table was created or migrated for each type.
-        /// </returns>
-        public CreateTablesResult CreateTables (CreateFlags createFlags = CreateFlags.None, params Type[] types)
+		/// <summary>
+		/// Executes a "create table if not exists" on the database for each type. It also
+		/// creates any specified indexes on the columns of the table. It uses
+		/// a schema automatically generated from the specified type. You can
+		/// later access this schema by calling GetMapping.
+		/// </summary>
+		/// <returns>
+		/// Whether the table was created or migrated for each type.
+		/// </returns>
+#if NET
+		[RequiresUnreferencedCode("This method requires 'DynamicallyAccessedMemberTypes.All' on each input 'Type' instance.")]
+#endif
+		public CreateTablesResult CreateTables (CreateFlags createFlags = CreateFlags.None, params Type[] types)
         {
             var result = new CreateTablesResult ();
             foreach (Type type in types) {
@@ -892,7 +1133,11 @@ namespace SQLite
         /// <param name="property">Property to index</param>
         /// <param name="unique">Whether the index should be unique</param>
         /// <returns>Zero on success.</returns>
-        public int CreateIndex<T> (Expression<Func<T, object>> property, bool unique = false)
+        public int CreateIndex<
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+#endif
+			T> (Expression<Func<T, object>> property, bool unique = false)
         {
             MemberExpression mx;
             if (property.Body.NodeType == ExpressionType.Convert) {
@@ -1126,7 +1371,11 @@ namespace SQLite
         /// <returns>
         /// An enumerable with one result for each row returned by the query.
         /// </returns>
-        public List<T> Query<T> (string query, params object[] args) where T : new()
+        public List<T> Query<
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+#endif
+			T> (string query, params object[] args) where T : new()
         {
             var cmd = CreateCommand (query, args);
             return cmd.ExecuteQuery<T> ();
@@ -1170,7 +1419,11 @@ namespace SQLite
         /// will call sqlite3_step on each call to MoveNext, so the database
         /// connection must remain open for the lifetime of the enumerator.
         /// </returns>
-        public IEnumerable<T> DeferredQuery<T> (string query, params object[] args) where T : new()
+        public IEnumerable<T> DeferredQuery<
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+#endif
+			T> (string query, params object[] args) where T : new()
         {
             var cmd = CreateCommand (query, args);
             return cmd.ExecuteDeferredQuery<T> ();
@@ -1238,7 +1491,11 @@ namespace SQLite
         /// A queryable object that is able to translate Where, OrderBy, and Take
         /// queries into native SQL.
         /// </returns>
-        public TableQuery<T> Table<T> () where T : new()
+        public TableQuery<T> Table<
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+#endif
+			T> () where T : new()
         {
             return new TableQuery<T> (this);
         }
@@ -1255,7 +1512,11 @@ namespace SQLite
         /// The object with the given primary key. Throws a not found exception
         /// if the object is not found.
         /// </returns>
-        public T Get<T> (object pk) where T : new()
+        public T Get<
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+#endif
+			T> (object pk) where T : new()
         {
             var map = GetMapping (typeof (T));
             return Query<T> (map.GetByPrimaryKeySql, pk).First ();
@@ -1292,7 +1553,11 @@ namespace SQLite
         /// The object that matches the given predicate. Throws a not found exception
         /// if the object is not found.
         /// </returns>
-        public T Get<T> (Expression<Func<T, bool>> predicate) where T : new()
+        public T Get<
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+#endif
+			T> (Expression<Func<T, bool>> predicate) where T : new()
         {
             return Table<T> ().Where (predicate).First ();
         }
@@ -1309,7 +1574,11 @@ namespace SQLite
         /// The object with the given primary key or null
         /// if the object is not found.
         /// </returns>
-        public T Find<T> (object pk) where T : new()
+        public T Find<
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+#endif
+			T> (object pk) where T : new()
         {
             var map = GetMapping (typeof (T));
             return Query<T> (map.GetByPrimaryKeySql, pk).FirstOrDefault ();
@@ -1346,7 +1615,11 @@ namespace SQLite
         /// The object that matches the given predicate or null
         /// if the object is not found.
         /// </returns>
-        public T Find<T> (Expression<Func<T, bool>> predicate) where T : new()
+        public T Find<
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+#endif
+			T> (Expression<Func<T, bool>> predicate) where T : new()
         {
             return Table<T> ().Where (predicate).FirstOrDefault ();
         }
@@ -1365,7 +1638,11 @@ namespace SQLite
         /// The object that matches the given predicate or null
         /// if the object is not found.
         /// </returns>
-        public T FindWithQuery<T> (string query, params object[] args) where T : new()
+        public T FindWithQuery<
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+#endif
+			T> (string query, params object[] args) where T : new()
         {
             return Query<T> (query, args).FirstOrDefault ();
         }
@@ -1713,7 +1990,13 @@ namespace SQLite
         /// <returns>
         /// The number of rows added to the table.
         /// </returns>
-        public int InsertAll (System.Collections.IEnumerable objects, Type objType, bool runInTransaction = true)
+        public int InsertAll (
+			System.Collections.IEnumerable objects,
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+#endif
+			Type objType,
+			bool runInTransaction = true)
         {
             var c = 0;
             if (runInTransaction) {
@@ -1786,7 +2069,12 @@ namespace SQLite
         /// <returns>
         /// The number of rows added to the table.
         /// </returns>
-        public int Insert (object obj, Type objType)
+        public int Insert (
+			object obj,
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+#endif
+			Type objType)
         {
             return Insert (obj, "", objType);
         }
@@ -1808,7 +2096,12 @@ namespace SQLite
         /// <returns>
         /// The number of rows modified.
         /// </returns>
-        public int InsertOrReplace (object obj, Type objType)
+        public int InsertOrReplace (
+			object obj,
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+#endif
+			Type objType)
         {
             return Insert (obj, "OR REPLACE", objType);
         }
@@ -1852,7 +2145,13 @@ namespace SQLite
         /// <returns>
         /// The number of rows added to the table.
         /// </returns>
-        public int Insert (object obj, string extra, Type objType)
+        public int Insert (
+			object obj,
+			string extra,
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+#endif
+			Type objType)
         {
             if (obj == null || objType == null) {
                 return 0;
@@ -1988,7 +2287,12 @@ namespace SQLite
         /// <returns>
         /// The number of rows updated.
         /// </returns>
-        public int Update (object obj, Type objType)
+        public int Update (
+			object obj,
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+#endif
+			Type objType)
         {
             int rowsAffected = 0;
             if (obj == null || objType == null) {
@@ -2104,7 +2408,11 @@ namespace SQLite
         /// <typeparam name='T'>
         /// The type of object.
         /// </typeparam>
-        public int Delete<T> (object primaryKey)
+        public int Delete<
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+#endif
+			T> (object primaryKey)
         {
             return Delete (primaryKey, GetMapping (typeof (T)));
         }
@@ -2571,7 +2879,11 @@ namespace SQLite
         readonly Column[] _insertColumns;
         readonly Column[] _insertOrReplaceColumns;
 
-        public TableMapping (Type type, CreateFlags createFlags = CreateFlags.None)
+        public TableMapping (
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+#endif
+			Type type, CreateFlags createFlags = CreateFlags.None)
         {
             MappedType = type;
             CreateFlags = createFlags;
@@ -2622,7 +2934,11 @@ namespace SQLite
             _insertOrReplaceColumns = Columns.ToArray ();
         }
 
-        private IReadOnlyCollection<MemberInfo> GetPublicMembers(Type type)
+        private IReadOnlyCollection<MemberInfo> GetPublicMembers(
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+#endif
+			Type type)
         {
             if(type.Name.StartsWith("ValueTuple`"))
                 return GetFieldsFromValueTuple(type);
@@ -2655,7 +2971,11 @@ namespace SQLite
             return members;
         }
 
-        private IReadOnlyCollection<MemberInfo> GetFieldsFromValueTuple(Type type)
+        private IReadOnlyCollection<MemberInfo> GetFieldsFromValueTuple(
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.NonPublicFields)]
+#endif
+			Type type)
         {
             Method = MapMethod.ByPosition;
             var fields = type.GetFields();
@@ -2983,15 +3303,25 @@ namespace SQLite
             return p.CustomAttributes.Any (x => x.AttributeType == typeof (AutoIncrementAttribute));
         }
 
-        public static FieldInfo GetField (TypeInfo t, string name)
+        public static FieldInfo GetField (
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+#endif
+			TypeInfo t,
+			string name)
         {
-            var f = t.GetDeclaredField (name);
+			var f = t.GetDeclaredField (name);
             if (f != null)
                 return f;
             return GetField (t.BaseType.GetTypeInfo (), name);
         }
 
-        public static PropertyInfo GetProperty (TypeInfo t, string name)
+        public static PropertyInfo GetProperty (
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+#endif
+			TypeInfo t,
+			string name)
         {
             var f = t.GetDeclaredProperty (name);
             if (f != null)
@@ -3096,12 +3426,20 @@ namespace SQLite
             throw SQLiteException.New (r, SQLite3.GetErrmsg (_conn.Handle));
         }
 
-        public IEnumerable<T> ExecuteDeferredQuery<T> ()
+        public IEnumerable<T> ExecuteDeferredQuery<
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+#endif
+			T> ()
         {
             return ExecuteDeferredQuery<T> (_conn.GetMapping (typeof (T)));
         }
 
-        public List<T> ExecuteQuery<T> ()
+        public List<T> ExecuteQuery<
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+#endif
+			T> ()
         {
             return ExecuteDeferredQuery<T> (_conn.GetMapping (typeof (T))).ToList ();
         }
@@ -3836,7 +4174,11 @@ namespace SQLite
         }
     }
 
-    public class TableQuery<T> : BaseTableQuery, IEnumerable<T>
+    public class TableQuery<
+#if NET8_0_OR_GREATER
+		[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+#endif
+		T> : BaseTableQuery, IEnumerable<T>
     {
         public SQLiteConnection Connection { get; private set; }
 
@@ -3867,7 +4209,11 @@ namespace SQLite
             Table = Connection.GetMapping (typeof (T));
         }
 
-        public TableQuery<U> Clone<U> ()
+        public TableQuery<U> Clone<
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+#endif
+			U> ()
         {
             var q = new TableQuery<U> (Connection, Table);
             q._where = _where;

--- a/src/SQLite.cs
+++ b/src/SQLite.cs
@@ -3039,7 +3039,7 @@ namespace SQLite
 
 		private IReadOnlyCollection<MemberInfo> GetFieldsFromValueTuple(
 #if NET8_0_OR_GREATER
-			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.NonPublicFields)]
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicFields)]
 #endif
 			Type type)
 		{

--- a/src/SQLite.cs
+++ b/src/SQLite.cs
@@ -289,14 +289,21 @@ namespace SQLite
 #endif
 			T> (string query, params object[] args) where T : new();
         IEnumerable<object> DeferredQuery (TableMapping map, string query, params object[] args);
-        int Delete (object objectToDelete);
+#if NET8_0_OR_GREATER
+		[RequiresUnreferencedCode ("This method requires ''DynamicallyAccessedMemberTypes.All' on the runtime type of 'objectToDelete'.")]
+#endif
+		int Delete (object objectToDelete);
         int Delete<
 #if NET8_0_OR_GREATER
 			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
 #endif
 			T> (object primaryKey);
         int Delete (object primaryKey, TableMapping map);
-        int DeleteAll<T> ();
+        int DeleteAll<
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+#endif
+			T> ();
         int DeleteAll (TableMapping map);
         int DropTable<
 #if NET8_0_OR_GREATER
@@ -347,14 +354,20 @@ namespace SQLite
 #endif
 			T> (CreateFlags createFlags = CreateFlags.None);
         List<SQLiteConnection.ColumnInfo> GetTableInfo (string tableName);
-        int Insert (object obj);
+#if NET8_0_OR_GREATER
+		[RequiresUnreferencedCode ("This method requires ''DynamicallyAccessedMemberTypes.All' on the runtime type of 'obj'.")]
+#endif
+		int Insert (object obj);
         int Insert (
 			object obj,
 #if NET8_0_OR_GREATER
 			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
 #endif
 			Type objType);
-        int Insert (object obj, string extra);
+#if NET8_0_OR_GREATER
+		[RequiresUnreferencedCode ("This method requires ''DynamicallyAccessedMemberTypes.All' on the runtime type of 'obj'.")]
+#endif
+		int Insert (object obj, string extra);
         int Insert (
 			object obj,
 			string extra,
@@ -362,8 +375,14 @@ namespace SQLite
 			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
 #endif
 			Type objType);
-        int InsertAll (IEnumerable objects, bool runInTransaction = true);
-        int InsertAll (IEnumerable objects, string extra, bool runInTransaction = true);
+#if NET8_0_OR_GREATER
+		[RequiresUnreferencedCode ("This method requires ''DynamicallyAccessedMemberTypes.All' on the runtime type of all objects in 'objects'.")]
+#endif
+		int InsertAll (IEnumerable objects, bool runInTransaction = true);
+#if NET8_0_OR_GREATER
+		[RequiresUnreferencedCode ("This method requires ''DynamicallyAccessedMemberTypes.All' on the runtime type of all objects in 'objects'.")]
+#endif
+		int InsertAll (IEnumerable objects, string extra, bool runInTransaction = true);
         int InsertAll (
 			IEnumerable objects,
 #if NET8_0_OR_GREATER
@@ -371,7 +390,10 @@ namespace SQLite
 #endif
 			Type objType,
 			bool runInTransaction = true);
-        int InsertOrReplace (object obj);
+#if NET8_0_OR_GREATER
+		[RequiresUnreferencedCode ("This method requires ''DynamicallyAccessedMemberTypes.All' on the runtime type of 'obj'.")]
+#endif
+		int InsertOrReplace (object obj);
         int InsertOrReplace (
 			object obj,
 #if NET8_0_OR_GREATER
@@ -397,14 +419,20 @@ namespace SQLite
 			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
 #endif
 			T> () where T : new();
-        int Update (object obj);
+#if NET8_0_OR_GREATER
+		[RequiresUnreferencedCode ("This method requires ''DynamicallyAccessedMemberTypes.All' on the runtime type of 'obj'.")]
+#endif
+		int Update (object obj);
         int Update (
 			object obj,
 #if NET8_0_OR_GREATER
 			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
 #endif
 			Type objType);
-        int UpdateAll (IEnumerable objects, bool runInTransaction = true);
+#if NET8_0_OR_GREATER
+		[RequiresUnreferencedCode ("This method requires ''DynamicallyAccessedMemberTypes.All' on the runtime type of all objects in 'objects'.")]
+#endif
+		int UpdateAll (IEnumerable objects, bool runInTransaction = true);
     }
 
     /// <summary>
@@ -1913,18 +1941,21 @@ namespace SQLite
             }
         }
 
-        /// <summary>
-        /// Inserts all specified objects.
-        /// </summary>
-        /// <param name="objects">
-        /// An <see cref="IEnumerable"/> of the objects to insert.
-        /// <param name="runInTransaction"/>
-        /// A boolean indicating if the inserts should be wrapped in a transaction.
-        /// </param>
-        /// <returns>
-        /// The number of rows added to the table.
-        /// </returns>
-        public int InsertAll (System.Collections.IEnumerable objects, bool runInTransaction = true)
+		/// <summary>
+		/// Inserts all specified objects.
+		/// </summary>
+		/// <param name="objects">
+		/// An <see cref="IEnumerable"/> of the objects to insert.
+		/// <param name="runInTransaction"/>
+		/// A boolean indicating if the inserts should be wrapped in a transaction.
+		/// </param>
+		/// <returns>
+		/// The number of rows added to the table.
+		/// </returns>
+#if NET8_0_OR_GREATER
+		[RequiresUnreferencedCode ("This method requires ''DynamicallyAccessedMemberTypes.All' on the runtime type of all objects in 'objects'.")]
+#endif
+		public int InsertAll (System.Collections.IEnumerable objects, bool runInTransaction = true)
         {
             var c = 0;
             if (runInTransaction) {
@@ -1942,22 +1973,25 @@ namespace SQLite
             return c;
         }
 
-        /// <summary>
-        /// Inserts all specified objects.
-        /// </summary>
-        /// <param name="objects">
-        /// An <see cref="IEnumerable"/> of the objects to insert.
-        /// </param>
-        /// <param name="extra">
-        /// Literal SQL code that gets placed into the command. INSERT {extra} INTO ...
-        /// </param>
-        /// <param name="runInTransaction">
-        /// A boolean indicating if the inserts should be wrapped in a transaction.
-        /// </param>
-        /// <returns>
-        /// The number of rows added to the table.
-        /// </returns>
-        public int InsertAll (System.Collections.IEnumerable objects, string extra, bool runInTransaction = true)
+		/// <summary>
+		/// Inserts all specified objects.
+		/// </summary>
+		/// <param name="objects">
+		/// An <see cref="IEnumerable"/> of the objects to insert.
+		/// </param>
+		/// <param name="extra">
+		/// Literal SQL code that gets placed into the command. INSERT {extra} INTO ...
+		/// </param>
+		/// <param name="runInTransaction">
+		/// A boolean indicating if the inserts should be wrapped in a transaction.
+		/// </param>
+		/// <returns>
+		/// The number of rows added to the table.
+		/// </returns>
+#if NET8_0_OR_GREATER
+		[RequiresUnreferencedCode ("This method requires ''DynamicallyAccessedMemberTypes.All' on the runtime type of all objects in 'objects'.")]
+#endif
+		public int InsertAll (System.Collections.IEnumerable objects, string extra, bool runInTransaction = true)
         {
             var c = 0;
             if (runInTransaction) {
@@ -2014,18 +2048,21 @@ namespace SQLite
             return c;
         }
 
-        /// <summary>
-        /// Inserts the given object (and updates its
-        /// auto incremented primary key if it has one).
-        /// The return value is the number of rows added to the table.
-        /// </summary>
-        /// <param name="obj">
-        /// The object to insert.
-        /// </param>
-        /// <returns>
-        /// The number of rows added to the table.
-        /// </returns>
-        public int Insert (object obj)
+		/// <summary>
+		/// Inserts the given object (and updates its
+		/// auto incremented primary key if it has one).
+		/// The return value is the number of rows added to the table.
+		/// </summary>
+		/// <param name="obj">
+		/// The object to insert.
+		/// </param>
+		/// <returns>
+		/// The number of rows added to the table.
+		/// </returns>
+#if NET8_0_OR_GREATER
+		[RequiresUnreferencedCode("This method requires ''DynamicallyAccessedMemberTypes.All' on the runtime type of 'obj'.")]
+#endif
+		public int Insert (object obj)
         {
             if (obj == null) {
                 return 0;
@@ -2033,21 +2070,24 @@ namespace SQLite
             return Insert (obj, "", Orm.GetType (obj));
         }
 
-        /// <summary>
-        /// Inserts the given object (and updates its
-        /// auto incremented primary key if it has one).
-        /// The return value is the number of rows added to the table.
-        /// If a UNIQUE constraint violation occurs with
-        /// some pre-existing object, this function deletes
-        /// the old object.
-        /// </summary>
-        /// <param name="obj">
-        /// The object to insert.
-        /// </param>
-        /// <returns>
-        /// The number of rows modified.
-        /// </returns>
-        public int InsertOrReplace (object obj)
+		/// <summary>
+		/// Inserts the given object (and updates its
+		/// auto incremented primary key if it has one).
+		/// The return value is the number of rows added to the table.
+		/// If a UNIQUE constraint violation occurs with
+		/// some pre-existing object, this function deletes
+		/// the old object.
+		/// </summary>
+		/// <param name="obj">
+		/// The object to insert.
+		/// </param>
+		/// <returns>
+		/// The number of rows modified.
+		/// </returns>
+#if NET8_0_OR_GREATER
+		[RequiresUnreferencedCode ("This method requires ''DynamicallyAccessedMemberTypes.All' on the runtime type of 'obj'.")]
+#endif
+		public int InsertOrReplace (object obj)
         {
             if (obj == null) {
                 return 0;
@@ -2106,21 +2146,24 @@ namespace SQLite
             return Insert (obj, "OR REPLACE", objType);
         }
 
-        /// <summary>
-        /// Inserts the given object (and updates its
-        /// auto incremented primary key if it has one).
-        /// The return value is the number of rows added to the table.
-        /// </summary>
-        /// <param name="obj">
-        /// The object to insert.
-        /// </param>
-        /// <param name="extra">
-        /// Literal SQL code that gets placed into the command. INSERT {extra} INTO ...
-        /// </param>
-        /// <returns>
-        /// The number of rows added to the table.
-        /// </returns>
-        public int Insert (object obj, string extra)
+		/// <summary>
+		/// Inserts the given object (and updates its
+		/// auto incremented primary key if it has one).
+		/// The return value is the number of rows added to the table.
+		/// </summary>
+		/// <param name="obj">
+		/// The object to insert.
+		/// </param>
+		/// <param name="extra">
+		/// Literal SQL code that gets placed into the command. INSERT {extra} INTO ...
+		/// </param>
+		/// <returns>
+		/// The number of rows added to the table.
+		/// </returns>
+#if NET8_0_OR_GREATER
+		[RequiresUnreferencedCode ("This method requires ''DynamicallyAccessedMemberTypes.All' on the runtime type of 'obj'.")]
+#endif
+		public int Insert (object obj, string extra)
         {
             if (obj == null) {
                 return 0;
@@ -2254,18 +2297,21 @@ namespace SQLite
             return insertCommand;
         }
 
-        /// <summary>
-        /// Updates all of the columns of a table using the specified object
-        /// except for its primary key.
-        /// The object is required to have a primary key.
-        /// </summary>
-        /// <param name="obj">
-        /// The object to update. It must have a primary key designated using the PrimaryKeyAttribute.
-        /// </param>
-        /// <returns>
-        /// The number of rows updated.
-        /// </returns>
-        public int Update (object obj)
+		/// <summary>
+		/// Updates all of the columns of a table using the specified object
+		/// except for its primary key.
+		/// The object is required to have a primary key.
+		/// </summary>
+		/// <param name="obj">
+		/// The object to update. It must have a primary key designated using the PrimaryKeyAttribute.
+		/// </param>
+		/// <returns>
+		/// The number of rows updated.
+		/// </returns>
+#if NET8_0_OR_GREATER
+		[RequiresUnreferencedCode ("This method requires ''DynamicallyAccessedMemberTypes.All' on the runtime type of 'obj'.")]
+#endif
+		public int Update (object obj)
         {
             if (obj == null) {
                 return 0;
@@ -2343,19 +2389,22 @@ namespace SQLite
             return rowsAffected;
         }
 
-        /// <summary>
-        /// Updates all specified objects.
-        /// </summary>
-        /// <param name="objects">
-        /// An <see cref="IEnumerable"/> of the objects to insert.
-        /// </param>
-        /// <param name="runInTransaction">
-        /// A boolean indicating if the inserts should be wrapped in a transaction
-        /// </param>
-        /// <returns>
-        /// The number of rows modified.
-        /// </returns>
-        public int UpdateAll (System.Collections.IEnumerable objects, bool runInTransaction = true)
+		/// <summary>
+		/// Updates all specified objects.
+		/// </summary>
+		/// <param name="objects">
+		/// An <see cref="IEnumerable"/> of the objects to insert.
+		/// </param>
+		/// <param name="runInTransaction">
+		/// A boolean indicating if the inserts should be wrapped in a transaction
+		/// </param>
+		/// <returns>
+		/// The number of rows modified.
+		/// </returns>
+#if NET8_0_OR_GREATER
+		[RequiresUnreferencedCode ("This method requires ''DynamicallyAccessedMemberTypes.All' on the runtime type of all objects in 'objects'.")]
+#endif
+		public int UpdateAll (System.Collections.IEnumerable objects, bool runInTransaction = true)
         {
             var c = 0;
             if (runInTransaction) {
@@ -2373,16 +2422,19 @@ namespace SQLite
             return c;
         }
 
-        /// <summary>
-        /// Deletes the given object from the database using its primary key.
-        /// </summary>
-        /// <param name="objectToDelete">
-        /// The object to delete. It must have a primary key designated using the PrimaryKeyAttribute.
-        /// </param>
-        /// <returns>
-        /// The number of rows deleted.
-        /// </returns>
-        public int Delete (object objectToDelete)
+		/// <summary>
+		/// Deletes the given object from the database using its primary key.
+		/// </summary>
+		/// <param name="objectToDelete">
+		/// The object to delete. It must have a primary key designated using the PrimaryKeyAttribute.
+		/// </param>
+		/// <returns>
+		/// The number of rows deleted.
+		/// </returns>
+#if NET8_0_OR_GREATER
+		[RequiresUnreferencedCode ("This method requires ''DynamicallyAccessedMemberTypes.All' on the runtime type of 'objectToDelete'.")]
+#endif
+		public int Delete (object objectToDelete)
         {
             var map = GetMapping (Orm.GetType (objectToDelete));
             var pk = map.PK;
@@ -2453,7 +2505,11 @@ namespace SQLite
         /// <typeparam name='T'>
         /// The type of objects to delete.
         /// </typeparam>
-        public int DeleteAll<T> ()
+        public int DeleteAll<
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+#endif
+			T> ()
         {
             var map = GetMapping (typeof (T));
             return DeleteAll (map);

--- a/src/SQLite.cs
+++ b/src/SQLite.cs
@@ -59,2253 +59,2253 @@ using Sqlite3Statement = System.IntPtr;
 
 namespace SQLite
 {
-	public class SQLiteException : Exception
-	{
-		public SQLite3.Result Result { get; private set; }
+    public class SQLiteException : Exception
+    {
+        public SQLite3.Result Result { get; private set; }
 
-		protected SQLiteException (SQLite3.Result r, string message) : base (message)
-		{
-			Result = r;
-		}
+        protected SQLiteException (SQLite3.Result r, string message) : base (message)
+        {
+            Result = r;
+        }
 
-		public static SQLiteException New (SQLite3.Result r, string message)
-		{
-			return new SQLiteException (r, message);
-		}
-	}
+        public static SQLiteException New (SQLite3.Result r, string message)
+        {
+            return new SQLiteException (r, message);
+        }
+    }
 
-	public class NotNullConstraintViolationException : SQLiteException
-	{
-		public IEnumerable<TableMapping.Column> Columns { get; protected set; }
+    public class NotNullConstraintViolationException : SQLiteException
+    {
+        public IEnumerable<TableMapping.Column> Columns { get; protected set; }
 
-		protected NotNullConstraintViolationException (SQLite3.Result r, string message)
-			: this (r, message, null, null)
-		{
+        protected NotNullConstraintViolationException (SQLite3.Result r, string message)
+            : this (r, message, null, null)
+        {
 
-		}
+        }
 
-		protected NotNullConstraintViolationException (SQLite3.Result r, string message, TableMapping mapping, object obj)
-			: base (r, message)
-		{
-			if (mapping != null && obj != null) {
-				this.Columns = from c in mapping.Columns
-							   where c.IsNullable == false && c.GetValue (obj) == null
-							   select c;
-			}
-		}
+        protected NotNullConstraintViolationException (SQLite3.Result r, string message, TableMapping mapping, object obj)
+            : base (r, message)
+        {
+            if (mapping != null && obj != null) {
+                this.Columns = from c in mapping.Columns
+                               where c.IsNullable == false && c.GetValue (obj) == null
+                               select c;
+            }
+        }
 
-		public static new NotNullConstraintViolationException New (SQLite3.Result r, string message)
-		{
-			return new NotNullConstraintViolationException (r, message);
-		}
+        public static new NotNullConstraintViolationException New (SQLite3.Result r, string message)
+        {
+            return new NotNullConstraintViolationException (r, message);
+        }
 
-		public static NotNullConstraintViolationException New (SQLite3.Result r, string message, TableMapping mapping, object obj)
-		{
-			return new NotNullConstraintViolationException (r, message, mapping, obj);
-		}
+        public static NotNullConstraintViolationException New (SQLite3.Result r, string message, TableMapping mapping, object obj)
+        {
+            return new NotNullConstraintViolationException (r, message, mapping, obj);
+        }
 
-		public static NotNullConstraintViolationException New (SQLiteException exception, TableMapping mapping, object obj)
-		{
-			return new NotNullConstraintViolationException (exception.Result, exception.Message, mapping, obj);
-		}
-	}
+        public static NotNullConstraintViolationException New (SQLiteException exception, TableMapping mapping, object obj)
+        {
+            return new NotNullConstraintViolationException (exception.Result, exception.Message, mapping, obj);
+        }
+    }
 
-	[Flags]
-	public enum SQLiteOpenFlags
-	{
-		ReadOnly = 1, ReadWrite = 2, Create = 4,
-		Uri = 0x40, Memory = 0x80,
-		NoMutex = 0x8000, FullMutex = 0x10000,
-		SharedCache = 0x20000, PrivateCache = 0x40000,
-		ProtectionComplete = 0x00100000,
-		ProtectionCompleteUnlessOpen = 0x00200000,
-		ProtectionCompleteUntilFirstUserAuthentication = 0x00300000,
-		ProtectionNone = 0x00400000
-	}
+    [Flags]
+    public enum SQLiteOpenFlags
+    {
+        ReadOnly = 1, ReadWrite = 2, Create = 4,
+        Uri = 0x40, Memory = 0x80,
+        NoMutex = 0x8000, FullMutex = 0x10000,
+        SharedCache = 0x20000, PrivateCache = 0x40000,
+        ProtectionComplete = 0x00100000,
+        ProtectionCompleteUnlessOpen = 0x00200000,
+        ProtectionCompleteUntilFirstUserAuthentication = 0x00300000,
+        ProtectionNone = 0x00400000
+    }
 
-	[Flags]
-	public enum CreateFlags
-	{
-		/// <summary>
-		/// Use the default creation options
-		/// </summary>
-		None = 0x000,
-		/// <summary>
-		/// Create a primary key index for a property called 'Id' (case-insensitive).
-		/// This avoids the need for the [PrimaryKey] attribute.
-		/// </summary>
-		ImplicitPK = 0x001,
-		/// <summary>
-		/// Create indices for properties ending in 'Id' (case-insensitive).
-		/// </summary>
-		ImplicitIndex = 0x002,
-		/// <summary>
-		/// Create a primary key for a property called 'Id' and
-		/// create an indices for properties ending in 'Id' (case-insensitive).
-		/// </summary>
-		AllImplicit = 0x003,
-		/// <summary>
-		/// Force the primary key property to be auto incrementing.
-		/// This avoids the need for the [AutoIncrement] attribute.
-		/// The primary key property on the class should have type int or long.
-		/// </summary>
-		AutoIncPK = 0x004,
-		/// <summary>
-		/// Create virtual table using FTS3
-		/// </summary>
-		FullTextSearch3 = 0x100,
-		/// <summary>
-		/// Create virtual table using FTS4
-		/// </summary>
-		FullTextSearch4 = 0x200
-	}
+    [Flags]
+    public enum CreateFlags
+    {
+        /// <summary>
+        /// Use the default creation options
+        /// </summary>
+        None = 0x000,
+        /// <summary>
+        /// Create a primary key index for a property called 'Id' (case-insensitive).
+        /// This avoids the need for the [PrimaryKey] attribute.
+        /// </summary>
+        ImplicitPK = 0x001,
+        /// <summary>
+        /// Create indices for properties ending in 'Id' (case-insensitive).
+        /// </summary>
+        ImplicitIndex = 0x002,
+        /// <summary>
+        /// Create a primary key for a property called 'Id' and
+        /// create an indices for properties ending in 'Id' (case-insensitive).
+        /// </summary>
+        AllImplicit = 0x003,
+        /// <summary>
+        /// Force the primary key property to be auto incrementing.
+        /// This avoids the need for the [AutoIncrement] attribute.
+        /// The primary key property on the class should have type int or long.
+        /// </summary>
+        AutoIncPK = 0x004,
+        /// <summary>
+        /// Create virtual table using FTS3
+        /// </summary>
+        FullTextSearch3 = 0x100,
+        /// <summary>
+        /// Create virtual table using FTS4
+        /// </summary>
+        FullTextSearch4 = 0x200
+    }
 
-	public interface ISQLiteConnection : IDisposable
-	{
-		Sqlite3DatabaseHandle Handle { get; }
-		string DatabasePath { get; }
-		int LibVersionNumber { get; }
-		bool TimeExecution { get; set; }
-		bool Trace { get; set; }
-		Action<string> Tracer { get; set; }
-		bool StoreDateTimeAsTicks { get; }
-		bool StoreTimeSpanAsTicks { get; }
-		string DateTimeStringFormat { get; }
-		TimeSpan BusyTimeout { get; set; }
-		IEnumerable<TableMapping> TableMappings { get; }
-		bool IsInTransaction { get; }
+    public interface ISQLiteConnection : IDisposable
+    {
+        Sqlite3DatabaseHandle Handle { get; }
+        string DatabasePath { get; }
+        int LibVersionNumber { get; }
+        bool TimeExecution { get; set; }
+        bool Trace { get; set; }
+        Action<string> Tracer { get; set; }
+        bool StoreDateTimeAsTicks { get; }
+        bool StoreTimeSpanAsTicks { get; }
+        string DateTimeStringFormat { get; }
+        TimeSpan BusyTimeout { get; set; }
+        IEnumerable<TableMapping> TableMappings { get; }
+        bool IsInTransaction { get; }
 
-		event EventHandler<NotifyTableChangedEventArgs> TableChanged;
+        event EventHandler<NotifyTableChangedEventArgs> TableChanged;
 
-		void Backup (string destinationDatabasePath, string databaseName = "main");
-		void BeginTransaction ();
-		void Close ();
-		void Commit ();
-		SQLiteCommand CreateCommand (string cmdText, params object[] ps);
-		SQLiteCommand CreateCommand (string cmdText, Dictionary<string, object> args);
-		int CreateIndex (string indexName, string tableName, string[] columnNames, bool unique = false);
-		int CreateIndex (string indexName, string tableName, string columnName, bool unique = false);
-		int CreateIndex (string tableName, string columnName, bool unique = false);
-		int CreateIndex (string tableName, string[] columnNames, bool unique = false);
-		int CreateIndex<T> (Expression<Func<T, object>> property, bool unique = false);
-		CreateTableResult CreateTable<T> (CreateFlags createFlags = CreateFlags.None);
-		CreateTableResult CreateTable (Type ty, CreateFlags createFlags = CreateFlags.None);
-		CreateTablesResult CreateTables<T, T2> (CreateFlags createFlags = CreateFlags.None)
-			where T : new()
-			where T2 : new();
-		CreateTablesResult CreateTables<T, T2, T3> (CreateFlags createFlags = CreateFlags.None)
-			where T : new()
-			where T2 : new()
-			where T3 : new();
-		CreateTablesResult CreateTables<T, T2, T3, T4> (CreateFlags createFlags = CreateFlags.None)
-			where T : new()
-			where T2 : new()
-			where T3 : new()
-			where T4 : new();
-		CreateTablesResult CreateTables<T, T2, T3, T4, T5> (CreateFlags createFlags = CreateFlags.None)
-			where T : new()
-			where T2 : new()
-			where T3 : new()
-			where T4 : new()
-			where T5 : new();
-		CreateTablesResult CreateTables (CreateFlags createFlags = CreateFlags.None, params Type[] types);
-		IEnumerable<T> DeferredQuery<T> (string query, params object[] args) where T : new();
-		IEnumerable<object> DeferredQuery (TableMapping map, string query, params object[] args);
-		int Delete (object objectToDelete);
-		int Delete<T> (object primaryKey);
-		int Delete (object primaryKey, TableMapping map);
-		int DeleteAll<T> ();
-		int DeleteAll (TableMapping map);
-		int DropTable<T> ();
-		int DropTable (TableMapping map);
-		void EnableLoadExtension (bool enabled);
-		void EnableWriteAheadLogging ();
-		int Execute (string query, params object[] args);
-		T ExecuteScalar<T> (string query, params object[] args);
-		T Find<T> (object pk) where T : new();
-		object Find (object pk, TableMapping map);
-		T Find<T> (Expression<Func<T, bool>> predicate) where T : new();
-		T FindWithQuery<T> (string query, params object[] args) where T : new();
-		object FindWithQuery (TableMapping map, string query, params object[] args);
-		T Get<T> (object pk) where T : new();
-		object Get (object pk, TableMapping map);
-		T Get<T> (Expression<Func<T, bool>> predicate) where T : new();
-		TableMapping GetMapping (Type type, CreateFlags createFlags = CreateFlags.None);
-		TableMapping GetMapping<T> (CreateFlags createFlags = CreateFlags.None);
-		List<SQLiteConnection.ColumnInfo> GetTableInfo (string tableName);
-		int Insert (object obj);
-		int Insert (object obj, Type objType);
-		int Insert (object obj, string extra);
-		int Insert (object obj, string extra, Type objType);
-		int InsertAll (IEnumerable objects, bool runInTransaction = true);
-		int InsertAll (IEnumerable objects, string extra, bool runInTransaction = true);
-		int InsertAll (IEnumerable objects, Type objType, bool runInTransaction = true);
-		int InsertOrReplace (object obj);
-		int InsertOrReplace (object obj, Type objType);
-		List<T> Query<T> (string query, params object[] args) where T : new();
-		List<object> Query (TableMapping map, string query, params object[] args);
-		List<T> QueryScalars<T> (string query, params object[] args);
-		void ReKey (string key);
-		void ReKey (byte[] key);
-		void Release (string savepoint);
-		void Rollback ();
-		void RollbackTo (string savepoint);
-		void RunInTransaction (Action action);
-		string SaveTransactionPoint ();
-		TableQuery<T> Table<T> () where T : new();
-		int Update (object obj);
-		int Update (object obj, Type objType);
-		int UpdateAll (IEnumerable objects, bool runInTransaction = true);
-	}
+        void Backup (string destinationDatabasePath, string databaseName = "main");
+        void BeginTransaction ();
+        void Close ();
+        void Commit ();
+        SQLiteCommand CreateCommand (string cmdText, params object[] ps);
+        SQLiteCommand CreateCommand (string cmdText, Dictionary<string, object> args);
+        int CreateIndex (string indexName, string tableName, string[] columnNames, bool unique = false);
+        int CreateIndex (string indexName, string tableName, string columnName, bool unique = false);
+        int CreateIndex (string tableName, string columnName, bool unique = false);
+        int CreateIndex (string tableName, string[] columnNames, bool unique = false);
+        int CreateIndex<T> (Expression<Func<T, object>> property, bool unique = false);
+        CreateTableResult CreateTable<T> (CreateFlags createFlags = CreateFlags.None);
+        CreateTableResult CreateTable (Type ty, CreateFlags createFlags = CreateFlags.None);
+        CreateTablesResult CreateTables<T, T2> (CreateFlags createFlags = CreateFlags.None)
+            where T : new()
+            where T2 : new();
+        CreateTablesResult CreateTables<T, T2, T3> (CreateFlags createFlags = CreateFlags.None)
+            where T : new()
+            where T2 : new()
+            where T3 : new();
+        CreateTablesResult CreateTables<T, T2, T3, T4> (CreateFlags createFlags = CreateFlags.None)
+            where T : new()
+            where T2 : new()
+            where T3 : new()
+            where T4 : new();
+        CreateTablesResult CreateTables<T, T2, T3, T4, T5> (CreateFlags createFlags = CreateFlags.None)
+            where T : new()
+            where T2 : new()
+            where T3 : new()
+            where T4 : new()
+            where T5 : new();
+        CreateTablesResult CreateTables (CreateFlags createFlags = CreateFlags.None, params Type[] types);
+        IEnumerable<T> DeferredQuery<T> (string query, params object[] args) where T : new();
+        IEnumerable<object> DeferredQuery (TableMapping map, string query, params object[] args);
+        int Delete (object objectToDelete);
+        int Delete<T> (object primaryKey);
+        int Delete (object primaryKey, TableMapping map);
+        int DeleteAll<T> ();
+        int DeleteAll (TableMapping map);
+        int DropTable<T> ();
+        int DropTable (TableMapping map);
+        void EnableLoadExtension (bool enabled);
+        void EnableWriteAheadLogging ();
+        int Execute (string query, params object[] args);
+        T ExecuteScalar<T> (string query, params object[] args);
+        T Find<T> (object pk) where T : new();
+        object Find (object pk, TableMapping map);
+        T Find<T> (Expression<Func<T, bool>> predicate) where T : new();
+        T FindWithQuery<T> (string query, params object[] args) where T : new();
+        object FindWithQuery (TableMapping map, string query, params object[] args);
+        T Get<T> (object pk) where T : new();
+        object Get (object pk, TableMapping map);
+        T Get<T> (Expression<Func<T, bool>> predicate) where T : new();
+        TableMapping GetMapping (Type type, CreateFlags createFlags = CreateFlags.None);
+        TableMapping GetMapping<T> (CreateFlags createFlags = CreateFlags.None);
+        List<SQLiteConnection.ColumnInfo> GetTableInfo (string tableName);
+        int Insert (object obj);
+        int Insert (object obj, Type objType);
+        int Insert (object obj, string extra);
+        int Insert (object obj, string extra, Type objType);
+        int InsertAll (IEnumerable objects, bool runInTransaction = true);
+        int InsertAll (IEnumerable objects, string extra, bool runInTransaction = true);
+        int InsertAll (IEnumerable objects, Type objType, bool runInTransaction = true);
+        int InsertOrReplace (object obj);
+        int InsertOrReplace (object obj, Type objType);
+        List<T> Query<T> (string query, params object[] args) where T : new();
+        List<object> Query (TableMapping map, string query, params object[] args);
+        List<T> QueryScalars<T> (string query, params object[] args);
+        void ReKey (string key);
+        void ReKey (byte[] key);
+        void Release (string savepoint);
+        void Rollback ();
+        void RollbackTo (string savepoint);
+        void RunInTransaction (Action action);
+        string SaveTransactionPoint ();
+        TableQuery<T> Table<T> () where T : new();
+        int Update (object obj);
+        int Update (object obj, Type objType);
+        int UpdateAll (IEnumerable objects, bool runInTransaction = true);
+    }
 
-	/// <summary>
-	/// An open connection to a SQLite database.
-	/// </summary>
-	[Preserve (AllMembers = true)]
-	public partial class SQLiteConnection : ISQLiteConnection
-	{
-		private bool _open;
-		private TimeSpan _busyTimeout;
-		readonly static Dictionary<string, TableMapping> _mappings = new Dictionary<string, TableMapping> ();
-		private System.Diagnostics.Stopwatch _sw;
-		private long _elapsedMilliseconds = 0;
+    /// <summary>
+    /// An open connection to a SQLite database.
+    /// </summary>
+    [Preserve (AllMembers = true)]
+    public partial class SQLiteConnection : ISQLiteConnection
+    {
+        private bool _open;
+        private TimeSpan _busyTimeout;
+        readonly static Dictionary<string, TableMapping> _mappings = new Dictionary<string, TableMapping> ();
+        private System.Diagnostics.Stopwatch _sw;
+        private long _elapsedMilliseconds = 0;
 
-		private int _transactionDepth = 0;
-		private Random _rand = new Random ();
+        private int _transactionDepth = 0;
+        private Random _rand = new Random ();
 
-		public Sqlite3DatabaseHandle Handle { get; private set; }
-		static readonly Sqlite3DatabaseHandle NullHandle = default (Sqlite3DatabaseHandle);
-		static readonly Sqlite3BackupHandle NullBackupHandle = default (Sqlite3BackupHandle);
+        public Sqlite3DatabaseHandle Handle { get; private set; }
+        static readonly Sqlite3DatabaseHandle NullHandle = default (Sqlite3DatabaseHandle);
+        static readonly Sqlite3BackupHandle NullBackupHandle = default (Sqlite3BackupHandle);
 
-		/// <summary>
-		/// Gets the database path used by this connection.
-		/// </summary>
-		public string DatabasePath { get; private set; }
+        /// <summary>
+        /// Gets the database path used by this connection.
+        /// </summary>
+        public string DatabasePath { get; private set; }
 
-		/// <summary>
-		/// Gets the SQLite library version number. 3007014 would be v3.7.14
-		/// </summary>
-		public int LibVersionNumber { get; private set; }
+        /// <summary>
+        /// Gets the SQLite library version number. 3007014 would be v3.7.14
+        /// </summary>
+        public int LibVersionNumber { get; private set; }
 
-		/// <summary>
-		/// Whether Trace lines should be written that show the execution time of queries.
-		/// </summary>
-		public bool TimeExecution { get; set; }
+        /// <summary>
+        /// Whether Trace lines should be written that show the execution time of queries.
+        /// </summary>
+        public bool TimeExecution { get; set; }
 
-		/// <summary>
-		/// Whether to write queries to <see cref="Tracer"/> during execution.
-		/// </summary>
-		public bool Trace { get; set; }
+        /// <summary>
+        /// Whether to write queries to <see cref="Tracer"/> during execution.
+        /// </summary>
+        public bool Trace { get; set; }
 
-		/// <summary>
-		/// The delegate responsible for writing trace lines.
-		/// </summary>
-		/// <value>The tracer.</value>
-		public Action<string> Tracer { get; set; }
+        /// <summary>
+        /// The delegate responsible for writing trace lines.
+        /// </summary>
+        /// <value>The tracer.</value>
+        public Action<string> Tracer { get; set; }
 
-		/// <summary>
-		/// Whether to store DateTime properties as ticks (true) or strings (false).
-		/// </summary>
-		public bool StoreDateTimeAsTicks { get; private set; }
+        /// <summary>
+        /// Whether to store DateTime properties as ticks (true) or strings (false).
+        /// </summary>
+        public bool StoreDateTimeAsTicks { get; private set; }
 
-		/// <summary>
-		/// Whether to store TimeSpan properties as ticks (true) or strings (false).
-		/// </summary>
-		public bool StoreTimeSpanAsTicks { get; private set; }
+        /// <summary>
+        /// Whether to store TimeSpan properties as ticks (true) or strings (false).
+        /// </summary>
+        public bool StoreTimeSpanAsTicks { get; private set; }
 
-		/// <summary>
-		/// The format to use when storing DateTime properties as strings. Ignored if StoreDateTimeAsTicks is true.
-		/// </summary>
-		/// <value>The date time string format.</value>
-		public string DateTimeStringFormat { get; private set; }
+        /// <summary>
+        /// The format to use when storing DateTime properties as strings. Ignored if StoreDateTimeAsTicks is true.
+        /// </summary>
+        /// <value>The date time string format.</value>
+        public string DateTimeStringFormat { get; private set; }
 
-		/// <summary>
-		/// The DateTimeStyles value to use when parsing a DateTime property string.
-		/// </summary>
-		/// <value>The date time style.</value>
-		internal System.Globalization.DateTimeStyles DateTimeStyle { get; private set; }
+        /// <summary>
+        /// The DateTimeStyles value to use when parsing a DateTime property string.
+        /// </summary>
+        /// <value>The date time style.</value>
+        internal System.Globalization.DateTimeStyles DateTimeStyle { get; private set; }
 
 #if USE_SQLITEPCL_RAW && !NO_SQLITEPCL_RAW_BATTERIES
-		static SQLiteConnection ()
-		{
-			SQLitePCL.Batteries_V2.Init ();
-		}
+        static SQLiteConnection ()
+        {
+            SQLitePCL.Batteries_V2.Init ();
+        }
 #endif
 
-		/// <summary>
-		/// Constructs a new SQLiteConnection and opens a SQLite database specified by databasePath.
-		/// </summary>
-		/// <param name="databasePath">
-		/// Specifies the path to the database file.
-		/// </param>
-		/// <param name="storeDateTimeAsTicks">
-		/// Specifies whether to store DateTime properties as ticks (true) or strings (false). You
-		/// absolutely do want to store them as Ticks in all new projects. The value of false is
-		/// only here for backwards compatibility. There is a *significant* speed advantage, with no
-		/// down sides, when setting storeDateTimeAsTicks = true.
-		/// If you use DateTimeOffset properties, it will be always stored as ticks regardingless
-		/// the storeDateTimeAsTicks parameter.
-		/// </param>
-		public SQLiteConnection (string databasePath, bool storeDateTimeAsTicks = true)
-			: this (new SQLiteConnectionString (databasePath, SQLiteOpenFlags.ReadWrite | SQLiteOpenFlags.Create, storeDateTimeAsTicks))
-		{
-		}
+        /// <summary>
+        /// Constructs a new SQLiteConnection and opens a SQLite database specified by databasePath.
+        /// </summary>
+        /// <param name="databasePath">
+        /// Specifies the path to the database file.
+        /// </param>
+        /// <param name="storeDateTimeAsTicks">
+        /// Specifies whether to store DateTime properties as ticks (true) or strings (false). You
+        /// absolutely do want to store them as Ticks in all new projects. The value of false is
+        /// only here for backwards compatibility. There is a *significant* speed advantage, with no
+        /// down sides, when setting storeDateTimeAsTicks = true.
+        /// If you use DateTimeOffset properties, it will be always stored as ticks regardingless
+        /// the storeDateTimeAsTicks parameter.
+        /// </param>
+        public SQLiteConnection (string databasePath, bool storeDateTimeAsTicks = true)
+            : this (new SQLiteConnectionString (databasePath, SQLiteOpenFlags.ReadWrite | SQLiteOpenFlags.Create, storeDateTimeAsTicks))
+        {
+        }
 
-		/// <summary>
-		/// Constructs a new SQLiteConnection and opens a SQLite database specified by databasePath.
-		/// </summary>
-		/// <param name="databasePath">
-		/// Specifies the path to the database file.
-		/// </param>
-		/// <param name="openFlags">
-		/// Flags controlling how the connection should be opened.
-		/// </param>
-		/// <param name="storeDateTimeAsTicks">
-		/// Specifies whether to store DateTime properties as ticks (true) or strings (false). You
-		/// absolutely do want to store them as Ticks in all new projects. The value of false is
-		/// only here for backwards compatibility. There is a *significant* speed advantage, with no
-		/// down sides, when setting storeDateTimeAsTicks = true.
-		/// If you use DateTimeOffset properties, it will be always stored as ticks regardingless
-		/// the storeDateTimeAsTicks parameter.
-		/// </param>
-		public SQLiteConnection (string databasePath, SQLiteOpenFlags openFlags, bool storeDateTimeAsTicks = true)
-			: this (new SQLiteConnectionString (databasePath, openFlags, storeDateTimeAsTicks))
-		{
-		}
+        /// <summary>
+        /// Constructs a new SQLiteConnection and opens a SQLite database specified by databasePath.
+        /// </summary>
+        /// <param name="databasePath">
+        /// Specifies the path to the database file.
+        /// </param>
+        /// <param name="openFlags">
+        /// Flags controlling how the connection should be opened.
+        /// </param>
+        /// <param name="storeDateTimeAsTicks">
+        /// Specifies whether to store DateTime properties as ticks (true) or strings (false). You
+        /// absolutely do want to store them as Ticks in all new projects. The value of false is
+        /// only here for backwards compatibility. There is a *significant* speed advantage, with no
+        /// down sides, when setting storeDateTimeAsTicks = true.
+        /// If you use DateTimeOffset properties, it will be always stored as ticks regardingless
+        /// the storeDateTimeAsTicks parameter.
+        /// </param>
+        public SQLiteConnection (string databasePath, SQLiteOpenFlags openFlags, bool storeDateTimeAsTicks = true)
+            : this (new SQLiteConnectionString (databasePath, openFlags, storeDateTimeAsTicks))
+        {
+        }
 
-		/// <summary>
-		/// Constructs a new SQLiteConnection and opens a SQLite database specified by databasePath.
-		/// </summary>
-		/// <param name="connectionString">
-		/// Details on how to find and open the database.
-		/// </param>
-		public SQLiteConnection (SQLiteConnectionString connectionString)
-		{
-			if (connectionString == null)
-				throw new ArgumentNullException (nameof (connectionString));
-			if (connectionString.DatabasePath == null)
-				throw new InvalidOperationException ("DatabasePath must be specified");
+        /// <summary>
+        /// Constructs a new SQLiteConnection and opens a SQLite database specified by databasePath.
+        /// </summary>
+        /// <param name="connectionString">
+        /// Details on how to find and open the database.
+        /// </param>
+        public SQLiteConnection (SQLiteConnectionString connectionString)
+        {
+            if (connectionString == null)
+                throw new ArgumentNullException (nameof (connectionString));
+            if (connectionString.DatabasePath == null)
+                throw new InvalidOperationException ("DatabasePath must be specified");
 
-			DatabasePath = connectionString.DatabasePath;
+            DatabasePath = connectionString.DatabasePath;
 
-			LibVersionNumber = SQLite3.LibVersionNumber ();
+            LibVersionNumber = SQLite3.LibVersionNumber ();
 
 #if NETFX_CORE
-			SQLite3.SetDirectory(/*temp directory type*/2, Windows.Storage.ApplicationData.Current.TemporaryFolder.Path);
+            SQLite3.SetDirectory(/*temp directory type*/2, Windows.Storage.ApplicationData.Current.TemporaryFolder.Path);
 #endif
 
-			Sqlite3DatabaseHandle handle;
+            Sqlite3DatabaseHandle handle;
 
 #if SILVERLIGHT || USE_CSHARP_SQLITE || USE_SQLITEPCL_RAW
-			var r = SQLite3.Open (connectionString.DatabasePath, out handle, (int)connectionString.OpenFlags, connectionString.VfsName);
+            var r = SQLite3.Open (connectionString.DatabasePath, out handle, (int)connectionString.OpenFlags, connectionString.VfsName);
 #else
-			// open using the byte[]
-			// in the case where the path may include Unicode
-			// force open to using UTF-8 using sqlite3_open_v2
-			var databasePathAsBytes = GetNullTerminatedUtf8 (connectionString.DatabasePath);
-			var r = SQLite3.Open (databasePathAsBytes, out handle, (int)connectionString.OpenFlags, connectionString.VfsName);
+            // open using the byte[]
+            // in the case where the path may include Unicode
+            // force open to using UTF-8 using sqlite3_open_v2
+            var databasePathAsBytes = GetNullTerminatedUtf8 (connectionString.DatabasePath);
+            var r = SQLite3.Open (databasePathAsBytes, out handle, (int)connectionString.OpenFlags, connectionString.VfsName);
 #endif
 
-			Handle = handle;
-			if (r != SQLite3.Result.OK) {
-				throw SQLiteException.New (r, String.Format ("Could not open database file: {0} ({1})", DatabasePath, r));
-			}
-			_open = true;
+            Handle = handle;
+            if (r != SQLite3.Result.OK) {
+                throw SQLiteException.New (r, String.Format ("Could not open database file: {0} ({1})", DatabasePath, r));
+            }
+            _open = true;
 
-			StoreDateTimeAsTicks = connectionString.StoreDateTimeAsTicks;
-			StoreTimeSpanAsTicks = connectionString.StoreTimeSpanAsTicks;
-			DateTimeStringFormat = connectionString.DateTimeStringFormat;
-			DateTimeStyle = connectionString.DateTimeStyle;
+            StoreDateTimeAsTicks = connectionString.StoreDateTimeAsTicks;
+            StoreTimeSpanAsTicks = connectionString.StoreTimeSpanAsTicks;
+            DateTimeStringFormat = connectionString.DateTimeStringFormat;
+            DateTimeStyle = connectionString.DateTimeStyle;
 
-			BusyTimeout = TimeSpan.FromSeconds (1.0);
-			Tracer = line => Debug.WriteLine (line);
+            BusyTimeout = TimeSpan.FromSeconds (1.0);
+            Tracer = line => Debug.WriteLine (line);
 
-			connectionString.PreKeyAction?.Invoke (this);
-			if (connectionString.Key is string stringKey) {
-				SetKey (stringKey);
-			}
-			else if (connectionString.Key is byte[] bytesKey) {
-				SetKey (bytesKey);
-			}
-			else if (connectionString.Key != null) {
-				throw new InvalidOperationException ("Encryption keys must be strings or byte arrays");
-			}
-			connectionString.PostKeyAction?.Invoke (this);
-		}
+            connectionString.PreKeyAction?.Invoke (this);
+            if (connectionString.Key is string stringKey) {
+                SetKey (stringKey);
+            }
+            else if (connectionString.Key is byte[] bytesKey) {
+                SetKey (bytesKey);
+            }
+            else if (connectionString.Key != null) {
+                throw new InvalidOperationException ("Encryption keys must be strings or byte arrays");
+            }
+            connectionString.PostKeyAction?.Invoke (this);
+        }
 
-		/// <summary>
-		/// Enables the write ahead logging. WAL is significantly faster in most scenarios
-		/// by providing better concurrency and better disk IO performance than the normal
-		/// journal mode. You only need to call this function once in the lifetime of the database.
-		/// </summary>
-		public void EnableWriteAheadLogging ()
-		{
-			ExecuteScalar<string> ("PRAGMA journal_mode=WAL");
-		}
+        /// <summary>
+        /// Enables the write ahead logging. WAL is significantly faster in most scenarios
+        /// by providing better concurrency and better disk IO performance than the normal
+        /// journal mode. You only need to call this function once in the lifetime of the database.
+        /// </summary>
+        public void EnableWriteAheadLogging ()
+        {
+            ExecuteScalar<string> ("PRAGMA journal_mode=WAL");
+        }
 
-		/// <summary>
-		/// Convert an input string to a quoted SQL string that can be safely used in queries.
-		/// </summary>
-		/// <returns>The quoted string.</returns>
-		/// <param name="unsafeString">The unsafe string to quote.</param>
-		static string Quote (string unsafeString)
-		{
-			// TODO: Doesn't call sqlite3_mprintf("%Q", u) because we're waiting on https://github.com/ericsink/SQLitePCL.raw/issues/153
-			if (unsafeString == null)
-				return "NULL";
-			var safe = unsafeString.Replace ("'", "''");
-			return "'" + safe + "'";
-		}
+        /// <summary>
+        /// Convert an input string to a quoted SQL string that can be safely used in queries.
+        /// </summary>
+        /// <returns>The quoted string.</returns>
+        /// <param name="unsafeString">The unsafe string to quote.</param>
+        static string Quote (string unsafeString)
+        {
+            // TODO: Doesn't call sqlite3_mprintf("%Q", u) because we're waiting on https://github.com/ericsink/SQLitePCL.raw/issues/153
+            if (unsafeString == null)
+                return "NULL";
+            var safe = unsafeString.Replace ("'", "''");
+            return "'" + safe + "'";
+        }
 
-		/// <summary>
-		/// Sets the key used to encrypt/decrypt the database with "pragma key = ...".
-		/// This must be the first thing you call before doing anything else with this connection
-		/// if your database is encrypted.
-		/// This only has an effect if you are using the SQLCipher nuget package.
-		/// </summary>
-		/// <param name="key">Encryption key plain text that is converted to the real encryption key using PBKDF2 key derivation</param>
-		void SetKey (string key)
-		{
-			if (key == null)
-				throw new ArgumentNullException (nameof (key));
-			var q = Quote (key);
-			ExecuteScalar<string> ("pragma key = " + q);
-		}
+        /// <summary>
+        /// Sets the key used to encrypt/decrypt the database with "pragma key = ...".
+        /// This must be the first thing you call before doing anything else with this connection
+        /// if your database is encrypted.
+        /// This only has an effect if you are using the SQLCipher nuget package.
+        /// </summary>
+        /// <param name="key">Encryption key plain text that is converted to the real encryption key using PBKDF2 key derivation</param>
+        void SetKey (string key)
+        {
+            if (key == null)
+                throw new ArgumentNullException (nameof (key));
+            var q = Quote (key);
+            ExecuteScalar<string> ("pragma key = " + q);
+        }
 
-		/// <summary>
-		/// Sets the key used to encrypt/decrypt the database.
-		/// This must be the first thing you call before doing anything else with this connection
-		/// if your database is encrypted.
-		/// This only has an effect if you are using the SQLCipher nuget package.
-		/// </summary>
-		/// <param name="key">256-bit (32 byte) encryption key data</param>
-		void SetKey (byte[] key)
-		{
-			if (key == null)
-				throw new ArgumentNullException (nameof (key));
-			if (key.Length != 32 && key.Length != 48)
-				throw new ArgumentException ("Key must be 32 bytes (256-bit) or 48 bytes (384-bit)", nameof (key));
-			var s = String.Join ("", key.Select (x => x.ToString ("X2")));
-			ExecuteScalar<string> ("pragma key = \"x'" + s + "'\"");
-		}
+        /// <summary>
+        /// Sets the key used to encrypt/decrypt the database.
+        /// This must be the first thing you call before doing anything else with this connection
+        /// if your database is encrypted.
+        /// This only has an effect if you are using the SQLCipher nuget package.
+        /// </summary>
+        /// <param name="key">256-bit (32 byte) encryption key data</param>
+        void SetKey (byte[] key)
+        {
+            if (key == null)
+                throw new ArgumentNullException (nameof (key));
+            if (key.Length != 32 && key.Length != 48)
+                throw new ArgumentException ("Key must be 32 bytes (256-bit) or 48 bytes (384-bit)", nameof (key));
+            var s = String.Join ("", key.Select (x => x.ToString ("X2")));
+            ExecuteScalar<string> ("pragma key = \"x'" + s + "'\"");
+        }
 
-		/// <summary>
-		/// Change the encryption key for a SQLCipher database with "pragma rekey = ...".
-		/// </summary>
-		/// <param name="key">Encryption key plain text that is converted to the real encryption key using PBKDF2 key derivation</param>
-		public void ReKey (string key)
-		{
-			if (key == null)
-				throw new ArgumentNullException(nameof(key));
-			var q = Quote(key);
-			ExecuteScalar<string>("pragma rekey = " + q);
-		}
+        /// <summary>
+        /// Change the encryption key for a SQLCipher database with "pragma rekey = ...".
+        /// </summary>
+        /// <param name="key">Encryption key plain text that is converted to the real encryption key using PBKDF2 key derivation</param>
+        public void ReKey (string key)
+        {
+            if (key == null)
+                throw new ArgumentNullException(nameof(key));
+            var q = Quote(key);
+            ExecuteScalar<string>("pragma rekey = " + q);
+        }
 
-		/// <summary>
-		/// Change the encryption key for a SQLCipher database.
-		/// </summary>
-		/// <param name="key">256-bit (32 byte) or 384-bit (48 bytes) encryption key data</param>
-		public void ReKey (byte[] key)
-		{
-			if (key == null)
-				throw new ArgumentNullException(nameof(key));
-			if (key.Length != 32 && key.Length != 48)
-				throw new ArgumentException ("Key must be 32 bytes (256-bit) or 48 bytes (384-bit)", nameof (key));
-			var s = String.Join("", key.Select(x => x.ToString("X2")));
-			ExecuteScalar<string>("pragma rekey = \"x'" + s + "'\"");
-		}
+        /// <summary>
+        /// Change the encryption key for a SQLCipher database.
+        /// </summary>
+        /// <param name="key">256-bit (32 byte) or 384-bit (48 bytes) encryption key data</param>
+        public void ReKey (byte[] key)
+        {
+            if (key == null)
+                throw new ArgumentNullException(nameof(key));
+            if (key.Length != 32 && key.Length != 48)
+                throw new ArgumentException ("Key must be 32 bytes (256-bit) or 48 bytes (384-bit)", nameof (key));
+            var s = String.Join("", key.Select(x => x.ToString("X2")));
+            ExecuteScalar<string>("pragma rekey = \"x'" + s + "'\"");
+        }
 
-		/// <summary>
-		/// Enable or disable extension loading.
-		/// </summary>
-		public void EnableLoadExtension (bool enabled)
-		{
-			SQLite3.Result r = SQLite3.EnableLoadExtension (Handle, enabled ? 1 : 0);
-			if (r != SQLite3.Result.OK) {
-				string msg = SQLite3.GetErrmsg (Handle);
-				throw SQLiteException.New (r, msg);
-			}
-		}
+        /// <summary>
+        /// Enable or disable extension loading.
+        /// </summary>
+        public void EnableLoadExtension (bool enabled)
+        {
+            SQLite3.Result r = SQLite3.EnableLoadExtension (Handle, enabled ? 1 : 0);
+            if (r != SQLite3.Result.OK) {
+                string msg = SQLite3.GetErrmsg (Handle);
+                throw SQLiteException.New (r, msg);
+            }
+        }
 
 #if !USE_SQLITEPCL_RAW
-		static byte[] GetNullTerminatedUtf8 (string s)
-		{
-			var utf8Length = System.Text.Encoding.UTF8.GetByteCount (s);
-			var bytes = new byte [utf8Length + 1];
-			utf8Length = System.Text.Encoding.UTF8.GetBytes(s, 0, s.Length, bytes, 0);
-			return bytes;
-		}
+        static byte[] GetNullTerminatedUtf8 (string s)
+        {
+            var utf8Length = System.Text.Encoding.UTF8.GetByteCount (s);
+            var bytes = new byte [utf8Length + 1];
+            utf8Length = System.Text.Encoding.UTF8.GetBytes(s, 0, s.Length, bytes, 0);
+            return bytes;
+        }
 #endif
 
-		/// <summary>
-		/// Sets a busy handler to sleep the specified amount of time when a table is locked.
-		/// The handler will sleep multiple times until a total time of <see cref="BusyTimeout"/> has accumulated.
-		/// </summary>
-		public TimeSpan BusyTimeout {
-			get { return _busyTimeout; }
-			set {
-				_busyTimeout = value;
-				if (Handle != NullHandle) {
-					SQLite3.BusyTimeout (Handle, (int)_busyTimeout.TotalMilliseconds);
-				}
-			}
-		}
-
-		/// <summary>
-		/// Returns the mappings from types to tables that the connection
-		/// currently understands.
-		/// </summary>
-		public IEnumerable<TableMapping> TableMappings {
-			get {
-				lock (_mappings) {
-					return new List<TableMapping> (_mappings.Values);
-				}
-			}
-		}
-
-		/// <summary>
-		/// Retrieves the mapping that is automatically generated for the given type.
-		/// </summary>
-		/// <param name="type">
-		/// The type whose mapping to the database is returned.
-		/// </param>
-		/// <param name="createFlags">
-		/// Optional flags allowing implicit PK and indexes based on naming conventions
-		/// </param>
-		/// <returns>
-		/// The mapping represents the schema of the columns of the database and contains
-		/// methods to set and get properties of objects.
-		/// </returns>
-		public TableMapping GetMapping (Type type, CreateFlags createFlags = CreateFlags.None)
-		{
-			TableMapping map;
-			var key = type.FullName;
-			lock (_mappings) {
-				if (_mappings.TryGetValue (key, out map)) {
-					if (createFlags != CreateFlags.None && createFlags != map.CreateFlags) {
-						map = new TableMapping (type, createFlags);
-						_mappings[key] = map;
-					}
-				}
-				else {
-					map = new TableMapping (type, createFlags);
-					_mappings.Add (key, map);
-				}
-			}
-			return map;
-		}
-
-		/// <summary>
-		/// Retrieves the mapping that is automatically generated for the given type.
-		/// </summary>
-		/// <param name="createFlags">
-		/// Optional flags allowing implicit PK and indexes based on naming conventions
-		/// </param>
-		/// <returns>
-		/// The mapping represents the schema of the columns of the database and contains
-		/// methods to set and get properties of objects.
-		/// </returns>
-		public TableMapping GetMapping<T> (CreateFlags createFlags = CreateFlags.None)
-		{
-			return GetMapping (typeof (T), createFlags);
-		}
-
-		private struct IndexedColumn
-		{
-			public int Order;
-			public string ColumnName;
-		}
-
-		private struct IndexInfo
-		{
-			public string IndexName;
-			public string TableName;
-			public bool Unique;
-			public List<IndexedColumn> Columns;
-		}
-
-		/// <summary>
-		/// Executes a "drop table" on the database.  This is non-recoverable.
-		/// </summary>
-		public int DropTable<T> ()
-		{
-			return DropTable (GetMapping (typeof (T)));
-		}
-
-		/// <summary>
-		/// Executes a "drop table" on the database.  This is non-recoverable.
-		/// </summary>
-		/// <param name="map">
-		/// The TableMapping used to identify the table.
-		/// </param>
-		public int DropTable (TableMapping map)
-		{
-			var query = string.Format ("drop table if exists \"{0}\"", map.TableName);
-			return Execute (query);
-		}
-
-		/// <summary>
-		/// Executes a "create table if not exists" on the database. It also
-		/// creates any specified indexes on the columns of the table. It uses
-		/// a schema automatically generated from the specified type. You can
-		/// later access this schema by calling GetMapping.
-		/// </summary>
-		/// <returns>
-		/// Whether the table was created or migrated.
-		/// </returns>
-		public CreateTableResult CreateTable<T> (CreateFlags createFlags = CreateFlags.None)
-		{
-			return CreateTable (typeof (T), createFlags);
-		}
-
-		/// <summary>
-		/// Executes a "create table if not exists" on the database. It also
-		/// creates any specified indexes on the columns of the table. It uses
-		/// a schema automatically generated from the specified type. You can
-		/// later access this schema by calling GetMapping.
-		/// </summary>
-		/// <param name="ty">Type to reflect to a database table.</param>
-		/// <param name="createFlags">Optional flags allowing implicit PK and indexes based on naming conventions.</param>
-		/// <returns>
-		/// Whether the table was created or migrated.
-		/// </returns>
-		public CreateTableResult CreateTable (Type ty, CreateFlags createFlags = CreateFlags.None)
-		{
-			var map = GetMapping (ty, createFlags);
-
-			// Present a nice error if no columns specified
-			if (map.Columns.Length == 0) {
-				throw new Exception (string.Format ("Cannot create a table without columns (does '{0}' have public properties?)", ty.FullName));
-			}
-
-			// Check if the table exists
-			var result = CreateTableResult.Created;
-			var existingCols = GetTableInfo (map.TableName);
-
-			// Create or migrate it
-			if (existingCols.Count == 0) {
-
-				// Facilitate virtual tables a.k.a. full-text search.
-				bool fts3 = (createFlags & CreateFlags.FullTextSearch3) != 0;
-				bool fts4 = (createFlags & CreateFlags.FullTextSearch4) != 0;
-				bool fts = fts3 || fts4;
-				var @virtual = fts ? "virtual " : string.Empty;
-				var @using = fts3 ? "using fts3 " : fts4 ? "using fts4 " : string.Empty;
-
-				// Build query.
-				var query = "create " + @virtual + "table if not exists \"" + map.TableName + "\" " + @using + "(\n";
-				var decls = map.Columns.Select (p => Orm.SqlDecl (p, StoreDateTimeAsTicks, StoreTimeSpanAsTicks));
-				var decl = string.Join (",\n", decls.ToArray ());
-				query += decl;
-				query += ")";
-				if (map.WithoutRowId) {
-					query += " without rowid";
-				}
-
-				Execute (query);
-			}
-			else {
-				result = CreateTableResult.Migrated;
-				MigrateTable (map, existingCols);
-			}
-
-			var indexes = new Dictionary<string, IndexInfo> ();
-			foreach (var c in map.Columns) {
-				foreach (var i in c.Indices) {
-					var iname = i.Name ?? map.TableName + "_" + c.Name;
-					IndexInfo iinfo;
-					if (!indexes.TryGetValue (iname, out iinfo)) {
-						iinfo = new IndexInfo {
-							IndexName = iname,
-							TableName = map.TableName,
-							Unique = i.Unique,
-							Columns = new List<IndexedColumn> ()
-						};
-						indexes.Add (iname, iinfo);
-					}
-
-					if (i.Unique != iinfo.Unique)
-						throw new Exception ("All the columns in an index must have the same value for their Unique property");
-
-					iinfo.Columns.Add (new IndexedColumn {
-						Order = i.Order,
-						ColumnName = c.Name
-					});
-				}
-			}
-
-			foreach (var indexName in indexes.Keys) {
-				var index = indexes[indexName];
-				var columns = index.Columns.OrderBy (i => i.Order).Select (i => i.ColumnName).ToArray ();
-				CreateIndex (indexName, index.TableName, columns, index.Unique);
-			}
-
-			return result;
-		}
-
-		/// <summary>
-		/// Executes a "create table if not exists" on the database for each type. It also
-		/// creates any specified indexes on the columns of the table. It uses
-		/// a schema automatically generated from the specified type. You can
-		/// later access this schema by calling GetMapping.
-		/// </summary>
-		/// <returns>
-		/// Whether the table was created or migrated for each type.
-		/// </returns>
-		public CreateTablesResult CreateTables<T, T2> (CreateFlags createFlags = CreateFlags.None)
-			where T : new()
-			where T2 : new()
-		{
-			return CreateTables (createFlags, typeof (T), typeof (T2));
-		}
-
-		/// <summary>
-		/// Executes a "create table if not exists" on the database for each type. It also
-		/// creates any specified indexes on the columns of the table. It uses
-		/// a schema automatically generated from the specified type. You can
-		/// later access this schema by calling GetMapping.
-		/// </summary>
-		/// <returns>
-		/// Whether the table was created or migrated for each type.
-		/// </returns>
-		public CreateTablesResult CreateTables<T, T2, T3> (CreateFlags createFlags = CreateFlags.None)
-			where T : new()
-			where T2 : new()
-			where T3 : new()
-		{
-			return CreateTables (createFlags, typeof (T), typeof (T2), typeof (T3));
-		}
-
-		/// <summary>
-		/// Executes a "create table if not exists" on the database for each type. It also
-		/// creates any specified indexes on the columns of the table. It uses
-		/// a schema automatically generated from the specified type. You can
-		/// later access this schema by calling GetMapping.
-		/// </summary>
-		/// <returns>
-		/// Whether the table was created or migrated for each type.
-		/// </returns>
-		public CreateTablesResult CreateTables<T, T2, T3, T4> (CreateFlags createFlags = CreateFlags.None)
-			where T : new()
-			where T2 : new()
-			where T3 : new()
-			where T4 : new()
-		{
-			return CreateTables (createFlags, typeof (T), typeof (T2), typeof (T3), typeof (T4));
-		}
-
-		/// <summary>
-		/// Executes a "create table if not exists" on the database for each type. It also
-		/// creates any specified indexes on the columns of the table. It uses
-		/// a schema automatically generated from the specified type. You can
-		/// later access this schema by calling GetMapping.
-		/// </summary>
-		/// <returns>
-		/// Whether the table was created or migrated for each type.
-		/// </returns>
-		public CreateTablesResult CreateTables<T, T2, T3, T4, T5> (CreateFlags createFlags = CreateFlags.None)
-			where T : new()
-			where T2 : new()
-			where T3 : new()
-			where T4 : new()
-			where T5 : new()
-		{
-			return CreateTables (createFlags, typeof (T), typeof (T2), typeof (T3), typeof (T4), typeof (T5));
-		}
-
-		/// <summary>
-		/// Executes a "create table if not exists" on the database for each type. It also
-		/// creates any specified indexes on the columns of the table. It uses
-		/// a schema automatically generated from the specified type. You can
-		/// later access this schema by calling GetMapping.
-		/// </summary>
-		/// <returns>
-		/// Whether the table was created or migrated for each type.
-		/// </returns>
-		public CreateTablesResult CreateTables (CreateFlags createFlags = CreateFlags.None, params Type[] types)
-		{
-			var result = new CreateTablesResult ();
-			foreach (Type type in types) {
-				var aResult = CreateTable (type, createFlags);
-				result.Results[type] = aResult;
-			}
-			return result;
-		}
-
-		/// <summary>
-		/// Creates an index for the specified table and columns.
-		/// </summary>
-		/// <param name="indexName">Name of the index to create</param>
-		/// <param name="tableName">Name of the database table</param>
-		/// <param name="columnNames">An array of column names to index</param>
-		/// <param name="unique">Whether the index should be unique</param>
-		/// <returns>Zero on success.</returns>
-		public int CreateIndex (string indexName, string tableName, string[] columnNames, bool unique = false)
-		{
-			const string sqlFormat = "create {2} index if not exists \"{3}\" on \"{0}\"(\"{1}\")";
-			var sql = String.Format (sqlFormat, tableName, string.Join ("\", \"", columnNames), unique ? "unique" : "", indexName);
-			return Execute (sql);
-		}
-
-		/// <summary>
-		/// Creates an index for the specified table and column.
-		/// </summary>
-		/// <param name="indexName">Name of the index to create</param>
-		/// <param name="tableName">Name of the database table</param>
-		/// <param name="columnName">Name of the column to index</param>
-		/// <param name="unique">Whether the index should be unique</param>
-		/// <returns>Zero on success.</returns>
-		public int CreateIndex (string indexName, string tableName, string columnName, bool unique = false)
-		{
-			return CreateIndex (indexName, tableName, new string[] { columnName }, unique);
-		}
-
-		/// <summary>
-		/// Creates an index for the specified table and column.
-		/// </summary>
-		/// <param name="tableName">Name of the database table</param>
-		/// <param name="columnName">Name of the column to index</param>
-		/// <param name="unique">Whether the index should be unique</param>
-		/// <returns>Zero on success.</returns>
-		public int CreateIndex (string tableName, string columnName, bool unique = false)
-		{
-			return CreateIndex (tableName + "_" + columnName, tableName, columnName, unique);
-		}
-
-		/// <summary>
-		/// Creates an index for the specified table and columns.
-		/// </summary>
-		/// <param name="tableName">Name of the database table</param>
-		/// <param name="columnNames">An array of column names to index</param>
-		/// <param name="unique">Whether the index should be unique</param>
-		/// <returns>Zero on success.</returns>
-		public int CreateIndex (string tableName, string[] columnNames, bool unique = false)
-		{
-			return CreateIndex (tableName + "_" + string.Join ("_", columnNames), tableName, columnNames, unique);
-		}
-
-		/// <summary>
-		/// Creates an index for the specified object property.
-		/// e.g. CreateIndex&lt;Client&gt;(c => c.Name);
-		/// </summary>
-		/// <typeparam name="T">Type to reflect to a database table.</typeparam>
-		/// <param name="property">Property to index</param>
-		/// <param name="unique">Whether the index should be unique</param>
-		/// <returns>Zero on success.</returns>
-		public int CreateIndex<T> (Expression<Func<T, object>> property, bool unique = false)
-		{
-			MemberExpression mx;
-			if (property.Body.NodeType == ExpressionType.Convert) {
-				mx = ((UnaryExpression)property.Body).Operand as MemberExpression;
-			}
-			else {
-				mx = (property.Body as MemberExpression);
-			}
-			var propertyInfo = mx.Member as PropertyInfo;
-			if (propertyInfo == null) {
-				throw new ArgumentException ("The lambda expression 'property' should point to a valid Property");
-			}
-
-			var propName = propertyInfo.Name;
-
-			var map = GetMapping<T> ();
-			var colName = map.FindColumnWithPropertyName (propName).Name;
-
-			return CreateIndex (map.TableName, colName, unique);
-		}
-
-		[Preserve (AllMembers = true)]
-		public class ColumnInfo
-		{
-			//			public int cid { get; set; }
-
-			[Column ("name")]
-			public string Name { get; set; }
-
-			//			[Column ("type")]
-			//			public string ColumnType { get; set; }
-
-			public int notnull { get; set; }
-
-			//			public string dflt_value { get; set; }
-
-			//			public int pk { get; set; }
-
-			public override string ToString ()
-			{
-				return Name;
-			}
-		}
-
-		/// <summary>
-		/// Query the built-in sqlite table_info table for a specific tables columns.
-		/// </summary>
-		/// <returns>The columns contains in the table.</returns>
-		/// <param name="tableName">Table name.</param>
-		public List<ColumnInfo> GetTableInfo (string tableName)
-		{
-			var query = "pragma table_info(\"" + tableName + "\")";
-			return Query<ColumnInfo> (query);
-		}
-
-		void MigrateTable (TableMapping map, List<ColumnInfo> existingCols)
-		{
-			var toBeAdded = new List<TableMapping.Column> ();
-
-			foreach (var p in map.Columns) {
-				var found = false;
-				foreach (var c in existingCols) {
-					found = (string.Compare (p.Name, c.Name, StringComparison.OrdinalIgnoreCase) == 0);
-					if (found)
-						break;
-				}
-				if (!found) {
-					toBeAdded.Add (p);
-				}
-			}
-
-			foreach (var p in toBeAdded) {
-				var addCol = "alter table \"" + map.TableName + "\" add column " + Orm.SqlDecl (p, StoreDateTimeAsTicks, StoreTimeSpanAsTicks);
-				Execute (addCol);
-			}
-		}
-
-		/// <summary>
-		/// Creates a new SQLiteCommand. Can be overridden to provide a sub-class.
-		/// </summary>
-		/// <seealso cref="SQLiteCommand.OnInstanceCreated"/>
-		protected virtual SQLiteCommand NewCommand ()
-		{
-			return new SQLiteCommand (this);
-		}
-
-		/// <summary>
-		/// Creates a new SQLiteCommand given the command text with arguments. Place a '?'
-		/// in the command text for each of the arguments.
-		/// </summary>
-		/// <param name="cmdText">
-		/// The fully escaped SQL.
-		/// </param>
-		/// <param name="ps">
-		/// Arguments to substitute for the occurences of '?' in the command text.
-		/// </param>
-		/// <returns>
-		/// A <see cref="SQLiteCommand"/>
-		/// </returns>
-		public SQLiteCommand CreateCommand (string cmdText, params object[] ps)
-		{
-			if (!_open)
-				throw SQLiteException.New (SQLite3.Result.Error, "Cannot create commands from unopened database");
-
-			var cmd = NewCommand ();
-			cmd.CommandText = cmdText;
-			foreach (var o in ps) {
-				cmd.Bind (o);
-			}
-			return cmd;
-		}
-
-		/// <summary>
-		/// Creates a new SQLiteCommand given the command text with named arguments. Place a "[@:$]VVV"
-		/// in the command text for each of the arguments. VVV represents an alphanumeric identifier.
-		/// For example, @name :name and $name can all be used in the query.
-		/// </summary>
-		/// <param name="cmdText">
-		/// The fully escaped SQL.
-		/// </param>
-		/// <param name="args">
-		/// Arguments to substitute for the occurences of "[@:$]VVV" in the command text.
-		/// </param>
-		/// <returns>
-		/// A <see cref="SQLiteCommand" />
-		/// </returns>
-		public SQLiteCommand CreateCommand (string cmdText, Dictionary<string, object> args)
-		{
-			if (!_open)
-				throw SQLiteException.New (SQLite3.Result.Error, "Cannot create commands from unopened database");
-
-			SQLiteCommand cmd = NewCommand ();
-			cmd.CommandText = cmdText;
-			foreach (var kv in args) {
-				cmd.Bind (kv.Key, kv.Value);
-			}
-			return cmd;
-		}
-
-		/// <summary>
-		/// Creates a SQLiteCommand given the command text (SQL) with arguments. Place a '?'
-		/// in the command text for each of the arguments and then executes that command.
-		/// Use this method instead of Query when you don't expect rows back. Such cases include
-		/// INSERTs, UPDATEs, and DELETEs.
-		/// You can set the Trace or TimeExecution properties of the connection
-		/// to profile execution.
-		/// </summary>
-		/// <param name="query">
-		/// The fully escaped SQL.
-		/// </param>
-		/// <param name="args">
-		/// Arguments to substitute for the occurences of '?' in the query.
-		/// </param>
-		/// <returns>
-		/// The number of rows modified in the database as a result of this execution.
-		/// </returns>
-		public int Execute (string query, params object[] args)
-		{
-			var cmd = CreateCommand (query, args);
-
-			if (TimeExecution) {
-				if (_sw == null) {
-					_sw = new Stopwatch ();
-				}
-				_sw.Reset ();
-				_sw.Start ();
-			}
-
-			var r = cmd.ExecuteNonQuery ();
-
-			if (TimeExecution) {
-				_sw.Stop ();
-				_elapsedMilliseconds += _sw.ElapsedMilliseconds;
-				Tracer?.Invoke (string.Format ("Finished in {0} ms ({1:0.0} s total)", _sw.ElapsedMilliseconds, _elapsedMilliseconds / 1000.0));
-			}
-
-			return r;
-		}
-
-		/// <summary>
-		/// Creates a SQLiteCommand given the command text (SQL) with arguments. Place a '?'
-		/// in the command text for each of the arguments and then executes that command.
-		/// Use this method when return primitive values.
-		/// You can set the Trace or TimeExecution properties of the connection
-		/// to profile execution.
-		/// </summary>
-		/// <param name="query">
-		/// The fully escaped SQL.
-		/// </param>
-		/// <param name="args">
-		/// Arguments to substitute for the occurences of '?' in the query.
-		/// </param>
-		/// <returns>
-		/// The number of rows modified in the database as a result of this execution.
-		/// </returns>
-		public T ExecuteScalar<T> (string query, params object[] args)
-		{
-			var cmd = CreateCommand (query, args);
-
-			if (TimeExecution) {
-				if (_sw == null) {
-					_sw = new Stopwatch ();
-				}
-				_sw.Reset ();
-				_sw.Start ();
-			}
-
-			var r = cmd.ExecuteScalar<T> ();
-
-			if (TimeExecution) {
-				_sw.Stop ();
-				_elapsedMilliseconds += _sw.ElapsedMilliseconds;
-				Tracer?.Invoke (string.Format ("Finished in {0} ms ({1:0.0} s total)", _sw.ElapsedMilliseconds, _elapsedMilliseconds / 1000.0));
-			}
-
-			return r;
-		}
-
-		/// <summary>
-		/// Creates a SQLiteCommand given the command text (SQL) with arguments. Place a '?'
-		/// in the command text for each of the arguments and then executes that command.
-		/// It returns each row of the result using the mapping automatically generated for
-		/// the given type.
-		/// </summary>
-		/// <param name="query">
-		/// The fully escaped SQL.
-		/// </param>
-		/// <param name="args">
-		/// Arguments to substitute for the occurences of '?' in the query.
-		/// </param>
-		/// <returns>
-		/// An enumerable with one result for each row returned by the query.
-		/// </returns>
-		public List<T> Query<T> (string query, params object[] args) where T : new()
-		{
-			var cmd = CreateCommand (query, args);
-			return cmd.ExecuteQuery<T> ();
-		}
-
-		/// <summary>
-		/// Creates a SQLiteCommand given the command text (SQL) with arguments. Place a '?'
-		/// in the command text for each of the arguments and then executes that command.
-		/// It returns the first column of each row of the result.
-		/// </summary>
-		/// <param name="query">
-		/// The fully escaped SQL.
-		/// </param>
-		/// <param name="args">
-		/// Arguments to substitute for the occurences of '?' in the query.
-		/// </param>
-		/// <returns>
-		/// An enumerable with one result for the first column of each row returned by the query.
-		/// </returns>
-		public List<T> QueryScalars<T> (string query, params object[] args)
-		{
-			var cmd = CreateCommand (query, args);
-			return cmd.ExecuteQueryScalars<T> ().ToList ();
-		}
-
-		/// <summary>
-		/// Creates a SQLiteCommand given the command text (SQL) with arguments. Place a '?'
-		/// in the command text for each of the arguments and then executes that command.
-		/// It returns each row of the result using the mapping automatically generated for
-		/// the given type.
-		/// </summary>
-		/// <param name="query">
-		/// The fully escaped SQL.
-		/// </param>
-		/// <param name="args">
-		/// Arguments to substitute for the occurences of '?' in the query.
-		/// </param>
-		/// <returns>
-		/// An enumerable with one result for each row returned by the query.
-		/// The enumerator (retrieved by calling GetEnumerator() on the result of this method)
-		/// will call sqlite3_step on each call to MoveNext, so the database
-		/// connection must remain open for the lifetime of the enumerator.
-		/// </returns>
-		public IEnumerable<T> DeferredQuery<T> (string query, params object[] args) where T : new()
-		{
-			var cmd = CreateCommand (query, args);
-			return cmd.ExecuteDeferredQuery<T> ();
-		}
-
-		/// <summary>
-		/// Creates a SQLiteCommand given the command text (SQL) with arguments. Place a '?'
-		/// in the command text for each of the arguments and then executes that command.
-		/// It returns each row of the result using the specified mapping. This function is
-		/// only used by libraries in order to query the database via introspection. It is
-		/// normally not used.
-		/// </summary>
-		/// <param name="map">
-		/// A <see cref="TableMapping"/> to use to convert the resulting rows
-		/// into objects.
-		/// </param>
-		/// <param name="query">
-		/// The fully escaped SQL.
-		/// </param>
-		/// <param name="args">
-		/// Arguments to substitute for the occurences of '?' in the query.
-		/// </param>
-		/// <returns>
-		/// An enumerable with one result for each row returned by the query.
-		/// </returns>
-		public List<object> Query (TableMapping map, string query, params object[] args)
-		{
-			var cmd = CreateCommand (query, args);
-			return cmd.ExecuteQuery<object> (map);
-		}
-
-		/// <summary>
-		/// Creates a SQLiteCommand given the command text (SQL) with arguments. Place a '?'
-		/// in the command text for each of the arguments and then executes that command.
-		/// It returns each row of the result using the specified mapping. This function is
-		/// only used by libraries in order to query the database via introspection. It is
-		/// normally not used.
-		/// </summary>
-		/// <param name="map">
-		/// A <see cref="TableMapping"/> to use to convert the resulting rows
-		/// into objects.
-		/// </param>
-		/// <param name="query">
-		/// The fully escaped SQL.
-		/// </param>
-		/// <param name="args">
-		/// Arguments to substitute for the occurences of '?' in the query.
-		/// </param>
-		/// <returns>
-		/// An enumerable with one result for each row returned by the query.
-		/// The enumerator (retrieved by calling GetEnumerator() on the result of this method)
-		/// will call sqlite3_step on each call to MoveNext, so the database
-		/// connection must remain open for the lifetime of the enumerator.
-		/// </returns>
-		public IEnumerable<object> DeferredQuery (TableMapping map, string query, params object[] args)
-		{
-			var cmd = CreateCommand (query, args);
-			return cmd.ExecuteDeferredQuery<object> (map);
-		}
-
-		/// <summary>
-		/// Returns a queryable interface to the table represented by the given type.
-		/// </summary>
-		/// <returns>
-		/// A queryable object that is able to translate Where, OrderBy, and Take
-		/// queries into native SQL.
-		/// </returns>
-		public TableQuery<T> Table<T> () where T : new()
-		{
-			return new TableQuery<T> (this);
-		}
-
-		/// <summary>
-		/// Attempts to retrieve an object with the given primary key from the table
-		/// associated with the specified type. Use of this method requires that
-		/// the given type have a designated PrimaryKey (using the PrimaryKeyAttribute).
-		/// </summary>
-		/// <param name="pk">
-		/// The primary key.
-		/// </param>
-		/// <returns>
-		/// The object with the given primary key. Throws a not found exception
-		/// if the object is not found.
-		/// </returns>
-		public T Get<T> (object pk) where T : new()
-		{
-			var map = GetMapping (typeof (T));
-			return Query<T> (map.GetByPrimaryKeySql, pk).First ();
-		}
-
-		/// <summary>
-		/// Attempts to retrieve an object with the given primary key from the table
-		/// associated with the specified type. Use of this method requires that
-		/// the given type have a designated PrimaryKey (using the PrimaryKeyAttribute).
-		/// </summary>
-		/// <param name="pk">
-		/// The primary key.
-		/// </param>
-		/// <param name="map">
-		/// The TableMapping used to identify the table.
-		/// </param>
-		/// <returns>
-		/// The object with the given primary key. Throws a not found exception
-		/// if the object is not found.
-		/// </returns>
-		public object Get (object pk, TableMapping map)
-		{
-			return Query (map, map.GetByPrimaryKeySql, pk).First ();
-		}
-
-		/// <summary>
-		/// Attempts to retrieve the first object that matches the predicate from the table
-		/// associated with the specified type.
-		/// </summary>
-		/// <param name="predicate">
-		/// A predicate for which object to find.
-		/// </param>
-		/// <returns>
-		/// The object that matches the given predicate. Throws a not found exception
-		/// if the object is not found.
-		/// </returns>
-		public T Get<T> (Expression<Func<T, bool>> predicate) where T : new()
-		{
-			return Table<T> ().Where (predicate).First ();
-		}
-
-		/// <summary>
-		/// Attempts to retrieve an object with the given primary key from the table
-		/// associated with the specified type. Use of this method requires that
-		/// the given type have a designated PrimaryKey (using the PrimaryKeyAttribute).
-		/// </summary>
-		/// <param name="pk">
-		/// The primary key.
-		/// </param>
-		/// <returns>
-		/// The object with the given primary key or null
-		/// if the object is not found.
-		/// </returns>
-		public T Find<T> (object pk) where T : new()
-		{
-			var map = GetMapping (typeof (T));
-			return Query<T> (map.GetByPrimaryKeySql, pk).FirstOrDefault ();
-		}
-
-		/// <summary>
-		/// Attempts to retrieve an object with the given primary key from the table
-		/// associated with the specified type. Use of this method requires that
-		/// the given type have a designated PrimaryKey (using the PrimaryKeyAttribute).
-		/// </summary>
-		/// <param name="pk">
-		/// The primary key.
-		/// </param>
-		/// <param name="map">
-		/// The TableMapping used to identify the table.
-		/// </param>
-		/// <returns>
-		/// The object with the given primary key or null
-		/// if the object is not found.
-		/// </returns>
-		public object Find (object pk, TableMapping map)
-		{
-			return Query (map, map.GetByPrimaryKeySql, pk).FirstOrDefault ();
-		}
-
-		/// <summary>
-		/// Attempts to retrieve the first object that matches the predicate from the table
-		/// associated with the specified type.
-		/// </summary>
-		/// <param name="predicate">
-		/// A predicate for which object to find.
-		/// </param>
-		/// <returns>
-		/// The object that matches the given predicate or null
-		/// if the object is not found.
-		/// </returns>
-		public T Find<T> (Expression<Func<T, bool>> predicate) where T : new()
-		{
-			return Table<T> ().Where (predicate).FirstOrDefault ();
-		}
-
-		/// <summary>
-		/// Attempts to retrieve the first object that matches the query from the table
-		/// associated with the specified type.
-		/// </summary>
-		/// <param name="query">
-		/// The fully escaped SQL.
-		/// </param>
-		/// <param name="args">
-		/// Arguments to substitute for the occurences of '?' in the query.
-		/// </param>
-		/// <returns>
-		/// The object that matches the given predicate or null
-		/// if the object is not found.
-		/// </returns>
-		public T FindWithQuery<T> (string query, params object[] args) where T : new()
-		{
-			return Query<T> (query, args).FirstOrDefault ();
-		}
-
-		/// <summary>
-		/// Attempts to retrieve the first object that matches the query from the table
-		/// associated with the specified type.
-		/// </summary>
-		/// <param name="map">
-		/// The TableMapping used to identify the table.
-		/// </param>
-		/// <param name="query">
-		/// The fully escaped SQL.
-		/// </param>
-		/// <param name="args">
-		/// Arguments to substitute for the occurences of '?' in the query.
-		/// </param>
-		/// <returns>
-		/// The object that matches the given predicate or null
-		/// if the object is not found.
-		/// </returns>
-		public object FindWithQuery (TableMapping map, string query, params object[] args)
-		{
-			return Query (map, query, args).FirstOrDefault ();
-		}
-
-		/// <summary>
-		/// Whether <see cref="BeginTransaction"/> has been called and the database is waiting for a <see cref="Commit"/>.
-		/// </summary>
-		public bool IsInTransaction {
-			get { return _transactionDepth > 0; }
-		}
-
-		/// <summary>
-		/// Begins a new transaction. Call <see cref="Commit"/> to end the transaction.
-		/// </summary>
-		/// <example cref="System.InvalidOperationException">Throws if a transaction has already begun.</example>
-		public void BeginTransaction ()
-		{
-			// The BEGIN command only works if the transaction stack is empty,
-			//    or in other words if there are no pending transactions.
-			// If the transaction stack is not empty when the BEGIN command is invoked,
-			//    then the command fails with an error.
-			// Rather than crash with an error, we will just ignore calls to BeginTransaction
-			//    that would result in an error.
-			if (Interlocked.CompareExchange (ref _transactionDepth, 1, 0) == 0) {
-				try {
-					Execute ("begin transaction");
-				}
-				catch (Exception ex) {
-					var sqlExp = ex as SQLiteException;
-					if (sqlExp != null) {
-						// It is recommended that applications respond to the errors listed below
-						//    by explicitly issuing a ROLLBACK command.
-						// TODO: This rollback failsafe should be localized to all throw sites.
-						switch (sqlExp.Result) {
-							case SQLite3.Result.IOError:
-							case SQLite3.Result.Full:
-							case SQLite3.Result.Busy:
-							case SQLite3.Result.NoMem:
-							case SQLite3.Result.Interrupt:
-								RollbackTo (null, true);
-								break;
-						}
-					}
-					else {
-						// Call decrement and not VolatileWrite in case we've already
-						//    created a transaction point in SaveTransactionPoint since the catch.
-						Interlocked.Decrement (ref _transactionDepth);
-					}
-
-					throw;
-				}
-			}
-			else {
-				// Calling BeginTransaction on an already open transaction is invalid
-				throw new InvalidOperationException ("Cannot begin a transaction while already in a transaction.");
-			}
-		}
-
-		/// <summary>
-		/// Creates a savepoint in the database at the current point in the transaction timeline.
-		/// Begins a new transaction if one is not in progress.
-		///
-		/// Call <see cref="RollbackTo(string)"/> to undo transactions since the returned savepoint.
-		/// Call <see cref="Release"/> to commit transactions after the savepoint returned here.
-		/// Call <see cref="Commit"/> to end the transaction, committing all changes.
-		/// </summary>
-		/// <returns>A string naming the savepoint.</returns>
-		public string SaveTransactionPoint ()
-		{
-			int depth = Interlocked.Increment (ref _transactionDepth) - 1;
-			string retVal = "S" + _rand.Next (short.MaxValue) + "D" + depth;
-
-			try {
-				Execute ("savepoint " + retVal);
-			}
-			catch (Exception ex) {
-				var sqlExp = ex as SQLiteException;
-				if (sqlExp != null) {
-					// It is recommended that applications respond to the errors listed below
-					//    by explicitly issuing a ROLLBACK command.
-					// TODO: This rollback failsafe should be localized to all throw sites.
-					switch (sqlExp.Result) {
-						case SQLite3.Result.IOError:
-						case SQLite3.Result.Full:
-						case SQLite3.Result.Busy:
-						case SQLite3.Result.NoMem:
-						case SQLite3.Result.Interrupt:
-							RollbackTo (null, true);
-							break;
-					}
-				}
-				else {
-					Interlocked.Decrement (ref _transactionDepth);
-				}
-
-				throw;
-			}
-
-			return retVal;
-		}
-
-		/// <summary>
-		/// Rolls back the transaction that was begun by <see cref="BeginTransaction"/> or <see cref="SaveTransactionPoint"/>.
-		/// </summary>
-		public void Rollback ()
-		{
-			RollbackTo (null, false);
-		}
-
-		/// <summary>
-		/// Rolls back the savepoint created by <see cref="BeginTransaction"/> or SaveTransactionPoint.
-		/// </summary>
-		/// <param name="savepoint">The name of the savepoint to roll back to, as returned by <see cref="SaveTransactionPoint"/>.  If savepoint is null or empty, this method is equivalent to a call to <see cref="Rollback"/></param>
-		public void RollbackTo (string savepoint)
-		{
-			RollbackTo (savepoint, false);
-		}
-
-		/// <summary>
-		/// Rolls back the transaction that was begun by <see cref="BeginTransaction"/>.
-		/// </summary>
-		/// <param name="savepoint">The name of the savepoint to roll back to, as returned by <see cref="SaveTransactionPoint"/>.  If savepoint is null or empty, this method is equivalent to a call to <see cref="Rollback"/></param>
-		/// <param name="noThrow">true to avoid throwing exceptions, false otherwise</param>
-		void RollbackTo (string savepoint, bool noThrow)
-		{
-			// Rolling back without a TO clause rolls backs all transactions
-			//    and leaves the transaction stack empty.
-			try {
-				if (String.IsNullOrEmpty (savepoint)) {
-					if (Interlocked.Exchange (ref _transactionDepth, 0) > 0) {
-						Execute ("rollback");
-					}
-				}
-				else {
-					DoSavePointExecute (savepoint, "rollback to ");
-				}
-			}
-			catch (SQLiteException) {
-				if (!noThrow)
-					throw;
-
-			}
-			// No need to rollback if there are no transactions open.
-		}
-
-		/// <summary>
-		/// Releases a savepoint returned from <see cref="SaveTransactionPoint"/>.  Releasing a savepoint
-		///    makes changes since that savepoint permanent if the savepoint began the transaction,
-		///    or otherwise the changes are permanent pending a call to <see cref="Commit"/>.
-		///
-		/// The RELEASE command is like a COMMIT for a SAVEPOINT.
-		/// </summary>
-		/// <param name="savepoint">The name of the savepoint to release.  The string should be the result of a call to <see cref="SaveTransactionPoint"/></param>
-		public void Release (string savepoint)
-		{
-			try {
-				DoSavePointExecute (savepoint, "release ");
-			}
-			catch (SQLiteException ex) {
-				if (ex.Result == SQLite3.Result.Busy) {
-					// Force a rollback since most people don't know this function can fail
-					// Don't call Rollback() since the _transactionDepth is 0 and it won't try
-					// Calling rollback makes our _transactionDepth variable correct.
-					// Writes to the database only happen at depth=0, so this failure will only happen then.
-					try {
-						Execute ("rollback");
-					}
-					catch {
-						// rollback can fail in all sorts of wonderful version-dependent ways. Let's just hope for the best
-					}
-				}
-				throw;
-			}
-		}
-
-		void DoSavePointExecute (string savepoint, string cmd)
-		{
-			// Validate the savepoint
-			int firstLen = savepoint.IndexOf ('D');
-			if (firstLen >= 2 && savepoint.Length > firstLen + 1) {
-				int depth;
-				if (Int32.TryParse (savepoint.Substring (firstLen + 1), out depth)) {
-					// TODO: Mild race here, but inescapable without locking almost everywhere.
-					if (0 <= depth && depth < _transactionDepth) {
+        /// <summary>
+        /// Sets a busy handler to sleep the specified amount of time when a table is locked.
+        /// The handler will sleep multiple times until a total time of <see cref="BusyTimeout"/> has accumulated.
+        /// </summary>
+        public TimeSpan BusyTimeout {
+            get { return _busyTimeout; }
+            set {
+                _busyTimeout = value;
+                if (Handle != NullHandle) {
+                    SQLite3.BusyTimeout (Handle, (int)_busyTimeout.TotalMilliseconds);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Returns the mappings from types to tables that the connection
+        /// currently understands.
+        /// </summary>
+        public IEnumerable<TableMapping> TableMappings {
+            get {
+                lock (_mappings) {
+                    return new List<TableMapping> (_mappings.Values);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Retrieves the mapping that is automatically generated for the given type.
+        /// </summary>
+        /// <param name="type">
+        /// The type whose mapping to the database is returned.
+        /// </param>
+        /// <param name="createFlags">
+        /// Optional flags allowing implicit PK and indexes based on naming conventions
+        /// </param>
+        /// <returns>
+        /// The mapping represents the schema of the columns of the database and contains
+        /// methods to set and get properties of objects.
+        /// </returns>
+        public TableMapping GetMapping (Type type, CreateFlags createFlags = CreateFlags.None)
+        {
+            TableMapping map;
+            var key = type.FullName;
+            lock (_mappings) {
+                if (_mappings.TryGetValue (key, out map)) {
+                    if (createFlags != CreateFlags.None && createFlags != map.CreateFlags) {
+                        map = new TableMapping (type, createFlags);
+                        _mappings[key] = map;
+                    }
+                }
+                else {
+                    map = new TableMapping (type, createFlags);
+                    _mappings.Add (key, map);
+                }
+            }
+            return map;
+        }
+
+        /// <summary>
+        /// Retrieves the mapping that is automatically generated for the given type.
+        /// </summary>
+        /// <param name="createFlags">
+        /// Optional flags allowing implicit PK and indexes based on naming conventions
+        /// </param>
+        /// <returns>
+        /// The mapping represents the schema of the columns of the database and contains
+        /// methods to set and get properties of objects.
+        /// </returns>
+        public TableMapping GetMapping<T> (CreateFlags createFlags = CreateFlags.None)
+        {
+            return GetMapping (typeof (T), createFlags);
+        }
+
+        private struct IndexedColumn
+        {
+            public int Order;
+            public string ColumnName;
+        }
+
+        private struct IndexInfo
+        {
+            public string IndexName;
+            public string TableName;
+            public bool Unique;
+            public List<IndexedColumn> Columns;
+        }
+
+        /// <summary>
+        /// Executes a "drop table" on the database.  This is non-recoverable.
+        /// </summary>
+        public int DropTable<T> ()
+        {
+            return DropTable (GetMapping (typeof (T)));
+        }
+
+        /// <summary>
+        /// Executes a "drop table" on the database.  This is non-recoverable.
+        /// </summary>
+        /// <param name="map">
+        /// The TableMapping used to identify the table.
+        /// </param>
+        public int DropTable (TableMapping map)
+        {
+            var query = string.Format ("drop table if exists \"{0}\"", map.TableName);
+            return Execute (query);
+        }
+
+        /// <summary>
+        /// Executes a "create table if not exists" on the database. It also
+        /// creates any specified indexes on the columns of the table. It uses
+        /// a schema automatically generated from the specified type. You can
+        /// later access this schema by calling GetMapping.
+        /// </summary>
+        /// <returns>
+        /// Whether the table was created or migrated.
+        /// </returns>
+        public CreateTableResult CreateTable<T> (CreateFlags createFlags = CreateFlags.None)
+        {
+            return CreateTable (typeof (T), createFlags);
+        }
+
+        /// <summary>
+        /// Executes a "create table if not exists" on the database. It also
+        /// creates any specified indexes on the columns of the table. It uses
+        /// a schema automatically generated from the specified type. You can
+        /// later access this schema by calling GetMapping.
+        /// </summary>
+        /// <param name="ty">Type to reflect to a database table.</param>
+        /// <param name="createFlags">Optional flags allowing implicit PK and indexes based on naming conventions.</param>
+        /// <returns>
+        /// Whether the table was created or migrated.
+        /// </returns>
+        public CreateTableResult CreateTable (Type ty, CreateFlags createFlags = CreateFlags.None)
+        {
+            var map = GetMapping (ty, createFlags);
+
+            // Present a nice error if no columns specified
+            if (map.Columns.Length == 0) {
+                throw new Exception (string.Format ("Cannot create a table without columns (does '{0}' have public properties?)", ty.FullName));
+            }
+
+            // Check if the table exists
+            var result = CreateTableResult.Created;
+            var existingCols = GetTableInfo (map.TableName);
+
+            // Create or migrate it
+            if (existingCols.Count == 0) {
+
+                // Facilitate virtual tables a.k.a. full-text search.
+                bool fts3 = (createFlags & CreateFlags.FullTextSearch3) != 0;
+                bool fts4 = (createFlags & CreateFlags.FullTextSearch4) != 0;
+                bool fts = fts3 || fts4;
+                var @virtual = fts ? "virtual " : string.Empty;
+                var @using = fts3 ? "using fts3 " : fts4 ? "using fts4 " : string.Empty;
+
+                // Build query.
+                var query = "create " + @virtual + "table if not exists \"" + map.TableName + "\" " + @using + "(\n";
+                var decls = map.Columns.Select (p => Orm.SqlDecl (p, StoreDateTimeAsTicks, StoreTimeSpanAsTicks));
+                var decl = string.Join (",\n", decls.ToArray ());
+                query += decl;
+                query += ")";
+                if (map.WithoutRowId) {
+                    query += " without rowid";
+                }
+
+                Execute (query);
+            }
+            else {
+                result = CreateTableResult.Migrated;
+                MigrateTable (map, existingCols);
+            }
+
+            var indexes = new Dictionary<string, IndexInfo> ();
+            foreach (var c in map.Columns) {
+                foreach (var i in c.Indices) {
+                    var iname = i.Name ?? map.TableName + "_" + c.Name;
+                    IndexInfo iinfo;
+                    if (!indexes.TryGetValue (iname, out iinfo)) {
+                        iinfo = new IndexInfo {
+                            IndexName = iname,
+                            TableName = map.TableName,
+                            Unique = i.Unique,
+                            Columns = new List<IndexedColumn> ()
+                        };
+                        indexes.Add (iname, iinfo);
+                    }
+
+                    if (i.Unique != iinfo.Unique)
+                        throw new Exception ("All the columns in an index must have the same value for their Unique property");
+
+                    iinfo.Columns.Add (new IndexedColumn {
+                        Order = i.Order,
+                        ColumnName = c.Name
+                    });
+                }
+            }
+
+            foreach (var indexName in indexes.Keys) {
+                var index = indexes[indexName];
+                var columns = index.Columns.OrderBy (i => i.Order).Select (i => i.ColumnName).ToArray ();
+                CreateIndex (indexName, index.TableName, columns, index.Unique);
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Executes a "create table if not exists" on the database for each type. It also
+        /// creates any specified indexes on the columns of the table. It uses
+        /// a schema automatically generated from the specified type. You can
+        /// later access this schema by calling GetMapping.
+        /// </summary>
+        /// <returns>
+        /// Whether the table was created or migrated for each type.
+        /// </returns>
+        public CreateTablesResult CreateTables<T, T2> (CreateFlags createFlags = CreateFlags.None)
+            where T : new()
+            where T2 : new()
+        {
+            return CreateTables (createFlags, typeof (T), typeof (T2));
+        }
+
+        /// <summary>
+        /// Executes a "create table if not exists" on the database for each type. It also
+        /// creates any specified indexes on the columns of the table. It uses
+        /// a schema automatically generated from the specified type. You can
+        /// later access this schema by calling GetMapping.
+        /// </summary>
+        /// <returns>
+        /// Whether the table was created or migrated for each type.
+        /// </returns>
+        public CreateTablesResult CreateTables<T, T2, T3> (CreateFlags createFlags = CreateFlags.None)
+            where T : new()
+            where T2 : new()
+            where T3 : new()
+        {
+            return CreateTables (createFlags, typeof (T), typeof (T2), typeof (T3));
+        }
+
+        /// <summary>
+        /// Executes a "create table if not exists" on the database for each type. It also
+        /// creates any specified indexes on the columns of the table. It uses
+        /// a schema automatically generated from the specified type. You can
+        /// later access this schema by calling GetMapping.
+        /// </summary>
+        /// <returns>
+        /// Whether the table was created or migrated for each type.
+        /// </returns>
+        public CreateTablesResult CreateTables<T, T2, T3, T4> (CreateFlags createFlags = CreateFlags.None)
+            where T : new()
+            where T2 : new()
+            where T3 : new()
+            where T4 : new()
+        {
+            return CreateTables (createFlags, typeof (T), typeof (T2), typeof (T3), typeof (T4));
+        }
+
+        /// <summary>
+        /// Executes a "create table if not exists" on the database for each type. It also
+        /// creates any specified indexes on the columns of the table. It uses
+        /// a schema automatically generated from the specified type. You can
+        /// later access this schema by calling GetMapping.
+        /// </summary>
+        /// <returns>
+        /// Whether the table was created or migrated for each type.
+        /// </returns>
+        public CreateTablesResult CreateTables<T, T2, T3, T4, T5> (CreateFlags createFlags = CreateFlags.None)
+            where T : new()
+            where T2 : new()
+            where T3 : new()
+            where T4 : new()
+            where T5 : new()
+        {
+            return CreateTables (createFlags, typeof (T), typeof (T2), typeof (T3), typeof (T4), typeof (T5));
+        }
+
+        /// <summary>
+        /// Executes a "create table if not exists" on the database for each type. It also
+        /// creates any specified indexes on the columns of the table. It uses
+        /// a schema automatically generated from the specified type. You can
+        /// later access this schema by calling GetMapping.
+        /// </summary>
+        /// <returns>
+        /// Whether the table was created or migrated for each type.
+        /// </returns>
+        public CreateTablesResult CreateTables (CreateFlags createFlags = CreateFlags.None, params Type[] types)
+        {
+            var result = new CreateTablesResult ();
+            foreach (Type type in types) {
+                var aResult = CreateTable (type, createFlags);
+                result.Results[type] = aResult;
+            }
+            return result;
+        }
+
+        /// <summary>
+        /// Creates an index for the specified table and columns.
+        /// </summary>
+        /// <param name="indexName">Name of the index to create</param>
+        /// <param name="tableName">Name of the database table</param>
+        /// <param name="columnNames">An array of column names to index</param>
+        /// <param name="unique">Whether the index should be unique</param>
+        /// <returns>Zero on success.</returns>
+        public int CreateIndex (string indexName, string tableName, string[] columnNames, bool unique = false)
+        {
+            const string sqlFormat = "create {2} index if not exists \"{3}\" on \"{0}\"(\"{1}\")";
+            var sql = String.Format (sqlFormat, tableName, string.Join ("\", \"", columnNames), unique ? "unique" : "", indexName);
+            return Execute (sql);
+        }
+
+        /// <summary>
+        /// Creates an index for the specified table and column.
+        /// </summary>
+        /// <param name="indexName">Name of the index to create</param>
+        /// <param name="tableName">Name of the database table</param>
+        /// <param name="columnName">Name of the column to index</param>
+        /// <param name="unique">Whether the index should be unique</param>
+        /// <returns>Zero on success.</returns>
+        public int CreateIndex (string indexName, string tableName, string columnName, bool unique = false)
+        {
+            return CreateIndex (indexName, tableName, new string[] { columnName }, unique);
+        }
+
+        /// <summary>
+        /// Creates an index for the specified table and column.
+        /// </summary>
+        /// <param name="tableName">Name of the database table</param>
+        /// <param name="columnName">Name of the column to index</param>
+        /// <param name="unique">Whether the index should be unique</param>
+        /// <returns>Zero on success.</returns>
+        public int CreateIndex (string tableName, string columnName, bool unique = false)
+        {
+            return CreateIndex (tableName + "_" + columnName, tableName, columnName, unique);
+        }
+
+        /// <summary>
+        /// Creates an index for the specified table and columns.
+        /// </summary>
+        /// <param name="tableName">Name of the database table</param>
+        /// <param name="columnNames">An array of column names to index</param>
+        /// <param name="unique">Whether the index should be unique</param>
+        /// <returns>Zero on success.</returns>
+        public int CreateIndex (string tableName, string[] columnNames, bool unique = false)
+        {
+            return CreateIndex (tableName + "_" + string.Join ("_", columnNames), tableName, columnNames, unique);
+        }
+
+        /// <summary>
+        /// Creates an index for the specified object property.
+        /// e.g. CreateIndex&lt;Client&gt;(c => c.Name);
+        /// </summary>
+        /// <typeparam name="T">Type to reflect to a database table.</typeparam>
+        /// <param name="property">Property to index</param>
+        /// <param name="unique">Whether the index should be unique</param>
+        /// <returns>Zero on success.</returns>
+        public int CreateIndex<T> (Expression<Func<T, object>> property, bool unique = false)
+        {
+            MemberExpression mx;
+            if (property.Body.NodeType == ExpressionType.Convert) {
+                mx = ((UnaryExpression)property.Body).Operand as MemberExpression;
+            }
+            else {
+                mx = (property.Body as MemberExpression);
+            }
+            var propertyInfo = mx.Member as PropertyInfo;
+            if (propertyInfo == null) {
+                throw new ArgumentException ("The lambda expression 'property' should point to a valid Property");
+            }
+
+            var propName = propertyInfo.Name;
+
+            var map = GetMapping<T> ();
+            var colName = map.FindColumnWithPropertyName (propName).Name;
+
+            return CreateIndex (map.TableName, colName, unique);
+        }
+
+        [Preserve (AllMembers = true)]
+        public class ColumnInfo
+        {
+            //			public int cid { get; set; }
+
+            [Column ("name")]
+            public string Name { get; set; }
+
+            //			[Column ("type")]
+            //			public string ColumnType { get; set; }
+
+            public int notnull { get; set; }
+
+            //			public string dflt_value { get; set; }
+
+            //			public int pk { get; set; }
+
+            public override string ToString ()
+            {
+                return Name;
+            }
+        }
+
+        /// <summary>
+        /// Query the built-in sqlite table_info table for a specific tables columns.
+        /// </summary>
+        /// <returns>The columns contains in the table.</returns>
+        /// <param name="tableName">Table name.</param>
+        public List<ColumnInfo> GetTableInfo (string tableName)
+        {
+            var query = "pragma table_info(\"" + tableName + "\")";
+            return Query<ColumnInfo> (query);
+        }
+
+        void MigrateTable (TableMapping map, List<ColumnInfo> existingCols)
+        {
+            var toBeAdded = new List<TableMapping.Column> ();
+
+            foreach (var p in map.Columns) {
+                var found = false;
+                foreach (var c in existingCols) {
+                    found = (string.Compare (p.Name, c.Name, StringComparison.OrdinalIgnoreCase) == 0);
+                    if (found)
+                        break;
+                }
+                if (!found) {
+                    toBeAdded.Add (p);
+                }
+            }
+
+            foreach (var p in toBeAdded) {
+                var addCol = "alter table \"" + map.TableName + "\" add column " + Orm.SqlDecl (p, StoreDateTimeAsTicks, StoreTimeSpanAsTicks);
+                Execute (addCol);
+            }
+        }
+
+        /// <summary>
+        /// Creates a new SQLiteCommand. Can be overridden to provide a sub-class.
+        /// </summary>
+        /// <seealso cref="SQLiteCommand.OnInstanceCreated"/>
+        protected virtual SQLiteCommand NewCommand ()
+        {
+            return new SQLiteCommand (this);
+        }
+
+        /// <summary>
+        /// Creates a new SQLiteCommand given the command text with arguments. Place a '?'
+        /// in the command text for each of the arguments.
+        /// </summary>
+        /// <param name="cmdText">
+        /// The fully escaped SQL.
+        /// </param>
+        /// <param name="ps">
+        /// Arguments to substitute for the occurences of '?' in the command text.
+        /// </param>
+        /// <returns>
+        /// A <see cref="SQLiteCommand"/>
+        /// </returns>
+        public SQLiteCommand CreateCommand (string cmdText, params object[] ps)
+        {
+            if (!_open)
+                throw SQLiteException.New (SQLite3.Result.Error, "Cannot create commands from unopened database");
+
+            var cmd = NewCommand ();
+            cmd.CommandText = cmdText;
+            foreach (var o in ps) {
+                cmd.Bind (o);
+            }
+            return cmd;
+        }
+
+        /// <summary>
+        /// Creates a new SQLiteCommand given the command text with named arguments. Place a "[@:$]VVV"
+        /// in the command text for each of the arguments. VVV represents an alphanumeric identifier.
+        /// For example, @name :name and $name can all be used in the query.
+        /// </summary>
+        /// <param name="cmdText">
+        /// The fully escaped SQL.
+        /// </param>
+        /// <param name="args">
+        /// Arguments to substitute for the occurences of "[@:$]VVV" in the command text.
+        /// </param>
+        /// <returns>
+        /// A <see cref="SQLiteCommand" />
+        /// </returns>
+        public SQLiteCommand CreateCommand (string cmdText, Dictionary<string, object> args)
+        {
+            if (!_open)
+                throw SQLiteException.New (SQLite3.Result.Error, "Cannot create commands from unopened database");
+
+            SQLiteCommand cmd = NewCommand ();
+            cmd.CommandText = cmdText;
+            foreach (var kv in args) {
+                cmd.Bind (kv.Key, kv.Value);
+            }
+            return cmd;
+        }
+
+        /// <summary>
+        /// Creates a SQLiteCommand given the command text (SQL) with arguments. Place a '?'
+        /// in the command text for each of the arguments and then executes that command.
+        /// Use this method instead of Query when you don't expect rows back. Such cases include
+        /// INSERTs, UPDATEs, and DELETEs.
+        /// You can set the Trace or TimeExecution properties of the connection
+        /// to profile execution.
+        /// </summary>
+        /// <param name="query">
+        /// The fully escaped SQL.
+        /// </param>
+        /// <param name="args">
+        /// Arguments to substitute for the occurences of '?' in the query.
+        /// </param>
+        /// <returns>
+        /// The number of rows modified in the database as a result of this execution.
+        /// </returns>
+        public int Execute (string query, params object[] args)
+        {
+            var cmd = CreateCommand (query, args);
+
+            if (TimeExecution) {
+                if (_sw == null) {
+                    _sw = new Stopwatch ();
+                }
+                _sw.Reset ();
+                _sw.Start ();
+            }
+
+            var r = cmd.ExecuteNonQuery ();
+
+            if (TimeExecution) {
+                _sw.Stop ();
+                _elapsedMilliseconds += _sw.ElapsedMilliseconds;
+                Tracer?.Invoke (string.Format ("Finished in {0} ms ({1:0.0} s total)", _sw.ElapsedMilliseconds, _elapsedMilliseconds / 1000.0));
+            }
+
+            return r;
+        }
+
+        /// <summary>
+        /// Creates a SQLiteCommand given the command text (SQL) with arguments. Place a '?'
+        /// in the command text for each of the arguments and then executes that command.
+        /// Use this method when return primitive values.
+        /// You can set the Trace or TimeExecution properties of the connection
+        /// to profile execution.
+        /// </summary>
+        /// <param name="query">
+        /// The fully escaped SQL.
+        /// </param>
+        /// <param name="args">
+        /// Arguments to substitute for the occurences of '?' in the query.
+        /// </param>
+        /// <returns>
+        /// The number of rows modified in the database as a result of this execution.
+        /// </returns>
+        public T ExecuteScalar<T> (string query, params object[] args)
+        {
+            var cmd = CreateCommand (query, args);
+
+            if (TimeExecution) {
+                if (_sw == null) {
+                    _sw = new Stopwatch ();
+                }
+                _sw.Reset ();
+                _sw.Start ();
+            }
+
+            var r = cmd.ExecuteScalar<T> ();
+
+            if (TimeExecution) {
+                _sw.Stop ();
+                _elapsedMilliseconds += _sw.ElapsedMilliseconds;
+                Tracer?.Invoke (string.Format ("Finished in {0} ms ({1:0.0} s total)", _sw.ElapsedMilliseconds, _elapsedMilliseconds / 1000.0));
+            }
+
+            return r;
+        }
+
+        /// <summary>
+        /// Creates a SQLiteCommand given the command text (SQL) with arguments. Place a '?'
+        /// in the command text for each of the arguments and then executes that command.
+        /// It returns each row of the result using the mapping automatically generated for
+        /// the given type.
+        /// </summary>
+        /// <param name="query">
+        /// The fully escaped SQL.
+        /// </param>
+        /// <param name="args">
+        /// Arguments to substitute for the occurences of '?' in the query.
+        /// </param>
+        /// <returns>
+        /// An enumerable with one result for each row returned by the query.
+        /// </returns>
+        public List<T> Query<T> (string query, params object[] args) where T : new()
+        {
+            var cmd = CreateCommand (query, args);
+            return cmd.ExecuteQuery<T> ();
+        }
+
+        /// <summary>
+        /// Creates a SQLiteCommand given the command text (SQL) with arguments. Place a '?'
+        /// in the command text for each of the arguments and then executes that command.
+        /// It returns the first column of each row of the result.
+        /// </summary>
+        /// <param name="query">
+        /// The fully escaped SQL.
+        /// </param>
+        /// <param name="args">
+        /// Arguments to substitute for the occurences of '?' in the query.
+        /// </param>
+        /// <returns>
+        /// An enumerable with one result for the first column of each row returned by the query.
+        /// </returns>
+        public List<T> QueryScalars<T> (string query, params object[] args)
+        {
+            var cmd = CreateCommand (query, args);
+            return cmd.ExecuteQueryScalars<T> ().ToList ();
+        }
+
+        /// <summary>
+        /// Creates a SQLiteCommand given the command text (SQL) with arguments. Place a '?'
+        /// in the command text for each of the arguments and then executes that command.
+        /// It returns each row of the result using the mapping automatically generated for
+        /// the given type.
+        /// </summary>
+        /// <param name="query">
+        /// The fully escaped SQL.
+        /// </param>
+        /// <param name="args">
+        /// Arguments to substitute for the occurences of '?' in the query.
+        /// </param>
+        /// <returns>
+        /// An enumerable with one result for each row returned by the query.
+        /// The enumerator (retrieved by calling GetEnumerator() on the result of this method)
+        /// will call sqlite3_step on each call to MoveNext, so the database
+        /// connection must remain open for the lifetime of the enumerator.
+        /// </returns>
+        public IEnumerable<T> DeferredQuery<T> (string query, params object[] args) where T : new()
+        {
+            var cmd = CreateCommand (query, args);
+            return cmd.ExecuteDeferredQuery<T> ();
+        }
+
+        /// <summary>
+        /// Creates a SQLiteCommand given the command text (SQL) with arguments. Place a '?'
+        /// in the command text for each of the arguments and then executes that command.
+        /// It returns each row of the result using the specified mapping. This function is
+        /// only used by libraries in order to query the database via introspection. It is
+        /// normally not used.
+        /// </summary>
+        /// <param name="map">
+        /// A <see cref="TableMapping"/> to use to convert the resulting rows
+        /// into objects.
+        /// </param>
+        /// <param name="query">
+        /// The fully escaped SQL.
+        /// </param>
+        /// <param name="args">
+        /// Arguments to substitute for the occurences of '?' in the query.
+        /// </param>
+        /// <returns>
+        /// An enumerable with one result for each row returned by the query.
+        /// </returns>
+        public List<object> Query (TableMapping map, string query, params object[] args)
+        {
+            var cmd = CreateCommand (query, args);
+            return cmd.ExecuteQuery<object> (map);
+        }
+
+        /// <summary>
+        /// Creates a SQLiteCommand given the command text (SQL) with arguments. Place a '?'
+        /// in the command text for each of the arguments and then executes that command.
+        /// It returns each row of the result using the specified mapping. This function is
+        /// only used by libraries in order to query the database via introspection. It is
+        /// normally not used.
+        /// </summary>
+        /// <param name="map">
+        /// A <see cref="TableMapping"/> to use to convert the resulting rows
+        /// into objects.
+        /// </param>
+        /// <param name="query">
+        /// The fully escaped SQL.
+        /// </param>
+        /// <param name="args">
+        /// Arguments to substitute for the occurences of '?' in the query.
+        /// </param>
+        /// <returns>
+        /// An enumerable with one result for each row returned by the query.
+        /// The enumerator (retrieved by calling GetEnumerator() on the result of this method)
+        /// will call sqlite3_step on each call to MoveNext, so the database
+        /// connection must remain open for the lifetime of the enumerator.
+        /// </returns>
+        public IEnumerable<object> DeferredQuery (TableMapping map, string query, params object[] args)
+        {
+            var cmd = CreateCommand (query, args);
+            return cmd.ExecuteDeferredQuery<object> (map);
+        }
+
+        /// <summary>
+        /// Returns a queryable interface to the table represented by the given type.
+        /// </summary>
+        /// <returns>
+        /// A queryable object that is able to translate Where, OrderBy, and Take
+        /// queries into native SQL.
+        /// </returns>
+        public TableQuery<T> Table<T> () where T : new()
+        {
+            return new TableQuery<T> (this);
+        }
+
+        /// <summary>
+        /// Attempts to retrieve an object with the given primary key from the table
+        /// associated with the specified type. Use of this method requires that
+        /// the given type have a designated PrimaryKey (using the PrimaryKeyAttribute).
+        /// </summary>
+        /// <param name="pk">
+        /// The primary key.
+        /// </param>
+        /// <returns>
+        /// The object with the given primary key. Throws a not found exception
+        /// if the object is not found.
+        /// </returns>
+        public T Get<T> (object pk) where T : new()
+        {
+            var map = GetMapping (typeof (T));
+            return Query<T> (map.GetByPrimaryKeySql, pk).First ();
+        }
+
+        /// <summary>
+        /// Attempts to retrieve an object with the given primary key from the table
+        /// associated with the specified type. Use of this method requires that
+        /// the given type have a designated PrimaryKey (using the PrimaryKeyAttribute).
+        /// </summary>
+        /// <param name="pk">
+        /// The primary key.
+        /// </param>
+        /// <param name="map">
+        /// The TableMapping used to identify the table.
+        /// </param>
+        /// <returns>
+        /// The object with the given primary key. Throws a not found exception
+        /// if the object is not found.
+        /// </returns>
+        public object Get (object pk, TableMapping map)
+        {
+            return Query (map, map.GetByPrimaryKeySql, pk).First ();
+        }
+
+        /// <summary>
+        /// Attempts to retrieve the first object that matches the predicate from the table
+        /// associated with the specified type.
+        /// </summary>
+        /// <param name="predicate">
+        /// A predicate for which object to find.
+        /// </param>
+        /// <returns>
+        /// The object that matches the given predicate. Throws a not found exception
+        /// if the object is not found.
+        /// </returns>
+        public T Get<T> (Expression<Func<T, bool>> predicate) where T : new()
+        {
+            return Table<T> ().Where (predicate).First ();
+        }
+
+        /// <summary>
+        /// Attempts to retrieve an object with the given primary key from the table
+        /// associated with the specified type. Use of this method requires that
+        /// the given type have a designated PrimaryKey (using the PrimaryKeyAttribute).
+        /// </summary>
+        /// <param name="pk">
+        /// The primary key.
+        /// </param>
+        /// <returns>
+        /// The object with the given primary key or null
+        /// if the object is not found.
+        /// </returns>
+        public T Find<T> (object pk) where T : new()
+        {
+            var map = GetMapping (typeof (T));
+            return Query<T> (map.GetByPrimaryKeySql, pk).FirstOrDefault ();
+        }
+
+        /// <summary>
+        /// Attempts to retrieve an object with the given primary key from the table
+        /// associated with the specified type. Use of this method requires that
+        /// the given type have a designated PrimaryKey (using the PrimaryKeyAttribute).
+        /// </summary>
+        /// <param name="pk">
+        /// The primary key.
+        /// </param>
+        /// <param name="map">
+        /// The TableMapping used to identify the table.
+        /// </param>
+        /// <returns>
+        /// The object with the given primary key or null
+        /// if the object is not found.
+        /// </returns>
+        public object Find (object pk, TableMapping map)
+        {
+            return Query (map, map.GetByPrimaryKeySql, pk).FirstOrDefault ();
+        }
+
+        /// <summary>
+        /// Attempts to retrieve the first object that matches the predicate from the table
+        /// associated with the specified type.
+        /// </summary>
+        /// <param name="predicate">
+        /// A predicate for which object to find.
+        /// </param>
+        /// <returns>
+        /// The object that matches the given predicate or null
+        /// if the object is not found.
+        /// </returns>
+        public T Find<T> (Expression<Func<T, bool>> predicate) where T : new()
+        {
+            return Table<T> ().Where (predicate).FirstOrDefault ();
+        }
+
+        /// <summary>
+        /// Attempts to retrieve the first object that matches the query from the table
+        /// associated with the specified type.
+        /// </summary>
+        /// <param name="query">
+        /// The fully escaped SQL.
+        /// </param>
+        /// <param name="args">
+        /// Arguments to substitute for the occurences of '?' in the query.
+        /// </param>
+        /// <returns>
+        /// The object that matches the given predicate or null
+        /// if the object is not found.
+        /// </returns>
+        public T FindWithQuery<T> (string query, params object[] args) where T : new()
+        {
+            return Query<T> (query, args).FirstOrDefault ();
+        }
+
+        /// <summary>
+        /// Attempts to retrieve the first object that matches the query from the table
+        /// associated with the specified type.
+        /// </summary>
+        /// <param name="map">
+        /// The TableMapping used to identify the table.
+        /// </param>
+        /// <param name="query">
+        /// The fully escaped SQL.
+        /// </param>
+        /// <param name="args">
+        /// Arguments to substitute for the occurences of '?' in the query.
+        /// </param>
+        /// <returns>
+        /// The object that matches the given predicate or null
+        /// if the object is not found.
+        /// </returns>
+        public object FindWithQuery (TableMapping map, string query, params object[] args)
+        {
+            return Query (map, query, args).FirstOrDefault ();
+        }
+
+        /// <summary>
+        /// Whether <see cref="BeginTransaction"/> has been called and the database is waiting for a <see cref="Commit"/>.
+        /// </summary>
+        public bool IsInTransaction {
+            get { return _transactionDepth > 0; }
+        }
+
+        /// <summary>
+        /// Begins a new transaction. Call <see cref="Commit"/> to end the transaction.
+        /// </summary>
+        /// <example cref="System.InvalidOperationException">Throws if a transaction has already begun.</example>
+        public void BeginTransaction ()
+        {
+            // The BEGIN command only works if the transaction stack is empty,
+            //    or in other words if there are no pending transactions.
+            // If the transaction stack is not empty when the BEGIN command is invoked,
+            //    then the command fails with an error.
+            // Rather than crash with an error, we will just ignore calls to BeginTransaction
+            //    that would result in an error.
+            if (Interlocked.CompareExchange (ref _transactionDepth, 1, 0) == 0) {
+                try {
+                    Execute ("begin transaction");
+                }
+                catch (Exception ex) {
+                    var sqlExp = ex as SQLiteException;
+                    if (sqlExp != null) {
+                        // It is recommended that applications respond to the errors listed below
+                        //    by explicitly issuing a ROLLBACK command.
+                        // TODO: This rollback failsafe should be localized to all throw sites.
+                        switch (sqlExp.Result) {
+                            case SQLite3.Result.IOError:
+                            case SQLite3.Result.Full:
+                            case SQLite3.Result.Busy:
+                            case SQLite3.Result.NoMem:
+                            case SQLite3.Result.Interrupt:
+                                RollbackTo (null, true);
+                                break;
+                        }
+                    }
+                    else {
+                        // Call decrement and not VolatileWrite in case we've already
+                        //    created a transaction point in SaveTransactionPoint since the catch.
+                        Interlocked.Decrement (ref _transactionDepth);
+                    }
+
+                    throw;
+                }
+            }
+            else {
+                // Calling BeginTransaction on an already open transaction is invalid
+                throw new InvalidOperationException ("Cannot begin a transaction while already in a transaction.");
+            }
+        }
+
+        /// <summary>
+        /// Creates a savepoint in the database at the current point in the transaction timeline.
+        /// Begins a new transaction if one is not in progress.
+        ///
+        /// Call <see cref="RollbackTo(string)"/> to undo transactions since the returned savepoint.
+        /// Call <see cref="Release"/> to commit transactions after the savepoint returned here.
+        /// Call <see cref="Commit"/> to end the transaction, committing all changes.
+        /// </summary>
+        /// <returns>A string naming the savepoint.</returns>
+        public string SaveTransactionPoint ()
+        {
+            int depth = Interlocked.Increment (ref _transactionDepth) - 1;
+            string retVal = "S" + _rand.Next (short.MaxValue) + "D" + depth;
+
+            try {
+                Execute ("savepoint " + retVal);
+            }
+            catch (Exception ex) {
+                var sqlExp = ex as SQLiteException;
+                if (sqlExp != null) {
+                    // It is recommended that applications respond to the errors listed below
+                    //    by explicitly issuing a ROLLBACK command.
+                    // TODO: This rollback failsafe should be localized to all throw sites.
+                    switch (sqlExp.Result) {
+                        case SQLite3.Result.IOError:
+                        case SQLite3.Result.Full:
+                        case SQLite3.Result.Busy:
+                        case SQLite3.Result.NoMem:
+                        case SQLite3.Result.Interrupt:
+                            RollbackTo (null, true);
+                            break;
+                    }
+                }
+                else {
+                    Interlocked.Decrement (ref _transactionDepth);
+                }
+
+                throw;
+            }
+
+            return retVal;
+        }
+
+        /// <summary>
+        /// Rolls back the transaction that was begun by <see cref="BeginTransaction"/> or <see cref="SaveTransactionPoint"/>.
+        /// </summary>
+        public void Rollback ()
+        {
+            RollbackTo (null, false);
+        }
+
+        /// <summary>
+        /// Rolls back the savepoint created by <see cref="BeginTransaction"/> or SaveTransactionPoint.
+        /// </summary>
+        /// <param name="savepoint">The name of the savepoint to roll back to, as returned by <see cref="SaveTransactionPoint"/>.  If savepoint is null or empty, this method is equivalent to a call to <see cref="Rollback"/></param>
+        public void RollbackTo (string savepoint)
+        {
+            RollbackTo (savepoint, false);
+        }
+
+        /// <summary>
+        /// Rolls back the transaction that was begun by <see cref="BeginTransaction"/>.
+        /// </summary>
+        /// <param name="savepoint">The name of the savepoint to roll back to, as returned by <see cref="SaveTransactionPoint"/>.  If savepoint is null or empty, this method is equivalent to a call to <see cref="Rollback"/></param>
+        /// <param name="noThrow">true to avoid throwing exceptions, false otherwise</param>
+        void RollbackTo (string savepoint, bool noThrow)
+        {
+            // Rolling back without a TO clause rolls backs all transactions
+            //    and leaves the transaction stack empty.
+            try {
+                if (String.IsNullOrEmpty (savepoint)) {
+                    if (Interlocked.Exchange (ref _transactionDepth, 0) > 0) {
+                        Execute ("rollback");
+                    }
+                }
+                else {
+                    DoSavePointExecute (savepoint, "rollback to ");
+                }
+            }
+            catch (SQLiteException) {
+                if (!noThrow)
+                    throw;
+
+            }
+            // No need to rollback if there are no transactions open.
+        }
+
+        /// <summary>
+        /// Releases a savepoint returned from <see cref="SaveTransactionPoint"/>.  Releasing a savepoint
+        ///    makes changes since that savepoint permanent if the savepoint began the transaction,
+        ///    or otherwise the changes are permanent pending a call to <see cref="Commit"/>.
+        ///
+        /// The RELEASE command is like a COMMIT for a SAVEPOINT.
+        /// </summary>
+        /// <param name="savepoint">The name of the savepoint to release.  The string should be the result of a call to <see cref="SaveTransactionPoint"/></param>
+        public void Release (string savepoint)
+        {
+            try {
+                DoSavePointExecute (savepoint, "release ");
+            }
+            catch (SQLiteException ex) {
+                if (ex.Result == SQLite3.Result.Busy) {
+                    // Force a rollback since most people don't know this function can fail
+                    // Don't call Rollback() since the _transactionDepth is 0 and it won't try
+                    // Calling rollback makes our _transactionDepth variable correct.
+                    // Writes to the database only happen at depth=0, so this failure will only happen then.
+                    try {
+                        Execute ("rollback");
+                    }
+                    catch {
+                        // rollback can fail in all sorts of wonderful version-dependent ways. Let's just hope for the best
+                    }
+                }
+                throw;
+            }
+        }
+
+        void DoSavePointExecute (string savepoint, string cmd)
+        {
+            // Validate the savepoint
+            int firstLen = savepoint.IndexOf ('D');
+            if (firstLen >= 2 && savepoint.Length > firstLen + 1) {
+                int depth;
+                if (Int32.TryParse (savepoint.Substring (firstLen + 1), out depth)) {
+                    // TODO: Mild race here, but inescapable without locking almost everywhere.
+                    if (0 <= depth && depth < _transactionDepth) {
 #if NETFX_CORE || USE_SQLITEPCL_RAW || NETCORE
-						Volatile.Write (ref _transactionDepth, depth);
+                        Volatile.Write (ref _transactionDepth, depth);
 #elif SILVERLIGHT
-						_transactionDepth = depth;
+                        _transactionDepth = depth;
 #else
                         Thread.VolatileWrite (ref _transactionDepth, depth);
 #endif
-						Execute (cmd + savepoint);
-						return;
-					}
-				}
-			}
-
-			throw new ArgumentException ("savePoint is not valid, and should be the result of a call to SaveTransactionPoint.", "savePoint");
-		}
-
-		/// <summary>
-		/// Commits the transaction that was begun by <see cref="BeginTransaction"/>.
-		/// </summary>
-		public void Commit ()
-		{
-			if (Interlocked.Exchange (ref _transactionDepth, 0) != 0) {
-				try {
-					Execute ("commit");
-				}
-				catch {
-					// Force a rollback since most people don't know this function can fail
-					// Don't call Rollback() since the _transactionDepth is 0 and it won't try
-					// Calling rollback makes our _transactionDepth variable correct.
-					try {
-						Execute ("rollback");
-					}
-					catch {
-						// rollback can fail in all sorts of wonderful version-dependent ways. Let's just hope for the best
-					}
-					throw;
-				}
-			}
-			// Do nothing on a commit with no open transaction
-		}
-
-		/// <summary>
-		/// Executes <paramref name="action"/> within a (possibly nested) transaction by wrapping it in a SAVEPOINT. If an
-		/// exception occurs the whole transaction is rolled back, not just the current savepoint. The exception
-		/// is rethrown.
-		/// </summary>
-		/// <param name="action">
-		/// The <see cref="Action"/> to perform within a transaction. <paramref name="action"/> can contain any number
-		/// of operations on the connection but should never call <see cref="BeginTransaction"/> or
-		/// <see cref="Commit"/>.
-		/// </param>
-		public void RunInTransaction (Action action)
-		{
-			try {
-				var savePoint = SaveTransactionPoint ();
-				action ();
-				Release (savePoint);
-			}
-			catch (Exception) {
-				Rollback ();
-				throw;
-			}
-		}
-
-		/// <summary>
-		/// Inserts all specified objects.
-		/// </summary>
-		/// <param name="objects">
-		/// An <see cref="IEnumerable"/> of the objects to insert.
-		/// <param name="runInTransaction"/>
-		/// A boolean indicating if the inserts should be wrapped in a transaction.
-		/// </param>
-		/// <returns>
-		/// The number of rows added to the table.
-		/// </returns>
-		public int InsertAll (System.Collections.IEnumerable objects, bool runInTransaction = true)
-		{
-			var c = 0;
-			if (runInTransaction) {
-				RunInTransaction (() => {
-					foreach (var r in objects) {
-						c += Insert (r);
-					}
-				});
-			}
-			else {
-				foreach (var r in objects) {
-					c += Insert (r);
-				}
-			}
-			return c;
-		}
-
-		/// <summary>
-		/// Inserts all specified objects.
-		/// </summary>
-		/// <param name="objects">
-		/// An <see cref="IEnumerable"/> of the objects to insert.
-		/// </param>
-		/// <param name="extra">
-		/// Literal SQL code that gets placed into the command. INSERT {extra} INTO ...
-		/// </param>
-		/// <param name="runInTransaction">
-		/// A boolean indicating if the inserts should be wrapped in a transaction.
-		/// </param>
-		/// <returns>
-		/// The number of rows added to the table.
-		/// </returns>
-		public int InsertAll (System.Collections.IEnumerable objects, string extra, bool runInTransaction = true)
-		{
-			var c = 0;
-			if (runInTransaction) {
-				RunInTransaction (() => {
-					foreach (var r in objects) {
-						c += Insert (r, extra);
-					}
-				});
-			}
-			else {
-				foreach (var r in objects) {
-					c += Insert (r, extra);
-				}
-			}
-			return c;
-		}
-
-		/// <summary>
-		/// Inserts all specified objects.
-		/// </summary>
-		/// <param name="objects">
-		/// An <see cref="IEnumerable"/> of the objects to insert.
-		/// </param>
-		/// <param name="objType">
-		/// The type of object to insert.
-		/// </param>
-		/// <param name="runInTransaction">
-		/// A boolean indicating if the inserts should be wrapped in a transaction.
-		/// </param>
-		/// <returns>
-		/// The number of rows added to the table.
-		/// </returns>
-		public int InsertAll (System.Collections.IEnumerable objects, Type objType, bool runInTransaction = true)
-		{
-			var c = 0;
-			if (runInTransaction) {
-				RunInTransaction (() => {
-					foreach (var r in objects) {
-						c += Insert (r, objType);
-					}
-				});
-			}
-			else {
-				foreach (var r in objects) {
-					c += Insert (r, objType);
-				}
-			}
-			return c;
-		}
-
-		/// <summary>
-		/// Inserts the given object (and updates its
-		/// auto incremented primary key if it has one).
-		/// The return value is the number of rows added to the table.
-		/// </summary>
-		/// <param name="obj">
-		/// The object to insert.
-		/// </param>
-		/// <returns>
-		/// The number of rows added to the table.
-		/// </returns>
-		public int Insert (object obj)
-		{
-			if (obj == null) {
-				return 0;
-			}
-			return Insert (obj, "", Orm.GetType (obj));
-		}
-
-		/// <summary>
-		/// Inserts the given object (and updates its
-		/// auto incremented primary key if it has one).
-		/// The return value is the number of rows added to the table.
-		/// If a UNIQUE constraint violation occurs with
-		/// some pre-existing object, this function deletes
-		/// the old object.
-		/// </summary>
-		/// <param name="obj">
-		/// The object to insert.
-		/// </param>
-		/// <returns>
-		/// The number of rows modified.
-		/// </returns>
-		public int InsertOrReplace (object obj)
-		{
-			if (obj == null) {
-				return 0;
-			}
-			return Insert (obj, "OR REPLACE", Orm.GetType (obj));
-		}
-
-		/// <summary>
-		/// Inserts the given object (and updates its
-		/// auto incremented primary key if it has one).
-		/// The return value is the number of rows added to the table.
-		/// </summary>
-		/// <param name="obj">
-		/// The object to insert.
-		/// </param>
-		/// <param name="objType">
-		/// The type of object to insert.
-		/// </param>
-		/// <returns>
-		/// The number of rows added to the table.
-		/// </returns>
-		public int Insert (object obj, Type objType)
-		{
-			return Insert (obj, "", objType);
-		}
-
-		/// <summary>
-		/// Inserts the given object (and updates its
-		/// auto incremented primary key if it has one).
-		/// The return value is the number of rows added to the table.
-		/// If a UNIQUE constraint violation occurs with
-		/// some pre-existing object, this function deletes
-		/// the old object.
-		/// </summary>
-		/// <param name="obj">
-		/// The object to insert.
-		/// </param>
-		/// <param name="objType">
-		/// The type of object to insert.
-		/// </param>
-		/// <returns>
-		/// The number of rows modified.
-		/// </returns>
-		public int InsertOrReplace (object obj, Type objType)
-		{
-			return Insert (obj, "OR REPLACE", objType);
-		}
-
-		/// <summary>
-		/// Inserts the given object (and updates its
-		/// auto incremented primary key if it has one).
-		/// The return value is the number of rows added to the table.
-		/// </summary>
-		/// <param name="obj">
-		/// The object to insert.
-		/// </param>
-		/// <param name="extra">
-		/// Literal SQL code that gets placed into the command. INSERT {extra} INTO ...
-		/// </param>
-		/// <returns>
-		/// The number of rows added to the table.
-		/// </returns>
-		public int Insert (object obj, string extra)
-		{
-			if (obj == null) {
-				return 0;
-			}
-			return Insert (obj, extra, Orm.GetType (obj));
-		}
-
-		/// <summary>
-		/// Inserts the given object (and updates its
-		/// auto incremented primary key if it has one).
-		/// The return value is the number of rows added to the table.
-		/// </summary>
-		/// <param name="obj">
-		/// The object to insert.
-		/// </param>
-		/// <param name="extra">
-		/// Literal SQL code that gets placed into the command. INSERT {extra} INTO ...
-		/// </param>
-		/// <param name="objType">
-		/// The type of object to insert.
-		/// </param>
-		/// <returns>
-		/// The number of rows added to the table.
-		/// </returns>
-		public int Insert (object obj, string extra, Type objType)
-		{
-			if (obj == null || objType == null) {
-				return 0;
-			}
-
-			var map = GetMapping (objType);
-
-			if (map.PK != null && map.PK.IsAutoGuid) {
-				if (map.PK.GetValue (obj).Equals (Guid.Empty)) {
-					map.PK.SetValue (obj, Guid.NewGuid ());
-				}
-			}
-
-			var replacing = string.Compare (extra, "OR REPLACE", StringComparison.OrdinalIgnoreCase) == 0;
-
-			var cols = replacing ? map.InsertOrReplaceColumns : map.InsertColumns;
-			var vals = new object[cols.Length];
-			for (var i = 0; i < vals.Length; i++) {
-				vals[i] = cols[i].GetValue (obj);
-			}
-
-			var insertCmd = GetInsertCommand (map, extra);
-			int count;
-
-			lock (insertCmd) {
-				// We lock here to protect the prepared statement returned via GetInsertCommand.
-				// A SQLite prepared statement can be bound for only one operation at a time.
-				try {
-					count = insertCmd.ExecuteNonQuery (vals);
-				}
-				catch (SQLiteException ex) {
-					if (SQLite3.ExtendedErrCode (this.Handle) == SQLite3.ExtendedResult.ConstraintNotNull) {
-						throw NotNullConstraintViolationException.New (ex.Result, ex.Message, map, obj);
-					}
-					throw;
-				}
-
-				if (map.HasAutoIncPK) {
-					var id = SQLite3.LastInsertRowid (Handle);
-					map.SetAutoIncPK (obj, id);
-				}
-			}
-			if (count > 0)
-				OnTableChanged (map, NotifyTableChangedAction.Insert);
-
-			return count;
-		}
-
-		readonly Dictionary<Tuple<string, string>, PreparedSqlLiteInsertCommand> _insertCommandMap = new Dictionary<Tuple<string, string>, PreparedSqlLiteInsertCommand> ();
-
-		PreparedSqlLiteInsertCommand GetInsertCommand (TableMapping map, string extra)
-		{
-			PreparedSqlLiteInsertCommand prepCmd;
-
-			var key = Tuple.Create (map.MappedType.FullName, extra);
-
-			lock (_insertCommandMap) {
-				if (_insertCommandMap.TryGetValue (key, out prepCmd)) {
-					return prepCmd;
-				}
-			}
-
-			prepCmd = CreateInsertCommand (map, extra);
-
-			lock (_insertCommandMap) {
-				if (_insertCommandMap.TryGetValue (key, out var existing)) {
-					prepCmd.Dispose ();
-					return existing;
-				}
-
-				_insertCommandMap.Add (key, prepCmd);
-			}
-
-			return prepCmd;
-		}
-
-		PreparedSqlLiteInsertCommand CreateInsertCommand (TableMapping map, string extra)
-		{
-			var cols = map.InsertColumns;
-			string insertSql;
-			if (cols.Length == 0 && map.Columns.Length == 1 && map.Columns[0].IsAutoInc) {
-				insertSql = string.Format ("insert {1} into \"{0}\" default values", map.TableName, extra);
-			}
-			else {
-				var replacing = string.Compare (extra, "OR REPLACE", StringComparison.OrdinalIgnoreCase) == 0;
-
-				if (replacing) {
-					cols = map.InsertOrReplaceColumns;
-				}
-
-				insertSql = string.Format ("insert {3} into \"{0}\"({1}) values ({2})", map.TableName,
-								   string.Join (",", (from c in cols
-													  select "\"" + c.Name + "\"").ToArray ()),
-								   string.Join (",", (from c in cols
-													  select "?").ToArray ()), extra);
-
-			}
-
-			var insertCommand = new PreparedSqlLiteInsertCommand (this, insertSql);
-			return insertCommand;
-		}
-
-		/// <summary>
-		/// Updates all of the columns of a table using the specified object
-		/// except for its primary key.
-		/// The object is required to have a primary key.
-		/// </summary>
-		/// <param name="obj">
-		/// The object to update. It must have a primary key designated using the PrimaryKeyAttribute.
-		/// </param>
-		/// <returns>
-		/// The number of rows updated.
-		/// </returns>
-		public int Update (object obj)
-		{
-			if (obj == null) {
-				return 0;
-			}
-			return Update (obj, Orm.GetType (obj));
-		}
-
-		/// <summary>
-		/// Updates all of the columns of a table using the specified object
-		/// except for its primary key.
-		/// The object is required to have a primary key.
-		/// </summary>
-		/// <param name="obj">
-		/// The object to update. It must have a primary key designated using the PrimaryKeyAttribute.
-		/// </param>
-		/// <param name="objType">
-		/// The type of object to insert.
-		/// </param>
-		/// <returns>
-		/// The number of rows updated.
-		/// </returns>
-		public int Update (object obj, Type objType)
-		{
-			int rowsAffected = 0;
-			if (obj == null || objType == null) {
-				return 0;
-			}
-
-			var map = GetMapping (objType);
-
-			var pk = map.PK;
-
-			if (pk == null) {
-				throw new NotSupportedException ("Cannot update " + map.TableName + ": it has no PK");
-			}
-
-			var cols = from p in map.Columns
-					   where p != pk
-					   select p;
-			var vals = from c in cols
-					   select c.GetValue (obj);
-			var ps = new List<object> (vals);
-			if (ps.Count == 0) {
-				// There is a PK but no accompanying data,
-				// so reset the PK to make the UPDATE work.
-				cols = map.Columns;
-				vals = from c in cols
-					   select c.GetValue (obj);
-				ps = new List<object> (vals);
-			}
-			ps.Add (pk.GetValue (obj));
-			var q = string.Format ("update \"{0}\" set {1} where \"{2}\" = ? ", map.TableName, string.Join (",", (from c in cols
-																												  select "\"" + c.Name + "\" = ? ").ToArray ()), pk.Name);
-
-			try {
-				rowsAffected = Execute (q, ps.ToArray ());
-			}
-			catch (SQLiteException ex) {
-
-				if (ex.Result == SQLite3.Result.Constraint && SQLite3.ExtendedErrCode (this.Handle) == SQLite3.ExtendedResult.ConstraintNotNull) {
-					throw NotNullConstraintViolationException.New (ex, map, obj);
-				}
-
-				throw;
-			}
-
-			if (rowsAffected > 0)
-				OnTableChanged (map, NotifyTableChangedAction.Update);
-
-			return rowsAffected;
-		}
-
-		/// <summary>
-		/// Updates all specified objects.
-		/// </summary>
-		/// <param name="objects">
-		/// An <see cref="IEnumerable"/> of the objects to insert.
-		/// </param>
-		/// <param name="runInTransaction">
-		/// A boolean indicating if the inserts should be wrapped in a transaction
-		/// </param>
-		/// <returns>
-		/// The number of rows modified.
-		/// </returns>
-		public int UpdateAll (System.Collections.IEnumerable objects, bool runInTransaction = true)
-		{
-			var c = 0;
-			if (runInTransaction) {
-				RunInTransaction (() => {
-					foreach (var r in objects) {
-						c += Update (r);
-					}
-				});
-			}
-			else {
-				foreach (var r in objects) {
-					c += Update (r);
-				}
-			}
-			return c;
-		}
-
-		/// <summary>
-		/// Deletes the given object from the database using its primary key.
-		/// </summary>
-		/// <param name="objectToDelete">
-		/// The object to delete. It must have a primary key designated using the PrimaryKeyAttribute.
-		/// </param>
-		/// <returns>
-		/// The number of rows deleted.
-		/// </returns>
-		public int Delete (object objectToDelete)
-		{
-			var map = GetMapping (Orm.GetType (objectToDelete));
-			var pk = map.PK;
-			if (pk == null) {
-				throw new NotSupportedException ("Cannot delete " + map.TableName + ": it has no PK");
-			}
-			var q = string.Format ("delete from \"{0}\" where \"{1}\" = ?", map.TableName, pk.Name);
-			var count = Execute (q, pk.GetValue (objectToDelete));
-			if (count > 0)
-				OnTableChanged (map, NotifyTableChangedAction.Delete);
-			return count;
-		}
-
-		/// <summary>
-		/// Deletes the object with the specified primary key.
-		/// </summary>
-		/// <param name="primaryKey">
-		/// The primary key of the object to delete.
-		/// </param>
-		/// <returns>
-		/// The number of objects deleted.
-		/// </returns>
-		/// <typeparam name='T'>
-		/// The type of object.
-		/// </typeparam>
-		public int Delete<T> (object primaryKey)
-		{
-			return Delete (primaryKey, GetMapping (typeof (T)));
-		}
-
-		/// <summary>
-		/// Deletes the object with the specified primary key.
-		/// </summary>
-		/// <param name="primaryKey">
-		/// The primary key of the object to delete.
-		/// </param>
-		/// <param name="map">
-		/// The TableMapping used to identify the table.
-		/// </param>
-		/// <returns>
-		/// The number of objects deleted.
-		/// </returns>
-		public int Delete (object primaryKey, TableMapping map)
-		{
-			var pk = map.PK;
-			if (pk == null) {
-				throw new NotSupportedException ("Cannot delete " + map.TableName + ": it has no PK");
-			}
-			var q = string.Format ("delete from \"{0}\" where \"{1}\" = ?", map.TableName, pk.Name);
-			var count = Execute (q, primaryKey);
-			if (count > 0)
-				OnTableChanged (map, NotifyTableChangedAction.Delete);
-			return count;
-		}
-
-		/// <summary>
-		/// Deletes all the objects from the specified table.
-		/// WARNING WARNING: Let me repeat. It deletes ALL the objects from the
-		/// specified table. Do you really want to do that?
-		/// </summary>
-		/// <returns>
-		/// The number of objects deleted.
-		/// </returns>
-		/// <typeparam name='T'>
-		/// The type of objects to delete.
-		/// </typeparam>
-		public int DeleteAll<T> ()
-		{
-			var map = GetMapping (typeof (T));
-			return DeleteAll (map);
-		}
-
-		/// <summary>
-		/// Deletes all the objects from the specified table.
-		/// WARNING WARNING: Let me repeat. It deletes ALL the objects from the
-		/// specified table. Do you really want to do that?
-		/// </summary>
-		/// <param name="map">
-		/// The TableMapping used to identify the table.
-		/// </param>
-		/// <returns>
-		/// The number of objects deleted.
-		/// </returns>
-		public int DeleteAll (TableMapping map)
-		{
-			var query = string.Format ("delete from \"{0}\"", map.TableName);
-			var count = Execute (query);
-			if (count > 0)
-				OnTableChanged (map, NotifyTableChangedAction.Delete);
-			return count;
-		}
-
-		/// <summary>
-		/// Backup the entire database to the specified path.
-		/// </summary>
-		/// <param name="destinationDatabasePath">Path to backup file.</param>
-		/// <param name="databaseName">The name of the database to backup (usually "main").</param>
-		public void Backup (string destinationDatabasePath, string databaseName = "main")
-		{
-			// Open the destination
-			var r = SQLite3.Open (destinationDatabasePath, out var destHandle);
-			if (r != SQLite3.Result.OK) {
-				throw SQLiteException.New (r, "Failed to open destination database");
-			}
-
-			// Init the backup
-			var backup = SQLite3.BackupInit (destHandle, databaseName, Handle, databaseName);
-			if (backup == NullBackupHandle) {
-				SQLite3.Close (destHandle);
-				throw new Exception ("Failed to create backup");
-			}
-
-			// Perform it
-			SQLite3.BackupStep (backup, -1);
-			SQLite3.BackupFinish (backup);
-
-			// Check for errors
-			r = SQLite3.GetResult (destHandle);
-			string msg = "";
-			if (r != SQLite3.Result.OK) {
-				msg = SQLite3.GetErrmsg (destHandle);
-			}
-
-			// Close everything and report errors
-			SQLite3.Close (destHandle);
-			if (r != SQLite3.Result.OK) {
-				throw SQLiteException.New (r, msg);
-			}
-		}
-
-		~SQLiteConnection ()
-		{
-			Dispose (false);
-		}
-
-		public void Dispose ()
-		{
-			Dispose (true);
-			GC.SuppressFinalize (this);
-		}
-
-		public void Close ()
-		{
-			Dispose (true);
-		}
-
-		protected virtual void Dispose (bool disposing)
-		{
-			var useClose2 = LibVersionNumber >= 3007014;
-
-			if (_open && Handle != NullHandle) {
-				try {
-					if (disposing) {
-						lock (_insertCommandMap) {
-							foreach (var sqlInsertCommand in _insertCommandMap.Values) {
-								sqlInsertCommand.Dispose ();
-							}
-							_insertCommandMap.Clear ();
-						}
-
-						var r = useClose2 ? SQLite3.Close2 (Handle) : SQLite3.Close (Handle);
-						if (r != SQLite3.Result.OK) {
-							string msg = SQLite3.GetErrmsg (Handle);
-							throw SQLiteException.New (r, msg);
-						}
-					}
-					else {
-						var r = useClose2 ? SQLite3.Close2 (Handle) : SQLite3.Close (Handle);
-					}
-				}
-				finally {
-					Handle = NullHandle;
-					_open = false;
-				}
-			}
-		}
-
-		void OnTableChanged (TableMapping table, NotifyTableChangedAction action)
-		{
-			var ev = TableChanged;
-			if (ev != null)
-				ev (this, new NotifyTableChangedEventArgs (table, action));
-		}
-
-		public event EventHandler<NotifyTableChangedEventArgs> TableChanged;
-	}
-
-	public class NotifyTableChangedEventArgs : EventArgs
-	{
-		public TableMapping Table { get; private set; }
-		public NotifyTableChangedAction Action { get; private set; }
-
-		public NotifyTableChangedEventArgs (TableMapping table, NotifyTableChangedAction action)
-		{
-			Table = table;
-			Action = action;
-		}
-	}
-
-	public enum NotifyTableChangedAction
-	{
-		Insert,
-		Update,
-		Delete,
-	}
-
-	/// <summary>
-	/// Represents a parsed connection string.
-	/// </summary>
-	public class SQLiteConnectionString
-	{
-		const string DateTimeSqliteDefaultFormat = "yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fff";
-
-		public string UniqueKey { get; }
-		public string DatabasePath { get; }
-		public bool StoreDateTimeAsTicks { get; }
-		public bool StoreTimeSpanAsTicks { get; }
-		public string DateTimeStringFormat { get; }
-		public System.Globalization.DateTimeStyles DateTimeStyle { get; }
-		public object Key { get; }
-		public SQLiteOpenFlags OpenFlags { get; }
-		public Action<SQLiteConnection> PreKeyAction { get; }
-		public Action<SQLiteConnection> PostKeyAction { get; }
-		public string VfsName { get; }
+                        Execute (cmd + savepoint);
+                        return;
+                    }
+                }
+            }
+
+            throw new ArgumentException ("savePoint is not valid, and should be the result of a call to SaveTransactionPoint.", "savePoint");
+        }
+
+        /// <summary>
+        /// Commits the transaction that was begun by <see cref="BeginTransaction"/>.
+        /// </summary>
+        public void Commit ()
+        {
+            if (Interlocked.Exchange (ref _transactionDepth, 0) != 0) {
+                try {
+                    Execute ("commit");
+                }
+                catch {
+                    // Force a rollback since most people don't know this function can fail
+                    // Don't call Rollback() since the _transactionDepth is 0 and it won't try
+                    // Calling rollback makes our _transactionDepth variable correct.
+                    try {
+                        Execute ("rollback");
+                    }
+                    catch {
+                        // rollback can fail in all sorts of wonderful version-dependent ways. Let's just hope for the best
+                    }
+                    throw;
+                }
+            }
+            // Do nothing on a commit with no open transaction
+        }
+
+        /// <summary>
+        /// Executes <paramref name="action"/> within a (possibly nested) transaction by wrapping it in a SAVEPOINT. If an
+        /// exception occurs the whole transaction is rolled back, not just the current savepoint. The exception
+        /// is rethrown.
+        /// </summary>
+        /// <param name="action">
+        /// The <see cref="Action"/> to perform within a transaction. <paramref name="action"/> can contain any number
+        /// of operations on the connection but should never call <see cref="BeginTransaction"/> or
+        /// <see cref="Commit"/>.
+        /// </param>
+        public void RunInTransaction (Action action)
+        {
+            try {
+                var savePoint = SaveTransactionPoint ();
+                action ();
+                Release (savePoint);
+            }
+            catch (Exception) {
+                Rollback ();
+                throw;
+            }
+        }
+
+        /// <summary>
+        /// Inserts all specified objects.
+        /// </summary>
+        /// <param name="objects">
+        /// An <see cref="IEnumerable"/> of the objects to insert.
+        /// <param name="runInTransaction"/>
+        /// A boolean indicating if the inserts should be wrapped in a transaction.
+        /// </param>
+        /// <returns>
+        /// The number of rows added to the table.
+        /// </returns>
+        public int InsertAll (System.Collections.IEnumerable objects, bool runInTransaction = true)
+        {
+            var c = 0;
+            if (runInTransaction) {
+                RunInTransaction (() => {
+                    foreach (var r in objects) {
+                        c += Insert (r);
+                    }
+                });
+            }
+            else {
+                foreach (var r in objects) {
+                    c += Insert (r);
+                }
+            }
+            return c;
+        }
+
+        /// <summary>
+        /// Inserts all specified objects.
+        /// </summary>
+        /// <param name="objects">
+        /// An <see cref="IEnumerable"/> of the objects to insert.
+        /// </param>
+        /// <param name="extra">
+        /// Literal SQL code that gets placed into the command. INSERT {extra} INTO ...
+        /// </param>
+        /// <param name="runInTransaction">
+        /// A boolean indicating if the inserts should be wrapped in a transaction.
+        /// </param>
+        /// <returns>
+        /// The number of rows added to the table.
+        /// </returns>
+        public int InsertAll (System.Collections.IEnumerable objects, string extra, bool runInTransaction = true)
+        {
+            var c = 0;
+            if (runInTransaction) {
+                RunInTransaction (() => {
+                    foreach (var r in objects) {
+                        c += Insert (r, extra);
+                    }
+                });
+            }
+            else {
+                foreach (var r in objects) {
+                    c += Insert (r, extra);
+                }
+            }
+            return c;
+        }
+
+        /// <summary>
+        /// Inserts all specified objects.
+        /// </summary>
+        /// <param name="objects">
+        /// An <see cref="IEnumerable"/> of the objects to insert.
+        /// </param>
+        /// <param name="objType">
+        /// The type of object to insert.
+        /// </param>
+        /// <param name="runInTransaction">
+        /// A boolean indicating if the inserts should be wrapped in a transaction.
+        /// </param>
+        /// <returns>
+        /// The number of rows added to the table.
+        /// </returns>
+        public int InsertAll (System.Collections.IEnumerable objects, Type objType, bool runInTransaction = true)
+        {
+            var c = 0;
+            if (runInTransaction) {
+                RunInTransaction (() => {
+                    foreach (var r in objects) {
+                        c += Insert (r, objType);
+                    }
+                });
+            }
+            else {
+                foreach (var r in objects) {
+                    c += Insert (r, objType);
+                }
+            }
+            return c;
+        }
+
+        /// <summary>
+        /// Inserts the given object (and updates its
+        /// auto incremented primary key if it has one).
+        /// The return value is the number of rows added to the table.
+        /// </summary>
+        /// <param name="obj">
+        /// The object to insert.
+        /// </param>
+        /// <returns>
+        /// The number of rows added to the table.
+        /// </returns>
+        public int Insert (object obj)
+        {
+            if (obj == null) {
+                return 0;
+            }
+            return Insert (obj, "", Orm.GetType (obj));
+        }
+
+        /// <summary>
+        /// Inserts the given object (and updates its
+        /// auto incremented primary key if it has one).
+        /// The return value is the number of rows added to the table.
+        /// If a UNIQUE constraint violation occurs with
+        /// some pre-existing object, this function deletes
+        /// the old object.
+        /// </summary>
+        /// <param name="obj">
+        /// The object to insert.
+        /// </param>
+        /// <returns>
+        /// The number of rows modified.
+        /// </returns>
+        public int InsertOrReplace (object obj)
+        {
+            if (obj == null) {
+                return 0;
+            }
+            return Insert (obj, "OR REPLACE", Orm.GetType (obj));
+        }
+
+        /// <summary>
+        /// Inserts the given object (and updates its
+        /// auto incremented primary key if it has one).
+        /// The return value is the number of rows added to the table.
+        /// </summary>
+        /// <param name="obj">
+        /// The object to insert.
+        /// </param>
+        /// <param name="objType">
+        /// The type of object to insert.
+        /// </param>
+        /// <returns>
+        /// The number of rows added to the table.
+        /// </returns>
+        public int Insert (object obj, Type objType)
+        {
+            return Insert (obj, "", objType);
+        }
+
+        /// <summary>
+        /// Inserts the given object (and updates its
+        /// auto incremented primary key if it has one).
+        /// The return value is the number of rows added to the table.
+        /// If a UNIQUE constraint violation occurs with
+        /// some pre-existing object, this function deletes
+        /// the old object.
+        /// </summary>
+        /// <param name="obj">
+        /// The object to insert.
+        /// </param>
+        /// <param name="objType">
+        /// The type of object to insert.
+        /// </param>
+        /// <returns>
+        /// The number of rows modified.
+        /// </returns>
+        public int InsertOrReplace (object obj, Type objType)
+        {
+            return Insert (obj, "OR REPLACE", objType);
+        }
+
+        /// <summary>
+        /// Inserts the given object (and updates its
+        /// auto incremented primary key if it has one).
+        /// The return value is the number of rows added to the table.
+        /// </summary>
+        /// <param name="obj">
+        /// The object to insert.
+        /// </param>
+        /// <param name="extra">
+        /// Literal SQL code that gets placed into the command. INSERT {extra} INTO ...
+        /// </param>
+        /// <returns>
+        /// The number of rows added to the table.
+        /// </returns>
+        public int Insert (object obj, string extra)
+        {
+            if (obj == null) {
+                return 0;
+            }
+            return Insert (obj, extra, Orm.GetType (obj));
+        }
+
+        /// <summary>
+        /// Inserts the given object (and updates its
+        /// auto incremented primary key if it has one).
+        /// The return value is the number of rows added to the table.
+        /// </summary>
+        /// <param name="obj">
+        /// The object to insert.
+        /// </param>
+        /// <param name="extra">
+        /// Literal SQL code that gets placed into the command. INSERT {extra} INTO ...
+        /// </param>
+        /// <param name="objType">
+        /// The type of object to insert.
+        /// </param>
+        /// <returns>
+        /// The number of rows added to the table.
+        /// </returns>
+        public int Insert (object obj, string extra, Type objType)
+        {
+            if (obj == null || objType == null) {
+                return 0;
+            }
+
+            var map = GetMapping (objType);
+
+            if (map.PK != null && map.PK.IsAutoGuid) {
+                if (map.PK.GetValue (obj).Equals (Guid.Empty)) {
+                    map.PK.SetValue (obj, Guid.NewGuid ());
+                }
+            }
+
+            var replacing = string.Compare (extra, "OR REPLACE", StringComparison.OrdinalIgnoreCase) == 0;
+
+            var cols = replacing ? map.InsertOrReplaceColumns : map.InsertColumns;
+            var vals = new object[cols.Length];
+            for (var i = 0; i < vals.Length; i++) {
+                vals[i] = cols[i].GetValue (obj);
+            }
+
+            var insertCmd = GetInsertCommand (map, extra);
+            int count;
+
+            lock (insertCmd) {
+                // We lock here to protect the prepared statement returned via GetInsertCommand.
+                // A SQLite prepared statement can be bound for only one operation at a time.
+                try {
+                    count = insertCmd.ExecuteNonQuery (vals);
+                }
+                catch (SQLiteException ex) {
+                    if (SQLite3.ExtendedErrCode (this.Handle) == SQLite3.ExtendedResult.ConstraintNotNull) {
+                        throw NotNullConstraintViolationException.New (ex.Result, ex.Message, map, obj);
+                    }
+                    throw;
+                }
+
+                if (map.HasAutoIncPK) {
+                    var id = SQLite3.LastInsertRowid (Handle);
+                    map.SetAutoIncPK (obj, id);
+                }
+            }
+            if (count > 0)
+                OnTableChanged (map, NotifyTableChangedAction.Insert);
+
+            return count;
+        }
+
+        readonly Dictionary<Tuple<string, string>, PreparedSqlLiteInsertCommand> _insertCommandMap = new Dictionary<Tuple<string, string>, PreparedSqlLiteInsertCommand> ();
+
+        PreparedSqlLiteInsertCommand GetInsertCommand (TableMapping map, string extra)
+        {
+            PreparedSqlLiteInsertCommand prepCmd;
+
+            var key = Tuple.Create (map.MappedType.FullName, extra);
+
+            lock (_insertCommandMap) {
+                if (_insertCommandMap.TryGetValue (key, out prepCmd)) {
+                    return prepCmd;
+                }
+            }
+
+            prepCmd = CreateInsertCommand (map, extra);
+
+            lock (_insertCommandMap) {
+                if (_insertCommandMap.TryGetValue (key, out var existing)) {
+                    prepCmd.Dispose ();
+                    return existing;
+                }
+
+                _insertCommandMap.Add (key, prepCmd);
+            }
+
+            return prepCmd;
+        }
+
+        PreparedSqlLiteInsertCommand CreateInsertCommand (TableMapping map, string extra)
+        {
+            var cols = map.InsertColumns;
+            string insertSql;
+            if (cols.Length == 0 && map.Columns.Length == 1 && map.Columns[0].IsAutoInc) {
+                insertSql = string.Format ("insert {1} into \"{0}\" default values", map.TableName, extra);
+            }
+            else {
+                var replacing = string.Compare (extra, "OR REPLACE", StringComparison.OrdinalIgnoreCase) == 0;
+
+                if (replacing) {
+                    cols = map.InsertOrReplaceColumns;
+                }
+
+                insertSql = string.Format ("insert {3} into \"{0}\"({1}) values ({2})", map.TableName,
+                                   string.Join (",", (from c in cols
+                                                      select "\"" + c.Name + "\"").ToArray ()),
+                                   string.Join (",", (from c in cols
+                                                      select "?").ToArray ()), extra);
+
+            }
+
+            var insertCommand = new PreparedSqlLiteInsertCommand (this, insertSql);
+            return insertCommand;
+        }
+
+        /// <summary>
+        /// Updates all of the columns of a table using the specified object
+        /// except for its primary key.
+        /// The object is required to have a primary key.
+        /// </summary>
+        /// <param name="obj">
+        /// The object to update. It must have a primary key designated using the PrimaryKeyAttribute.
+        /// </param>
+        /// <returns>
+        /// The number of rows updated.
+        /// </returns>
+        public int Update (object obj)
+        {
+            if (obj == null) {
+                return 0;
+            }
+            return Update (obj, Orm.GetType (obj));
+        }
+
+        /// <summary>
+        /// Updates all of the columns of a table using the specified object
+        /// except for its primary key.
+        /// The object is required to have a primary key.
+        /// </summary>
+        /// <param name="obj">
+        /// The object to update. It must have a primary key designated using the PrimaryKeyAttribute.
+        /// </param>
+        /// <param name="objType">
+        /// The type of object to insert.
+        /// </param>
+        /// <returns>
+        /// The number of rows updated.
+        /// </returns>
+        public int Update (object obj, Type objType)
+        {
+            int rowsAffected = 0;
+            if (obj == null || objType == null) {
+                return 0;
+            }
+
+            var map = GetMapping (objType);
+
+            var pk = map.PK;
+
+            if (pk == null) {
+                throw new NotSupportedException ("Cannot update " + map.TableName + ": it has no PK");
+            }
+
+            var cols = from p in map.Columns
+                       where p != pk
+                       select p;
+            var vals = from c in cols
+                       select c.GetValue (obj);
+            var ps = new List<object> (vals);
+            if (ps.Count == 0) {
+                // There is a PK but no accompanying data,
+                // so reset the PK to make the UPDATE work.
+                cols = map.Columns;
+                vals = from c in cols
+                       select c.GetValue (obj);
+                ps = new List<object> (vals);
+            }
+            ps.Add (pk.GetValue (obj));
+            var q = string.Format ("update \"{0}\" set {1} where \"{2}\" = ? ", map.TableName, string.Join (",", (from c in cols
+                                                                                                                  select "\"" + c.Name + "\" = ? ").ToArray ()), pk.Name);
+
+            try {
+                rowsAffected = Execute (q, ps.ToArray ());
+            }
+            catch (SQLiteException ex) {
+
+                if (ex.Result == SQLite3.Result.Constraint && SQLite3.ExtendedErrCode (this.Handle) == SQLite3.ExtendedResult.ConstraintNotNull) {
+                    throw NotNullConstraintViolationException.New (ex, map, obj);
+                }
+
+                throw;
+            }
+
+            if (rowsAffected > 0)
+                OnTableChanged (map, NotifyTableChangedAction.Update);
+
+            return rowsAffected;
+        }
+
+        /// <summary>
+        /// Updates all specified objects.
+        /// </summary>
+        /// <param name="objects">
+        /// An <see cref="IEnumerable"/> of the objects to insert.
+        /// </param>
+        /// <param name="runInTransaction">
+        /// A boolean indicating if the inserts should be wrapped in a transaction
+        /// </param>
+        /// <returns>
+        /// The number of rows modified.
+        /// </returns>
+        public int UpdateAll (System.Collections.IEnumerable objects, bool runInTransaction = true)
+        {
+            var c = 0;
+            if (runInTransaction) {
+                RunInTransaction (() => {
+                    foreach (var r in objects) {
+                        c += Update (r);
+                    }
+                });
+            }
+            else {
+                foreach (var r in objects) {
+                    c += Update (r);
+                }
+            }
+            return c;
+        }
+
+        /// <summary>
+        /// Deletes the given object from the database using its primary key.
+        /// </summary>
+        /// <param name="objectToDelete">
+        /// The object to delete. It must have a primary key designated using the PrimaryKeyAttribute.
+        /// </param>
+        /// <returns>
+        /// The number of rows deleted.
+        /// </returns>
+        public int Delete (object objectToDelete)
+        {
+            var map = GetMapping (Orm.GetType (objectToDelete));
+            var pk = map.PK;
+            if (pk == null) {
+                throw new NotSupportedException ("Cannot delete " + map.TableName + ": it has no PK");
+            }
+            var q = string.Format ("delete from \"{0}\" where \"{1}\" = ?", map.TableName, pk.Name);
+            var count = Execute (q, pk.GetValue (objectToDelete));
+            if (count > 0)
+                OnTableChanged (map, NotifyTableChangedAction.Delete);
+            return count;
+        }
+
+        /// <summary>
+        /// Deletes the object with the specified primary key.
+        /// </summary>
+        /// <param name="primaryKey">
+        /// The primary key of the object to delete.
+        /// </param>
+        /// <returns>
+        /// The number of objects deleted.
+        /// </returns>
+        /// <typeparam name='T'>
+        /// The type of object.
+        /// </typeparam>
+        public int Delete<T> (object primaryKey)
+        {
+            return Delete (primaryKey, GetMapping (typeof (T)));
+        }
+
+        /// <summary>
+        /// Deletes the object with the specified primary key.
+        /// </summary>
+        /// <param name="primaryKey">
+        /// The primary key of the object to delete.
+        /// </param>
+        /// <param name="map">
+        /// The TableMapping used to identify the table.
+        /// </param>
+        /// <returns>
+        /// The number of objects deleted.
+        /// </returns>
+        public int Delete (object primaryKey, TableMapping map)
+        {
+            var pk = map.PK;
+            if (pk == null) {
+                throw new NotSupportedException ("Cannot delete " + map.TableName + ": it has no PK");
+            }
+            var q = string.Format ("delete from \"{0}\" where \"{1}\" = ?", map.TableName, pk.Name);
+            var count = Execute (q, primaryKey);
+            if (count > 0)
+                OnTableChanged (map, NotifyTableChangedAction.Delete);
+            return count;
+        }
+
+        /// <summary>
+        /// Deletes all the objects from the specified table.
+        /// WARNING WARNING: Let me repeat. It deletes ALL the objects from the
+        /// specified table. Do you really want to do that?
+        /// </summary>
+        /// <returns>
+        /// The number of objects deleted.
+        /// </returns>
+        /// <typeparam name='T'>
+        /// The type of objects to delete.
+        /// </typeparam>
+        public int DeleteAll<T> ()
+        {
+            var map = GetMapping (typeof (T));
+            return DeleteAll (map);
+        }
+
+        /// <summary>
+        /// Deletes all the objects from the specified table.
+        /// WARNING WARNING: Let me repeat. It deletes ALL the objects from the
+        /// specified table. Do you really want to do that?
+        /// </summary>
+        /// <param name="map">
+        /// The TableMapping used to identify the table.
+        /// </param>
+        /// <returns>
+        /// The number of objects deleted.
+        /// </returns>
+        public int DeleteAll (TableMapping map)
+        {
+            var query = string.Format ("delete from \"{0}\"", map.TableName);
+            var count = Execute (query);
+            if (count > 0)
+                OnTableChanged (map, NotifyTableChangedAction.Delete);
+            return count;
+        }
+
+        /// <summary>
+        /// Backup the entire database to the specified path.
+        /// </summary>
+        /// <param name="destinationDatabasePath">Path to backup file.</param>
+        /// <param name="databaseName">The name of the database to backup (usually "main").</param>
+        public void Backup (string destinationDatabasePath, string databaseName = "main")
+        {
+            // Open the destination
+            var r = SQLite3.Open (destinationDatabasePath, out var destHandle);
+            if (r != SQLite3.Result.OK) {
+                throw SQLiteException.New (r, "Failed to open destination database");
+            }
+
+            // Init the backup
+            var backup = SQLite3.BackupInit (destHandle, databaseName, Handle, databaseName);
+            if (backup == NullBackupHandle) {
+                SQLite3.Close (destHandle);
+                throw new Exception ("Failed to create backup");
+            }
+
+            // Perform it
+            SQLite3.BackupStep (backup, -1);
+            SQLite3.BackupFinish (backup);
+
+            // Check for errors
+            r = SQLite3.GetResult (destHandle);
+            string msg = "";
+            if (r != SQLite3.Result.OK) {
+                msg = SQLite3.GetErrmsg (destHandle);
+            }
+
+            // Close everything and report errors
+            SQLite3.Close (destHandle);
+            if (r != SQLite3.Result.OK) {
+                throw SQLiteException.New (r, msg);
+            }
+        }
+
+        ~SQLiteConnection ()
+        {
+            Dispose (false);
+        }
+
+        public void Dispose ()
+        {
+            Dispose (true);
+            GC.SuppressFinalize (this);
+        }
+
+        public void Close ()
+        {
+            Dispose (true);
+        }
+
+        protected virtual void Dispose (bool disposing)
+        {
+            var useClose2 = LibVersionNumber >= 3007014;
+
+            if (_open && Handle != NullHandle) {
+                try {
+                    if (disposing) {
+                        lock (_insertCommandMap) {
+                            foreach (var sqlInsertCommand in _insertCommandMap.Values) {
+                                sqlInsertCommand.Dispose ();
+                            }
+                            _insertCommandMap.Clear ();
+                        }
+
+                        var r = useClose2 ? SQLite3.Close2 (Handle) : SQLite3.Close (Handle);
+                        if (r != SQLite3.Result.OK) {
+                            string msg = SQLite3.GetErrmsg (Handle);
+                            throw SQLiteException.New (r, msg);
+                        }
+                    }
+                    else {
+                        var r = useClose2 ? SQLite3.Close2 (Handle) : SQLite3.Close (Handle);
+                    }
+                }
+                finally {
+                    Handle = NullHandle;
+                    _open = false;
+                }
+            }
+        }
+
+        void OnTableChanged (TableMapping table, NotifyTableChangedAction action)
+        {
+            var ev = TableChanged;
+            if (ev != null)
+                ev (this, new NotifyTableChangedEventArgs (table, action));
+        }
+
+        public event EventHandler<NotifyTableChangedEventArgs> TableChanged;
+    }
+
+    public class NotifyTableChangedEventArgs : EventArgs
+    {
+        public TableMapping Table { get; private set; }
+        public NotifyTableChangedAction Action { get; private set; }
+
+        public NotifyTableChangedEventArgs (TableMapping table, NotifyTableChangedAction action)
+        {
+            Table = table;
+            Action = action;
+        }
+    }
+
+    public enum NotifyTableChangedAction
+    {
+        Insert,
+        Update,
+        Delete,
+    }
+
+    /// <summary>
+    /// Represents a parsed connection string.
+    /// </summary>
+    public class SQLiteConnectionString
+    {
+        const string DateTimeSqliteDefaultFormat = "yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fff";
+
+        public string UniqueKey { get; }
+        public string DatabasePath { get; }
+        public bool StoreDateTimeAsTicks { get; }
+        public bool StoreTimeSpanAsTicks { get; }
+        public string DateTimeStringFormat { get; }
+        public System.Globalization.DateTimeStyles DateTimeStyle { get; }
+        public object Key { get; }
+        public SQLiteOpenFlags OpenFlags { get; }
+        public Action<SQLiteConnection> PreKeyAction { get; }
+        public Action<SQLiteConnection> PostKeyAction { get; }
+        public string VfsName { get; }
 
 #if NETFX_CORE
-		static readonly string MetroStyleDataPath = Windows.Storage.ApplicationData.Current.LocalFolder.Path;
+        static readonly string MetroStyleDataPath = Windows.Storage.ApplicationData.Current.LocalFolder.Path;
 
         public static readonly string[] InMemoryDbPaths = new[]
         {
@@ -2320,2673 +2320,2679 @@ namespace SQLite
 
 #endif
 
-		/// <summary>
-		/// Constructs a new SQLiteConnectionString with all the data needed to open an SQLiteConnection.
-		/// </summary>
-		/// <param name="databasePath">
-		/// Specifies the path to the database file.
-		/// </param>
-		/// <param name="storeDateTimeAsTicks">
-		/// Specifies whether to store DateTime properties as ticks (true) or strings (false). You
-		/// absolutely do want to store them as Ticks in all new projects. The value of false is
-		/// only here for backwards compatibility. There is a *significant* speed advantage, with no
-		/// down sides, when setting storeDateTimeAsTicks = true.
-		/// If you use DateTimeOffset properties, it will be always stored as ticks regardingless
-		/// the storeDateTimeAsTicks parameter.
-		/// </param>
-		public SQLiteConnectionString (string databasePath, bool storeDateTimeAsTicks = true)
-			: this (databasePath, SQLiteOpenFlags.Create | SQLiteOpenFlags.ReadWrite, storeDateTimeAsTicks)
-		{
-		}
+        /// <summary>
+        /// Constructs a new SQLiteConnectionString with all the data needed to open an SQLiteConnection.
+        /// </summary>
+        /// <param name="databasePath">
+        /// Specifies the path to the database file.
+        /// </param>
+        /// <param name="storeDateTimeAsTicks">
+        /// Specifies whether to store DateTime properties as ticks (true) or strings (false). You
+        /// absolutely do want to store them as Ticks in all new projects. The value of false is
+        /// only here for backwards compatibility. There is a *significant* speed advantage, with no
+        /// down sides, when setting storeDateTimeAsTicks = true.
+        /// If you use DateTimeOffset properties, it will be always stored as ticks regardingless
+        /// the storeDateTimeAsTicks parameter.
+        /// </param>
+        public SQLiteConnectionString (string databasePath, bool storeDateTimeAsTicks = true)
+            : this (databasePath, SQLiteOpenFlags.Create | SQLiteOpenFlags.ReadWrite, storeDateTimeAsTicks)
+        {
+        }
 
-		/// <summary>
-		/// Constructs a new SQLiteConnectionString with all the data needed to open an SQLiteConnection.
-		/// </summary>
-		/// <param name="databasePath">
-		/// Specifies the path to the database file.
-		/// </param>
-		/// <param name="storeDateTimeAsTicks">
-		/// Specifies whether to store DateTime properties as ticks (true) or strings (false). You
-		/// absolutely do want to store them as Ticks in all new projects. The value of false is
-		/// only here for backwards compatibility. There is a *significant* speed advantage, with no
-		/// down sides, when setting storeDateTimeAsTicks = true.
-		/// If you use DateTimeOffset properties, it will be always stored as ticks regardingless
-		/// the storeDateTimeAsTicks parameter.
-		/// </param>
-		/// <param name="key">
-		/// Specifies the encryption key to use on the database. Should be a string or a byte[].
-		/// </param>
-		/// <param name="preKeyAction">
-		/// Executes prior to setting key for SQLCipher databases
-		/// </param>
-		/// <param name="postKeyAction">
-		/// Executes after setting key for SQLCipher databases
-		/// </param>
-		/// <param name="vfsName">
-		/// Specifies the Virtual File System to use on the database.
-		/// </param>
-		public SQLiteConnectionString (string databasePath, bool storeDateTimeAsTicks, object key = null, Action<SQLiteConnection> preKeyAction = null, Action<SQLiteConnection> postKeyAction = null, string vfsName = null)
-			: this (databasePath, SQLiteOpenFlags.Create | SQLiteOpenFlags.ReadWrite, storeDateTimeAsTicks, key, preKeyAction, postKeyAction, vfsName)
-		{
-		}
+        /// <summary>
+        /// Constructs a new SQLiteConnectionString with all the data needed to open an SQLiteConnection.
+        /// </summary>
+        /// <param name="databasePath">
+        /// Specifies the path to the database file.
+        /// </param>
+        /// <param name="storeDateTimeAsTicks">
+        /// Specifies whether to store DateTime properties as ticks (true) or strings (false). You
+        /// absolutely do want to store them as Ticks in all new projects. The value of false is
+        /// only here for backwards compatibility. There is a *significant* speed advantage, with no
+        /// down sides, when setting storeDateTimeAsTicks = true.
+        /// If you use DateTimeOffset properties, it will be always stored as ticks regardingless
+        /// the storeDateTimeAsTicks parameter.
+        /// </param>
+        /// <param name="key">
+        /// Specifies the encryption key to use on the database. Should be a string or a byte[].
+        /// </param>
+        /// <param name="preKeyAction">
+        /// Executes prior to setting key for SQLCipher databases
+        /// </param>
+        /// <param name="postKeyAction">
+        /// Executes after setting key for SQLCipher databases
+        /// </param>
+        /// <param name="vfsName">
+        /// Specifies the Virtual File System to use on the database.
+        /// </param>
+        public SQLiteConnectionString (string databasePath, bool storeDateTimeAsTicks, object key = null, Action<SQLiteConnection> preKeyAction = null, Action<SQLiteConnection> postKeyAction = null, string vfsName = null)
+            : this (databasePath, SQLiteOpenFlags.Create | SQLiteOpenFlags.ReadWrite, storeDateTimeAsTicks, key, preKeyAction, postKeyAction, vfsName)
+        {
+        }
 
-		/// <summary>
-		/// Constructs a new SQLiteConnectionString with all the data needed to open an SQLiteConnection.
-		/// </summary>
-		/// <param name="databasePath">
-		/// Specifies the path to the database file.
-		/// </param>
-		/// <param name="openFlags">
-		/// Flags controlling how the connection should be opened.
-		/// </param>
-		/// <param name="storeDateTimeAsTicks">
-		/// Specifies whether to store DateTime properties as ticks (true) or strings (false). You
-		/// absolutely do want to store them as Ticks in all new projects. The value of false is
-		/// only here for backwards compatibility. There is a *significant* speed advantage, with no
-		/// down sides, when setting storeDateTimeAsTicks = true.
-		/// If you use DateTimeOffset properties, it will be always stored as ticks regardingless
-		/// the storeDateTimeAsTicks parameter.
-		/// </param>
-		/// <param name="key">
-		/// Specifies the encryption key to use on the database. Should be a string or a byte[].
-		/// </param>
-		/// <param name="preKeyAction">
-		/// Executes prior to setting key for SQLCipher databases
-		/// </param>
-		/// <param name="postKeyAction">
-		/// Executes after setting key for SQLCipher databases
-		/// </param>
-		/// <param name="vfsName">
-		/// Specifies the Virtual File System to use on the database.
-		/// </param>
-		/// <param name="dateTimeStringFormat">
-		/// Specifies the format to use when storing DateTime properties as strings.
-		/// </param>
-		/// <param name="storeTimeSpanAsTicks">
-		/// Specifies whether to store TimeSpan properties as ticks (true) or strings (false). You
-		/// absolutely do want to store them as Ticks in all new projects. The value of false is
-		/// only here for backwards compatibility. There is a *significant* speed advantage, with no
-		/// down sides, when setting storeTimeSpanAsTicks = true.
-		/// </param>
-		public SQLiteConnectionString (string databasePath, SQLiteOpenFlags openFlags, bool storeDateTimeAsTicks, object key = null, Action<SQLiteConnection> preKeyAction = null, Action<SQLiteConnection> postKeyAction = null, string vfsName = null, string dateTimeStringFormat = DateTimeSqliteDefaultFormat, bool storeTimeSpanAsTicks = true)
-		{
-			if (key != null && !((key is byte[]) || (key is string)))
-				throw new ArgumentException ("Encryption keys must be strings or byte arrays", nameof (key));
+        /// <summary>
+        /// Constructs a new SQLiteConnectionString with all the data needed to open an SQLiteConnection.
+        /// </summary>
+        /// <param name="databasePath">
+        /// Specifies the path to the database file.
+        /// </param>
+        /// <param name="openFlags">
+        /// Flags controlling how the connection should be opened.
+        /// </param>
+        /// <param name="storeDateTimeAsTicks">
+        /// Specifies whether to store DateTime properties as ticks (true) or strings (false). You
+        /// absolutely do want to store them as Ticks in all new projects. The value of false is
+        /// only here for backwards compatibility. There is a *significant* speed advantage, with no
+        /// down sides, when setting storeDateTimeAsTicks = true.
+        /// If you use DateTimeOffset properties, it will be always stored as ticks regardingless
+        /// the storeDateTimeAsTicks parameter.
+        /// </param>
+        /// <param name="key">
+        /// Specifies the encryption key to use on the database. Should be a string or a byte[].
+        /// </param>
+        /// <param name="preKeyAction">
+        /// Executes prior to setting key for SQLCipher databases
+        /// </param>
+        /// <param name="postKeyAction">
+        /// Executes after setting key for SQLCipher databases
+        /// </param>
+        /// <param name="vfsName">
+        /// Specifies the Virtual File System to use on the database.
+        /// </param>
+        /// <param name="dateTimeStringFormat">
+        /// Specifies the format to use when storing DateTime properties as strings.
+        /// </param>
+        /// <param name="storeTimeSpanAsTicks">
+        /// Specifies whether to store TimeSpan properties as ticks (true) or strings (false). You
+        /// absolutely do want to store them as Ticks in all new projects. The value of false is
+        /// only here for backwards compatibility. There is a *significant* speed advantage, with no
+        /// down sides, when setting storeTimeSpanAsTicks = true.
+        /// </param>
+        public SQLiteConnectionString (string databasePath, SQLiteOpenFlags openFlags, bool storeDateTimeAsTicks, object key = null, Action<SQLiteConnection> preKeyAction = null, Action<SQLiteConnection> postKeyAction = null, string vfsName = null, string dateTimeStringFormat = DateTimeSqliteDefaultFormat, bool storeTimeSpanAsTicks = true)
+        {
+            if (key != null && !((key is byte[]) || (key is string)))
+                throw new ArgumentException ("Encryption keys must be strings or byte arrays", nameof (key));
 
-			UniqueKey = string.Format ("{0}_{1:X8}", databasePath, (uint)openFlags);
-			StoreDateTimeAsTicks = storeDateTimeAsTicks;
-			StoreTimeSpanAsTicks = storeTimeSpanAsTicks;
-			DateTimeStringFormat = dateTimeStringFormat;
-			DateTimeStyle = "o".Equals (DateTimeStringFormat, StringComparison.OrdinalIgnoreCase) || "r".Equals (DateTimeStringFormat, StringComparison.OrdinalIgnoreCase) ? System.Globalization.DateTimeStyles.RoundtripKind : System.Globalization.DateTimeStyles.None;
-			Key = key;
-			PreKeyAction = preKeyAction;
-			PostKeyAction = postKeyAction;
-			OpenFlags = openFlags;
-			VfsName = vfsName;
+            UniqueKey = string.Format ("{0}_{1:X8}", databasePath, (uint)openFlags);
+            StoreDateTimeAsTicks = storeDateTimeAsTicks;
+            StoreTimeSpanAsTicks = storeTimeSpanAsTicks;
+            DateTimeStringFormat = dateTimeStringFormat;
+            DateTimeStyle = "o".Equals (DateTimeStringFormat, StringComparison.OrdinalIgnoreCase) || "r".Equals (DateTimeStringFormat, StringComparison.OrdinalIgnoreCase) ? System.Globalization.DateTimeStyles.RoundtripKind : System.Globalization.DateTimeStyles.None;
+            Key = key;
+            PreKeyAction = preKeyAction;
+            PostKeyAction = postKeyAction;
+            OpenFlags = openFlags;
+            VfsName = vfsName;
 
 #if NETFX_CORE
-			DatabasePath = IsInMemoryPath(databasePath)
+            DatabasePath = IsInMemoryPath(databasePath)
                 ? databasePath
                 : System.IO.Path.Combine(MetroStyleDataPath, databasePath);
 
 #else
-			DatabasePath = databasePath;
+            DatabasePath = databasePath;
 #endif
-		}
-	}
+        }
+    }
 
-	[AttributeUsage (AttributeTargets.Class)]
-	public class TableAttribute : Attribute
-	{
-		public string Name { get; set; }
+    [AttributeUsage (AttributeTargets.Class)]
+    public class TableAttribute : Attribute
+    {
+        public string Name { get; set; }
 
-		/// <summary>
-		/// Flag whether to create the table without rowid (see https://sqlite.org/withoutrowid.html)
-		///
-		/// The default is <c>false</c> so that sqlite adds an implicit <c>rowid</c> to every table created.
-		/// </summary>
-		public bool WithoutRowId { get; set; }
+        /// <summary>
+        /// Flag whether to create the table without rowid (see https://sqlite.org/withoutrowid.html)
+        ///
+        /// The default is <c>false</c> so that sqlite adds an implicit <c>rowid</c> to every table created.
+        /// </summary>
+        public bool WithoutRowId { get; set; }
 
-		public TableAttribute (string name)
-		{
-			Name = name;
-		}
-	}
+        public TableAttribute (string name)
+        {
+            Name = name;
+        }
+    }
 
-	[AttributeUsage (AttributeTargets.Property)]
-	public class ColumnAttribute : Attribute
-	{
-		public string Name { get; set; }
+    [AttributeUsage (AttributeTargets.Property)]
+    public class ColumnAttribute : Attribute
+    {
+        public string Name { get; set; }
 
-		public ColumnAttribute (string name)
-		{
-			Name = name;
-		}
-	}
+        public ColumnAttribute (string name)
+        {
+            Name = name;
+        }
+    }
 
-	[AttributeUsage (AttributeTargets.Property)]
-	public class PrimaryKeyAttribute : Attribute
-	{
-	}
+    [AttributeUsage (AttributeTargets.Property)]
+    public class PrimaryKeyAttribute : Attribute
+    {
+    }
 
-	[AttributeUsage (AttributeTargets.Property)]
-	public class AutoIncrementAttribute : Attribute
-	{
-	}
+    [AttributeUsage (AttributeTargets.Property)]
+    public class AutoIncrementAttribute : Attribute
+    {
+    }
 
-	[AttributeUsage (AttributeTargets.Property, AllowMultiple = true)]
-	public class IndexedAttribute : Attribute
-	{
-		public string Name { get; set; }
-		public int Order { get; set; }
-		public virtual bool Unique { get; set; }
+    [AttributeUsage (AttributeTargets.Property, AllowMultiple = true)]
+    public class IndexedAttribute : Attribute
+    {
+        public string Name { get; set; }
+        public int Order { get; set; }
+        public virtual bool Unique { get; set; }
 
-		public IndexedAttribute ()
-		{
-		}
+        public IndexedAttribute ()
+        {
+        }
 
-		public IndexedAttribute (string name, int order)
-		{
-			Name = name;
-			Order = order;
-		}
-	}
+        public IndexedAttribute (string name, int order)
+        {
+            Name = name;
+            Order = order;
+        }
+    }
 
-	[AttributeUsage (AttributeTargets.Property)]
-	public class IgnoreAttribute : Attribute
-	{
-	}
+    [AttributeUsage (AttributeTargets.Property)]
+    public class IgnoreAttribute : Attribute
+    {
+    }
 
-	[AttributeUsage (AttributeTargets.Property)]
-	public class UniqueAttribute : IndexedAttribute
-	{
-		public override bool Unique {
-			get { return true; }
-			set { /* throw?  */ }
-		}
-	}
+    [AttributeUsage (AttributeTargets.Property)]
+    public class UniqueAttribute : IndexedAttribute
+    {
+        public override bool Unique {
+            get { return true; }
+            set { /* throw?  */ }
+        }
+    }
 
-	[AttributeUsage (AttributeTargets.Property)]
-	public class MaxLengthAttribute : Attribute
-	{
-		public int Value { get; private set; }
+    [AttributeUsage (AttributeTargets.Property)]
+    public class MaxLengthAttribute : Attribute
+    {
+        public int Value { get; private set; }
 
-		public MaxLengthAttribute (int length)
-		{
-			Value = length;
-		}
-	}
+        public MaxLengthAttribute (int length)
+        {
+            Value = length;
+        }
+    }
 
-	public sealed class PreserveAttribute : System.Attribute
-	{
-		public bool AllMembers;
-		public bool Conditional;
-	}
+    public sealed class PreserveAttribute : System.Attribute
+    {
+        public bool AllMembers;
+        public bool Conditional;
+    }
 
-	/// <summary>
-	/// Select the collating sequence to use on a column.
-	/// "BINARY", "NOCASE", and "RTRIM" are supported.
-	/// "BINARY" is the default.
-	/// </summary>
-	[AttributeUsage (AttributeTargets.Property)]
-	public class CollationAttribute : Attribute
-	{
-		public string Value { get; private set; }
+    /// <summary>
+    /// Select the collating sequence to use on a column.
+    /// "BINARY", "NOCASE", and "RTRIM" are supported.
+    /// "BINARY" is the default.
+    /// </summary>
+    [AttributeUsage (AttributeTargets.Property)]
+    public class CollationAttribute : Attribute
+    {
+        public string Value { get; private set; }
 
-		public CollationAttribute (string collation)
-		{
-			Value = collation;
-		}
-	}
+        public CollationAttribute (string collation)
+        {
+            Value = collation;
+        }
+    }
 
-	[AttributeUsage (AttributeTargets.Property)]
-	public class NotNullAttribute : Attribute
-	{
-	}
+    [AttributeUsage (AttributeTargets.Property)]
+    public class NotNullAttribute : Attribute
+    {
+    }
 
-	[AttributeUsage (AttributeTargets.Enum)]
-	public class StoreAsTextAttribute : Attribute
-	{
-	}
+    [AttributeUsage (AttributeTargets.Enum)]
+    public class StoreAsTextAttribute : Attribute
+    {
+    }
 
-	public class TableMapping
-	{
-		public Type MappedType { get; private set; }
+    public class TableMapping
+    {
+        public Type MappedType { get; private set; }
 
-		public string TableName { get; private set; }
+        public string TableName { get; private set; }
 
-		public bool WithoutRowId { get; private set; }
+        public bool WithoutRowId { get; private set; }
 
-		public Column[] Columns { get; private set; }
+        public Column[] Columns { get; private set; }
 
-		public Column PK { get; private set; }
+        public Column PK { get; private set; }
 
-		public string GetByPrimaryKeySql { get; private set; }
+        public string GetByPrimaryKeySql { get; private set; }
 
-		public CreateFlags CreateFlags { get; private set; }
+        public CreateFlags CreateFlags { get; private set; }
 
-		internal MapMethod Method { get; private set; } = MapMethod.ByName;
+        internal MapMethod Method { get; private set; } = MapMethod.ByName;
 
-		readonly Column _autoPk;
-		readonly Column[] _insertColumns;
-		readonly Column[] _insertOrReplaceColumns;
+        readonly Column _autoPk;
+        readonly Column[] _insertColumns;
+        readonly Column[] _insertOrReplaceColumns;
 
-		public TableMapping (Type type, CreateFlags createFlags = CreateFlags.None)
-		{
-			MappedType = type;
-			CreateFlags = createFlags;
+        public TableMapping (Type type, CreateFlags createFlags = CreateFlags.None)
+        {
+            MappedType = type;
+            CreateFlags = createFlags;
 
-			var typeInfo = type.GetTypeInfo ();
+            var typeInfo = type.GetTypeInfo ();
 #if ENABLE_IL2CPP
-			var tableAttr = typeInfo.GetCustomAttribute<TableAttribute> ();
+            var tableAttr = typeInfo.GetCustomAttribute<TableAttribute> ();
 #else
-			var tableAttr =
-				typeInfo.CustomAttributes
-						.Where (x => x.AttributeType == typeof (TableAttribute))
-						.Select (x => (TableAttribute)Orm.InflateAttribute (x))
-						.FirstOrDefault ();
+            var tableAttr =
+                typeInfo.CustomAttributes
+                        .Where (x => x.AttributeType == typeof (TableAttribute))
+                        .Select (x => (TableAttribute)Orm.InflateAttribute (x))
+                        .FirstOrDefault ();
 #endif
 
-			TableName = (tableAttr != null && !string.IsNullOrEmpty (tableAttr.Name)) ? tableAttr.Name : MappedType.Name;
-			WithoutRowId = tableAttr != null ? tableAttr.WithoutRowId : false;
+            TableName = (tableAttr != null && !string.IsNullOrEmpty (tableAttr.Name)) ? tableAttr.Name : MappedType.Name;
+            WithoutRowId = tableAttr != null ? tableAttr.WithoutRowId : false;
 
-			var members = GetPublicMembers(type);
-			var cols = new List<Column>(members.Count);
-			foreach(var m in members)
-			{
-				var ignore = m.IsDefined(typeof(IgnoreAttribute), true);
-				if(!ignore)
-					cols.Add(new Column(m, createFlags));
-			}
-			Columns = cols.ToArray ();
-			foreach (var c in Columns) {
-				if (c.IsAutoInc && c.IsPK) {
-					_autoPk = c;
-				}
-				if (c.IsPK) {
-					PK = c;
-				}
-			}
+            var members = GetPublicMembers(type);
+            var cols = new List<Column>(members.Count);
+            foreach(var m in members)
+            {
+                var ignore = m.IsDefined(typeof(IgnoreAttribute), true);
+                if(!ignore)
+                    cols.Add(new Column(m, createFlags));
+            }
+            Columns = cols.ToArray ();
+            foreach (var c in Columns) {
+                if (c.IsAutoInc && c.IsPK) {
+                    _autoPk = c;
+                }
+                if (c.IsPK) {
+                    PK = c;
+                }
+            }
 
-			HasAutoIncPK = _autoPk != null;
+            HasAutoIncPK = _autoPk != null;
 
-			if (PK != null) {
-				GetByPrimaryKeySql = string.Format ("select * from \"{0}\" where \"{1}\" = ?", TableName, PK.Name);
-			}
-			else {
-				// People should not be calling Get/Find without a PK
-				GetByPrimaryKeySql = string.Format ("select * from \"{0}\" limit 1", TableName);
-			}
+            if (PK != null) {
+                GetByPrimaryKeySql = string.Format ("select * from \"{0}\" where \"{1}\" = ?", TableName, PK.Name);
+            }
+            else {
+                // People should not be calling Get/Find without a PK
+                GetByPrimaryKeySql = string.Format ("select * from \"{0}\" limit 1", TableName);
+            }
 
-			_insertColumns = Columns.Where (c => !c.IsAutoInc).ToArray ();
-			_insertOrReplaceColumns = Columns.ToArray ();
-		}
+            _insertColumns = Columns.Where (c => !c.IsAutoInc).ToArray ();
+            _insertOrReplaceColumns = Columns.ToArray ();
+        }
 
-		private IReadOnlyCollection<MemberInfo> GetPublicMembers(Type type)
-		{
-			if(type.Name.StartsWith("ValueTuple`"))
-				return GetFieldsFromValueTuple(type);
+        private IReadOnlyCollection<MemberInfo> GetPublicMembers(Type type)
+        {
+            if(type.Name.StartsWith("ValueTuple`"))
+                return GetFieldsFromValueTuple(type);
 
-			var members = new List<MemberInfo>();
-			var memberNames = new HashSet<string>();
-			var newMembers = new List<MemberInfo>();
-			do
-			{
-				var ti = type.GetTypeInfo();
-				newMembers.Clear();
+            var members = new List<MemberInfo>();
+            var memberNames = new HashSet<string>();
+            var newMembers = new List<MemberInfo>();
+            do
+            {
+                var ti = type.GetTypeInfo();
+                newMembers.Clear();
 
-				newMembers.AddRange(
-					from p in ti.DeclaredProperties
-					where !memberNames.Contains(p.Name) &&
-						p.CanRead && p.CanWrite &&
-						p.GetMethod != null && p.SetMethod != null &&
-						p.GetMethod.IsPublic && p.SetMethod.IsPublic &&
-						!p.GetMethod.IsStatic && !p.SetMethod.IsStatic
-					select p);
+                newMembers.AddRange(
+                    from p in ti.DeclaredProperties
+                    where !memberNames.Contains(p.Name) &&
+                        p.CanRead && p.CanWrite &&
+                        p.GetMethod != null && p.SetMethod != null &&
+                        p.GetMethod.IsPublic && p.SetMethod.IsPublic &&
+                        !p.GetMethod.IsStatic && !p.SetMethod.IsStatic
+                    select p);
 
-				members.AddRange(newMembers);
-				foreach(var m in newMembers)
-					memberNames.Add(m.Name);
+                members.AddRange(newMembers);
+                foreach(var m in newMembers)
+                    memberNames.Add(m.Name);
 
-				type = ti.BaseType;
-			}
-			while(type != typeof(object));
+                type = ti.BaseType;
+            }
+            while(type != typeof(object));
 
-			return members;
-		}
+            return members;
+        }
 
-		private IReadOnlyCollection<MemberInfo> GetFieldsFromValueTuple(Type type)
-		{
-			Method = MapMethod.ByPosition;
-			var fields = type.GetFields();
+        private IReadOnlyCollection<MemberInfo> GetFieldsFromValueTuple(Type type)
+        {
+            Method = MapMethod.ByPosition;
+            var fields = type.GetFields();
 
-			// https://docs.microsoft.com/en-us/dotnet/api/system.valuetuple-8.rest
-			if(fields.Length >= 8)
-				throw new NotSupportedException("ValueTuple with more than 7 members not supported due to nesting; see https://docs.microsoft.com/en-us/dotnet/api/system.valuetuple-8.rest");
+            // https://docs.microsoft.com/en-us/dotnet/api/system.valuetuple-8.rest
+            if(fields.Length >= 8)
+                throw new NotSupportedException("ValueTuple with more than 7 members not supported due to nesting; see https://docs.microsoft.com/en-us/dotnet/api/system.valuetuple-8.rest");
 
-			return fields;
-		}
+            return fields;
+        }
 
-		public bool HasAutoIncPK { get; private set; }
+        public bool HasAutoIncPK { get; private set; }
 
-		public void SetAutoIncPK (object obj, long id)
-		{
-			if (_autoPk != null) {
-				_autoPk.SetValue (obj, Convert.ChangeType (id, _autoPk.ColumnType, null));
-			}
-		}
+        public void SetAutoIncPK (object obj, long id)
+        {
+            if (_autoPk != null) {
+                _autoPk.SetValue (obj, Convert.ChangeType (id, _autoPk.ColumnType, null));
+            }
+        }
 
-		public Column[] InsertColumns {
-			get {
-				return _insertColumns;
-			}
-		}
+        public Column[] InsertColumns {
+            get {
+                return _insertColumns;
+            }
+        }
 
-		public Column[] InsertOrReplaceColumns {
-			get {
-				return _insertOrReplaceColumns;
-			}
-		}
+        public Column[] InsertOrReplaceColumns {
+            get {
+                return _insertOrReplaceColumns;
+            }
+        }
 
-		public Column FindColumnWithPropertyName (string propertyName)
-		{
-			var exact = Columns.FirstOrDefault (c => c.PropertyName == propertyName);
-			return exact;
-		}
+        public Column FindColumnWithPropertyName (string propertyName)
+        {
+            var exact = Columns.FirstOrDefault (c => c.PropertyName == propertyName);
+            return exact;
+        }
 
-		public Column FindColumn (string columnName)
-		{
-			if(Method != MapMethod.ByName)
-				throw new InvalidOperationException($"This {nameof(TableMapping)} is not mapped by name, but {Method}.");
+        public Column FindColumn (string columnName)
+        {
+            if(Method != MapMethod.ByName)
+                throw new InvalidOperationException($"This {nameof(TableMapping)} is not mapped by name, but {Method}.");
 
-			var exact = Columns.FirstOrDefault (c => c.Name.ToLower () == columnName.ToLower ());
-			return exact;
-		}
+            var exact = Columns.FirstOrDefault (c => c.Name.ToLower () == columnName.ToLower ());
+            return exact;
+        }
 
-		public class Column
-		{
-			MemberInfo _member;
+        public class Column
+        {
+            MemberInfo _member;
 
-			public string Name { get; private set; }
+            public string Name { get; private set; }
 
-			public PropertyInfo PropertyInfo => _member as PropertyInfo;
+            public PropertyInfo PropertyInfo => _member as PropertyInfo;
 
-			public string PropertyName { get { return _member.Name; } }
+            public string PropertyName { get { return _member.Name; } }
 
-			public Type ColumnType { get; private set; }
+            public Type ColumnType { get; private set; }
 
-			public string Collation { get; private set; }
+            public string Collation { get; private set; }
 
-			public bool IsAutoInc { get; private set; }
-			public bool IsAutoGuid { get; private set; }
+            public bool IsAutoInc { get; private set; }
+            public bool IsAutoGuid { get; private set; }
 
-			public bool IsPK { get; private set; }
+            public bool IsPK { get; private set; }
 
-			public IEnumerable<IndexedAttribute> Indices { get; set; }
+            public IEnumerable<IndexedAttribute> Indices { get; set; }
 
-			public bool IsNullable { get; private set; }
+            public bool IsNullable { get; private set; }
 
-			public int? MaxStringLength { get; private set; }
+            public int? MaxStringLength { get; private set; }
 
-			public bool StoreAsText { get; private set; }
+            public bool StoreAsText { get; private set; }
 
-			public Column (MemberInfo member, CreateFlags createFlags = CreateFlags.None)
-			{
-				_member = member;
-				var memberType = GetMemberType(member);
+            public Column (MemberInfo member, CreateFlags createFlags = CreateFlags.None)
+            {
+                _member = member;
+                var memberType = GetMemberType(member);
 
-				var colAttr = member.CustomAttributes.FirstOrDefault (x => x.AttributeType == typeof (ColumnAttribute));
+                var colAttr = member.CustomAttributes.FirstOrDefault (x => x.AttributeType == typeof (ColumnAttribute));
 #if ENABLE_IL2CPP
                 var ca = member.GetCustomAttribute(typeof(ColumnAttribute)) as ColumnAttribute;
-				Name = ca == null ? member.Name : ca.Name;
+                Name = ca == null ? member.Name : ca.Name;
 #else
-				Name = (colAttr != null && colAttr.ConstructorArguments.Count > 0) ?
-						colAttr.ConstructorArguments[0].Value?.ToString () :
-						member.Name;
+                Name = (colAttr != null && colAttr.ConstructorArguments.Count > 0) ?
+                        colAttr.ConstructorArguments[0].Value?.ToString () :
+                        member.Name;
 #endif
-				//If this type is Nullable<T> then Nullable.GetUnderlyingType returns the T, otherwise it returns null, so get the actual type instead
-				ColumnType = Nullable.GetUnderlyingType (memberType) ?? memberType;
-				Collation = Orm.Collation (member);
+                //If this type is Nullable<T> then Nullable.GetUnderlyingType returns the T, otherwise it returns null, so get the actual type instead
+                ColumnType = Nullable.GetUnderlyingType (memberType) ?? memberType;
+                Collation = Orm.Collation (member);
 
-				IsPK = Orm.IsPK (member) ||
-					(((createFlags & CreateFlags.ImplicitPK) == CreateFlags.ImplicitPK) &&
-					 	string.Compare (member.Name, Orm.ImplicitPkName, StringComparison.OrdinalIgnoreCase) == 0);
+                IsPK = Orm.IsPK (member) ||
+                    (((createFlags & CreateFlags.ImplicitPK) == CreateFlags.ImplicitPK) &&
+                        string.Compare (member.Name, Orm.ImplicitPkName, StringComparison.OrdinalIgnoreCase) == 0);
 
-				var isAuto = Orm.IsAutoInc (member) || (IsPK && ((createFlags & CreateFlags.AutoIncPK) == CreateFlags.AutoIncPK));
-				IsAutoGuid = isAuto && ColumnType == typeof (Guid);
-				IsAutoInc = isAuto && !IsAutoGuid;
+                var isAuto = Orm.IsAutoInc (member) || (IsPK && ((createFlags & CreateFlags.AutoIncPK) == CreateFlags.AutoIncPK));
+                IsAutoGuid = isAuto && ColumnType == typeof (Guid);
+                IsAutoInc = isAuto && !IsAutoGuid;
 
-				Indices = Orm.GetIndices (member);
-				if (!Indices.Any ()
-					&& !IsPK
-					&& ((createFlags & CreateFlags.ImplicitIndex) == CreateFlags.ImplicitIndex)
-					&& Name.EndsWith (Orm.ImplicitIndexSuffix, StringComparison.OrdinalIgnoreCase)
-					) {
-					Indices = new IndexedAttribute[] { new IndexedAttribute () };
-				}
-				IsNullable = !(IsPK || Orm.IsMarkedNotNull (member));
-				MaxStringLength = Orm.MaxStringLength (member);
+                Indices = Orm.GetIndices (member);
+                if (!Indices.Any ()
+                    && !IsPK
+                    && ((createFlags & CreateFlags.ImplicitIndex) == CreateFlags.ImplicitIndex)
+                    && Name.EndsWith (Orm.ImplicitIndexSuffix, StringComparison.OrdinalIgnoreCase)
+                    ) {
+                    Indices = new IndexedAttribute[] { new IndexedAttribute () };
+                }
+                IsNullable = !(IsPK || Orm.IsMarkedNotNull (member));
+                MaxStringLength = Orm.MaxStringLength (member);
 
-				StoreAsText = memberType.GetTypeInfo ().CustomAttributes.Any (x => x.AttributeType == typeof (StoreAsTextAttribute));
-			}
+                StoreAsText = memberType.GetTypeInfo ().CustomAttributes.Any (x => x.AttributeType == typeof (StoreAsTextAttribute));
+            }
 
-			public Column (PropertyInfo member, CreateFlags createFlags = CreateFlags.None)
-				: this((MemberInfo)member, createFlags)
-			{ }
+            public Column (PropertyInfo member, CreateFlags createFlags = CreateFlags.None)
+                : this((MemberInfo)member, createFlags)
+            { }
 
-			public void SetValue (object obj, object val)
-			{
-				if(_member is PropertyInfo propy)
-				{
-					if (val != null && ColumnType.GetTypeInfo ().IsEnum)
-						propy.SetValue (obj, Enum.ToObject (ColumnType, val));
-					else
-						propy.SetValue (obj, val);
-				}
-				else if(_member is FieldInfo field)
-				{
-					if (val != null && ColumnType.GetTypeInfo ().IsEnum)
-						field.SetValue (obj, Enum.ToObject (ColumnType, val));
-					else
-						field.SetValue (obj, val);
-				}
-				else
-					throw new InvalidProgramException("unreachable condition");
-			}
+            public void SetValue (object obj, object val)
+            {
+                if(_member is PropertyInfo propy)
+                {
+                    if (val != null && ColumnType.GetTypeInfo ().IsEnum)
+                        propy.SetValue (obj, Enum.ToObject (ColumnType, val));
+                    else
+                        propy.SetValue (obj, val);
+                }
+                else if(_member is FieldInfo field)
+                {
+                    if (val != null && ColumnType.GetTypeInfo ().IsEnum)
+                        field.SetValue (obj, Enum.ToObject (ColumnType, val));
+                    else
+                        field.SetValue (obj, val);
+                }
+                else
+                    throw new InvalidProgramException("unreachable condition");
+            }
 
-			public object GetValue (object obj)
-			{
-				if(_member is PropertyInfo propy)
-					return propy.GetValue(obj);
-				else if(_member is FieldInfo field)
-					return field.GetValue(obj);
-				else
-					throw new InvalidProgramException("unreachable condition");
-			}
+            public object GetValue (object obj)
+            {
+                if(_member is PropertyInfo propy)
+                    return propy.GetValue(obj);
+                else if(_member is FieldInfo field)
+                    return field.GetValue(obj);
+                else
+                    throw new InvalidProgramException("unreachable condition");
+            }
 
-			private static Type GetMemberType(MemberInfo m)
-			{
-				switch(m.MemberType)
-				{
-					case MemberTypes.Property: return ((PropertyInfo)m).PropertyType;
-					case MemberTypes.Field: return ((FieldInfo)m).FieldType;
-					default: throw new InvalidProgramException($"{nameof(TableMapping)} supports properties or fields only.");
-				}
-			}
-		}
+            private static Type GetMemberType(MemberInfo m)
+            {
+                switch(m.MemberType)
+                {
+                    case MemberTypes.Property: return ((PropertyInfo)m).PropertyType;
+                    case MemberTypes.Field: return ((FieldInfo)m).FieldType;
+                    default: throw new InvalidProgramException($"{nameof(TableMapping)} supports properties or fields only.");
+                }
+            }
+        }
 
-		internal enum MapMethod
-		{
-			ByName,
-			ByPosition
-		}
-	}
+        internal enum MapMethod
+        {
+            ByName,
+            ByPosition
+        }
+    }
 
-	class EnumCacheInfo
-	{
-		public EnumCacheInfo (Type type)
-		{
-			var typeInfo = type.GetTypeInfo ();
+    class EnumCacheInfo
+    {
+        public EnumCacheInfo (Type type)
+        {
+            var typeInfo = type.GetTypeInfo ();
 
-			IsEnum = typeInfo.IsEnum;
+            IsEnum = typeInfo.IsEnum;
 
-			if (IsEnum) {
-				StoreAsText = typeInfo.CustomAttributes.Any (x => x.AttributeType == typeof (StoreAsTextAttribute));
+            if (IsEnum) {
+                StoreAsText = typeInfo.CustomAttributes.Any (x => x.AttributeType == typeof (StoreAsTextAttribute));
 
-				if (StoreAsText) {
-					EnumValues = new Dictionary<int, string> ();
-					foreach (object e in Enum.GetValues (type)) {
-						EnumValues[Convert.ToInt32 (e)] = e.ToString ();
-					}
-				}
-			}
-		}
+                if (StoreAsText) {
+                    EnumValues = new Dictionary<int, string> ();
+#if NET8_0_OR_GREATER
+                    foreach (object e in Enum.GetValuesAsUnderlyingType (type)) {
+                        EnumValues[Convert.ToInt32 (e)] = Enum.ToObject(type, e).ToString ();
+                    }
+#else
+                    foreach (object e in Enum.GetValues (type)) {
+                        EnumValues[Convert.ToInt32 (e)] = e.ToString ();
+                    }
+#endif
+                }
+            }
+        }
 
-		public bool IsEnum { get; private set; }
+        public bool IsEnum { get; private set; }
 
-		public bool StoreAsText { get; private set; }
+        public bool StoreAsText { get; private set; }
 
-		public Dictionary<int, string> EnumValues { get; private set; }
-	}
+        public Dictionary<int, string> EnumValues { get; private set; }
+    }
 
-	static class EnumCache
-	{
-		static readonly Dictionary<Type, EnumCacheInfo> Cache = new Dictionary<Type, EnumCacheInfo> ();
+    static class EnumCache
+    {
+        static readonly Dictionary<Type, EnumCacheInfo> Cache = new Dictionary<Type, EnumCacheInfo> ();
 
-		public static EnumCacheInfo GetInfo<T> ()
-		{
-			return GetInfo (typeof (T));
-		}
+        public static EnumCacheInfo GetInfo<T> ()
+        {
+            return GetInfo (typeof (T));
+        }
 
-		public static EnumCacheInfo GetInfo (Type type)
-		{
-			lock (Cache) {
-				EnumCacheInfo info = null;
-				if (!Cache.TryGetValue (type, out info)) {
-					info = new EnumCacheInfo (type);
-					Cache[type] = info;
-				}
+        public static EnumCacheInfo GetInfo (Type type)
+        {
+            lock (Cache) {
+                EnumCacheInfo info = null;
+                if (!Cache.TryGetValue (type, out info)) {
+                    info = new EnumCacheInfo (type);
+                    Cache[type] = info;
+                }
 
-				return info;
-			}
-		}
-	}
+                return info;
+            }
+        }
+    }
 
-	public static class Orm
-	{
-		public const int DefaultMaxStringLength = 140;
-		public const string ImplicitPkName = "Id";
-		public const string ImplicitIndexSuffix = "Id";
+    public static class Orm
+    {
+        public const int DefaultMaxStringLength = 140;
+        public const string ImplicitPkName = "Id";
+        public const string ImplicitIndexSuffix = "Id";
 
-		public static Type GetType (object obj)
-		{
-			if (obj == null)
-				return typeof (object);
-			var rt = obj as IReflectableType;
-			if (rt != null)
-				return rt.GetTypeInfo ().AsType ();
-			return obj.GetType ();
-		}
+        public static Type GetType (object obj)
+        {
+            if (obj == null)
+                return typeof (object);
+            var rt = obj as IReflectableType;
+            if (rt != null)
+                return rt.GetTypeInfo ().AsType ();
+            return obj.GetType ();
+        }
 
-		public static string SqlDecl (TableMapping.Column p, bool storeDateTimeAsTicks, bool storeTimeSpanAsTicks)
-		{
-			string decl = "\"" + p.Name + "\" " + SqlType (p, storeDateTimeAsTicks, storeTimeSpanAsTicks) + " ";
+        public static string SqlDecl (TableMapping.Column p, bool storeDateTimeAsTicks, bool storeTimeSpanAsTicks)
+        {
+            string decl = "\"" + p.Name + "\" " + SqlType (p, storeDateTimeAsTicks, storeTimeSpanAsTicks) + " ";
 
-			if (p.IsPK) {
-				decl += "primary key ";
-			}
-			if (p.IsAutoInc) {
-				decl += "autoincrement ";
-			}
-			if (!p.IsNullable) {
-				decl += "not null ";
-			}
-			if (!string.IsNullOrEmpty (p.Collation)) {
-				decl += "collate " + p.Collation + " ";
-			}
+            if (p.IsPK) {
+                decl += "primary key ";
+            }
+            if (p.IsAutoInc) {
+                decl += "autoincrement ";
+            }
+            if (!p.IsNullable) {
+                decl += "not null ";
+            }
+            if (!string.IsNullOrEmpty (p.Collation)) {
+                decl += "collate " + p.Collation + " ";
+            }
 
-			return decl;
-		}
+            return decl;
+        }
 
-		public static string SqlType (TableMapping.Column p, bool storeDateTimeAsTicks, bool storeTimeSpanAsTicks)
-		{
-			var clrType = p.ColumnType;
-			if (clrType == typeof (Boolean) || clrType == typeof (Byte) || clrType == typeof (UInt16) || clrType == typeof (SByte) || clrType == typeof (Int16) || clrType == typeof (Int32) || clrType == typeof (UInt32) || clrType == typeof (Int64) || clrType == typeof (UInt64)) {
-				return "integer";
-			}
-			else if (clrType == typeof (Single) || clrType == typeof (Double) || clrType == typeof (Decimal)) {
-				return "float";
-			}
-			else if (clrType == typeof (String) || clrType == typeof (StringBuilder) || clrType == typeof (Uri) || clrType == typeof (UriBuilder)) {
-				int? len = p.MaxStringLength;
+        public static string SqlType (TableMapping.Column p, bool storeDateTimeAsTicks, bool storeTimeSpanAsTicks)
+        {
+            var clrType = p.ColumnType;
+            if (clrType == typeof (Boolean) || clrType == typeof (Byte) || clrType == typeof (UInt16) || clrType == typeof (SByte) || clrType == typeof (Int16) || clrType == typeof (Int32) || clrType == typeof (UInt32) || clrType == typeof (Int64) || clrType == typeof (UInt64)) {
+                return "integer";
+            }
+            else if (clrType == typeof (Single) || clrType == typeof (Double) || clrType == typeof (Decimal)) {
+                return "float";
+            }
+            else if (clrType == typeof (String) || clrType == typeof (StringBuilder) || clrType == typeof (Uri) || clrType == typeof (UriBuilder)) {
+                int? len = p.MaxStringLength;
 
-				if (len.HasValue)
-					return "varchar(" + len.Value + ")";
+                if (len.HasValue)
+                    return "varchar(" + len.Value + ")";
 
-				return "varchar";
-			}
-			else if (clrType == typeof (TimeSpan)) {
-				return storeTimeSpanAsTicks ? "bigint" : "time";
-			}
-			else if (clrType == typeof (DateTime)) {
-				return storeDateTimeAsTicks ? "bigint" : "datetime";
-			}
-			else if (clrType == typeof (DateTimeOffset)) {
-				return "bigint";
-			}
-			else if (clrType.GetTypeInfo ().IsEnum) {
-				if (p.StoreAsText)
-					return "varchar";
-				else
-					return "integer";
-			}
-			else if (clrType == typeof (byte[])) {
-				return "blob";
-			}
-			else if (clrType == typeof (Guid)) {
-				return "varchar(36)";
-			}
-			else {
-				throw new NotSupportedException ("Don't know about " + clrType);
-			}
-		}
+                return "varchar";
+            }
+            else if (clrType == typeof (TimeSpan)) {
+                return storeTimeSpanAsTicks ? "bigint" : "time";
+            }
+            else if (clrType == typeof (DateTime)) {
+                return storeDateTimeAsTicks ? "bigint" : "datetime";
+            }
+            else if (clrType == typeof (DateTimeOffset)) {
+                return "bigint";
+            }
+            else if (clrType.GetTypeInfo ().IsEnum) {
+                if (p.StoreAsText)
+                    return "varchar";
+                else
+                    return "integer";
+            }
+            else if (clrType == typeof (byte[])) {
+                return "blob";
+            }
+            else if (clrType == typeof (Guid)) {
+                return "varchar(36)";
+            }
+            else {
+                throw new NotSupportedException ("Don't know about " + clrType);
+            }
+        }
 
-		public static bool IsPK (MemberInfo p)
-		{
-			return p.CustomAttributes.Any (x => x.AttributeType == typeof (PrimaryKeyAttribute));
-		}
+        public static bool IsPK (MemberInfo p)
+        {
+            return p.CustomAttributes.Any (x => x.AttributeType == typeof (PrimaryKeyAttribute));
+        }
 
-		public static string Collation (MemberInfo p)
-		{
+        public static string Collation (MemberInfo p)
+        {
 #if ENABLE_IL2CPP
-			return (p.GetCustomAttribute<CollationAttribute> ()?.Value) ?? "";
+            return (p.GetCustomAttribute<CollationAttribute> ()?.Value) ?? "";
 #else
-			return
-				(p.CustomAttributes
-				 .Where (x => typeof (CollationAttribute) == x.AttributeType)
-				 .Select (x => {
-					 var args = x.ConstructorArguments;
-					 return args.Count > 0 ? ((args[0].Value as string) ?? "") : "";
-				 })
-				 .FirstOrDefault ()) ?? "";
+            return
+                (p.CustomAttributes
+                 .Where (x => typeof (CollationAttribute) == x.AttributeType)
+                 .Select (x => {
+                     var args = x.ConstructorArguments;
+                     return args.Count > 0 ? ((args[0].Value as string) ?? "") : "";
+                 })
+                 .FirstOrDefault ()) ?? "";
 #endif
-		}
+        }
 
-		public static bool IsAutoInc (MemberInfo p)
-		{
-			return p.CustomAttributes.Any (x => x.AttributeType == typeof (AutoIncrementAttribute));
-		}
+        public static bool IsAutoInc (MemberInfo p)
+        {
+            return p.CustomAttributes.Any (x => x.AttributeType == typeof (AutoIncrementAttribute));
+        }
 
-		public static FieldInfo GetField (TypeInfo t, string name)
-		{
-			var f = t.GetDeclaredField (name);
-			if (f != null)
-				return f;
-			return GetField (t.BaseType.GetTypeInfo (), name);
-		}
+        public static FieldInfo GetField (TypeInfo t, string name)
+        {
+            var f = t.GetDeclaredField (name);
+            if (f != null)
+                return f;
+            return GetField (t.BaseType.GetTypeInfo (), name);
+        }
 
-		public static PropertyInfo GetProperty (TypeInfo t, string name)
-		{
-			var f = t.GetDeclaredProperty (name);
-			if (f != null)
-				return f;
-			return GetProperty (t.BaseType.GetTypeInfo (), name);
-		}
+        public static PropertyInfo GetProperty (TypeInfo t, string name)
+        {
+            var f = t.GetDeclaredProperty (name);
+            if (f != null)
+                return f;
+            return GetProperty (t.BaseType.GetTypeInfo (), name);
+        }
 
-		public static object InflateAttribute (CustomAttributeData x)
-		{
-			var atype = x.AttributeType;
-			var typeInfo = atype.GetTypeInfo ();
+        public static object InflateAttribute (CustomAttributeData x)
+        {
+            var atype = x.AttributeType;
+            var typeInfo = atype.GetTypeInfo ();
 #if ENABLE_IL2CPP
-			var r = Activator.CreateInstance (x.AttributeType);
+            var r = Activator.CreateInstance (x.AttributeType);
 #else
-			var args = x.ConstructorArguments.Select (a => a.Value).ToArray ();
-			var r = Activator.CreateInstance (x.AttributeType, args);
-			foreach (var arg in x.NamedArguments) {
-				if (arg.IsField) {
-					GetField (typeInfo, arg.MemberName).SetValue (r, arg.TypedValue.Value);
-				}
-				else {
-					GetProperty (typeInfo, arg.MemberName).SetValue (r, arg.TypedValue.Value);
-				}
-			}
+            var args = x.ConstructorArguments.Select (a => a.Value).ToArray ();
+            var r = Activator.CreateInstance (x.AttributeType, args);
+            foreach (var arg in x.NamedArguments) {
+                if (arg.IsField) {
+                    GetField (typeInfo, arg.MemberName).SetValue (r, arg.TypedValue.Value);
+                }
+                else {
+                    GetProperty (typeInfo, arg.MemberName).SetValue (r, arg.TypedValue.Value);
+                }
+            }
 #endif
-			return r;
-		}
+            return r;
+        }
 
-		public static IEnumerable<IndexedAttribute> GetIndices (MemberInfo p)
-		{
+        public static IEnumerable<IndexedAttribute> GetIndices (MemberInfo p)
+        {
 #if ENABLE_IL2CPP
-			return p.GetCustomAttributes<IndexedAttribute> ();
+            return p.GetCustomAttributes<IndexedAttribute> ();
 #else
-			var indexedInfo = typeof (IndexedAttribute).GetTypeInfo ();
-			return
-				p.CustomAttributes
-				 .Where (x => indexedInfo.IsAssignableFrom (x.AttributeType.GetTypeInfo ()))
-				 .Select (x => (IndexedAttribute)InflateAttribute (x));
+            var indexedInfo = typeof (IndexedAttribute).GetTypeInfo ();
+            return
+                p.CustomAttributes
+                 .Where (x => indexedInfo.IsAssignableFrom (x.AttributeType.GetTypeInfo ()))
+                 .Select (x => (IndexedAttribute)InflateAttribute (x));
 #endif
-		}
+        }
 
-		public static int? MaxStringLength (MemberInfo p)
-		{
+        public static int? MaxStringLength (MemberInfo p)
+        {
 #if ENABLE_IL2CPP
-			return p.GetCustomAttribute<MaxLengthAttribute> ()?.Value;
+            return p.GetCustomAttribute<MaxLengthAttribute> ()?.Value;
 #else
-			var attr = p.CustomAttributes.FirstOrDefault (x => x.AttributeType == typeof (MaxLengthAttribute));
-			if (attr != null) {
-				var attrv = (MaxLengthAttribute)InflateAttribute (attr);
-				return attrv.Value;
-			}
-			return null;
+            var attr = p.CustomAttributes.FirstOrDefault (x => x.AttributeType == typeof (MaxLengthAttribute));
+            if (attr != null) {
+                var attrv = (MaxLengthAttribute)InflateAttribute (attr);
+                return attrv.Value;
+            }
+            return null;
 #endif
-		}
-
-		public static int? MaxStringLength (PropertyInfo p) => MaxStringLength((MemberInfo)p);
-
-		public static bool IsMarkedNotNull (MemberInfo p)
-		{
-			return p.CustomAttributes.Any (x => x.AttributeType == typeof (NotNullAttribute));
-		}
-	}
-
-	public partial class SQLiteCommand
-	{
-		SQLiteConnection _conn;
-		private List<Binding> _bindings;
-
-		public string CommandText { get; set; }
-
-		public SQLiteCommand (SQLiteConnection conn)
-		{
-			_conn = conn;
-			_bindings = new List<Binding> ();
-			CommandText = "";
-		}
-
-		public int ExecuteNonQuery ()
-		{
-			if (_conn.Trace) {
-				_conn.Tracer?.Invoke ("Executing: " + this);
-			}
-
-			var r = SQLite3.Result.OK;
-			var stmt = Prepare ();
-			r = SQLite3.Step (stmt);
-			Finalize (stmt);
-			if (r == SQLite3.Result.Done) {
-				int rowsAffected = SQLite3.Changes (_conn.Handle);
-				return rowsAffected;
-			}
-			else if (r == SQLite3.Result.Error) {
-				string msg = SQLite3.GetErrmsg (_conn.Handle);
-				throw SQLiteException.New (r, msg);
-			}
-			else if (r == SQLite3.Result.Constraint) {
-				if (SQLite3.ExtendedErrCode (_conn.Handle) == SQLite3.ExtendedResult.ConstraintNotNull) {
-					throw NotNullConstraintViolationException.New (r, SQLite3.GetErrmsg (_conn.Handle));
-				}
-			}
-
-			throw SQLiteException.New (r, SQLite3.GetErrmsg (_conn.Handle));
-		}
-
-		public IEnumerable<T> ExecuteDeferredQuery<T> ()
-		{
-			return ExecuteDeferredQuery<T> (_conn.GetMapping (typeof (T)));
-		}
-
-		public List<T> ExecuteQuery<T> ()
-		{
-			return ExecuteDeferredQuery<T> (_conn.GetMapping (typeof (T))).ToList ();
-		}
-
-		public List<T> ExecuteQuery<T> (TableMapping map)
-		{
-			return ExecuteDeferredQuery<T> (map).ToList ();
-		}
-
-		/// <summary>
-		/// Invoked every time an instance is loaded from the database.
-		/// </summary>
-		/// <param name='obj'>
-		/// The newly created object.
-		/// </param>
-		/// <remarks>
-		/// This can be overridden in combination with the <see cref="SQLiteConnection.NewCommand"/>
-		/// method to hook into the life-cycle of objects.
-		/// </remarks>
-		protected virtual void OnInstanceCreated (object obj)
-		{
-			// Can be overridden.
-		}
-
-		public IEnumerable<T> ExecuteDeferredQuery<T> (TableMapping map)
-		{
-			if (_conn.Trace) {
-				_conn.Tracer?.Invoke ("Executing Query: " + this);
-			}
-
-			var stmt = Prepare ();
-			try {
-				var cols = new TableMapping.Column[SQLite3.ColumnCount (stmt)];
-				var fastColumnSetters = new Action<object, Sqlite3Statement, int>[SQLite3.ColumnCount (stmt)];
-
-				if (map.Method == TableMapping.MapMethod.ByPosition)
-				{
-					Array.Copy(map.Columns, cols, Math.Min(cols.Length, map.Columns.Length));
-				}
-				else if (map.Method == TableMapping.MapMethod.ByName) {
-					MethodInfo getSetter = null;
-					if (typeof(T) != map.MappedType) {
-						getSetter = typeof(FastColumnSetter)
-							.GetMethod (nameof(FastColumnSetter.GetFastSetter),
-								BindingFlags.NonPublic | BindingFlags.Static).MakeGenericMethod (map.MappedType);
-					}
-
-					for (int i = 0; i < cols.Length; i++) {						
-						var name = SQLite3.ColumnName16 (stmt, i);
-						cols[i] = map.FindColumn (name);
-						if (cols[i] != null)
-							if (getSetter != null) {
-								fastColumnSetters[i] = (Action<object, Sqlite3Statement, int>)getSetter.Invoke(null, new object[]{ _conn, cols[i]});
-							}
-							else {
-								fastColumnSetters[i] = FastColumnSetter.GetFastSetter<T>(_conn, cols[i]);
-							}
-					}
-				}
-
-				while (SQLite3.Step (stmt) == SQLite3.Result.Row) {
-					var obj = Activator.CreateInstance (map.MappedType);
-					for (int i = 0; i < cols.Length; i++) {
-						if (cols[i] == null)
-							continue;
-
-						if (fastColumnSetters[i] != null) {
-							fastColumnSetters[i].Invoke (obj, stmt, i);
-						}
-						else {
-							var colType = SQLite3.ColumnType (stmt, i);
-							var val = ReadCol (stmt, i, colType, cols[i].ColumnType);
-							cols[i].SetValue (obj, val);
-						}
-					}
-					OnInstanceCreated (obj);
-					yield return (T)obj;
-				}
-			}
-			finally {
-				SQLite3.Finalize (stmt);
-			}
-		}
-
-		public T ExecuteScalar<T> ()
-		{
-			if (_conn.Trace) {
-				_conn.Tracer?.Invoke ("Executing Query: " + this);
-			}
-
-			T val = default (T);
-
-			var stmt = Prepare ();
-
-			try {
-				var r = SQLite3.Step (stmt);
-				if (r == SQLite3.Result.Row) {
-					var colType = SQLite3.ColumnType (stmt, 0);
-					var colval = ReadCol (stmt, 0, colType, typeof (T));
-					if (colval != null) {
-						val = (T)colval;
-					}
-				}
-				else if (r == SQLite3.Result.Done) {
-				}
-				else {
-					throw SQLiteException.New (r, SQLite3.GetErrmsg (_conn.Handle));
-				}
-			}
-			finally {
-				Finalize (stmt);
-			}
-
-			return val;
-		}
-
-		public IEnumerable<T> ExecuteQueryScalars<T> ()
-		{
-			if (_conn.Trace) {
-				_conn.Tracer?.Invoke ("Executing Query: " + this);
-			}
-			var stmt = Prepare ();
-			try {
-				if (SQLite3.ColumnCount (stmt) < 1) {
-					throw new InvalidOperationException ("QueryScalars should return at least one column");
-				}
-				while (SQLite3.Step (stmt) == SQLite3.Result.Row) {
-					var colType = SQLite3.ColumnType (stmt, 0);
-					var val = ReadCol (stmt, 0, colType, typeof (T));
-					if (val == null) {
-						yield return default (T);
-					}
-					else {
-						yield return (T)val;
-					}
-				}
-			}
-			finally {
-				Finalize (stmt);
-			}
-		}
-
-		public void Bind (string name, object val)
-		{
-			_bindings.Add (new Binding {
-				Name = name,
-				Value = val
-			});
-		}
-
-		public void Bind (object val)
-		{
-			Bind (null, val);
-		}
-
-		public override string ToString ()
-		{
-			var parts = new string[1 + _bindings.Count];
-			parts[0] = CommandText;
-			var i = 1;
-			foreach (var b in _bindings) {
-				parts[i] = string.Format ("  {0}: {1}", i - 1, b.Value);
-				i++;
-			}
-			return string.Join (Environment.NewLine, parts);
-		}
-
-		Sqlite3Statement Prepare ()
-		{
-			var stmt = SQLite3.Prepare2 (_conn.Handle, CommandText);
-			BindAll (stmt);
-			return stmt;
-		}
-
-		void Finalize (Sqlite3Statement stmt)
-		{
-			SQLite3.Finalize (stmt);
-		}
-
-		void BindAll (Sqlite3Statement stmt)
-		{
-			int nextIdx = 1;
-			foreach (var b in _bindings) {
-				if (b.Name != null) {
-					b.Index = SQLite3.BindParameterIndex (stmt, b.Name);
-				}
-				else {
-					b.Index = nextIdx++;
-				}
-
-				BindParameter (stmt, b.Index, b.Value, _conn.StoreDateTimeAsTicks, _conn.DateTimeStringFormat, _conn.StoreTimeSpanAsTicks);
-			}
-		}
-
-		static IntPtr NegativePointer = new IntPtr (-1);
-
-		internal static void BindParameter (Sqlite3Statement stmt, int index, object value, bool storeDateTimeAsTicks, string dateTimeStringFormat, bool storeTimeSpanAsTicks)
-		{
-			if (value == null) {
-				SQLite3.BindNull (stmt, index);
-			}
-			else {
-				if (value is Int32) {
-					SQLite3.BindInt (stmt, index, (int)value);
-				}
-				else if (value is String) {
-					SQLite3.BindText (stmt, index, (string)value, -1, NegativePointer);
-				}
-				else if (value is Byte || value is UInt16 || value is SByte || value is Int16) {
-					SQLite3.BindInt (stmt, index, Convert.ToInt32 (value));
-				}
-				else if (value is Boolean) {
-					SQLite3.BindInt (stmt, index, (bool)value ? 1 : 0);
-				}
-				else if (value is UInt32 || value is Int64 || value is UInt64) {
-					SQLite3.BindInt64 (stmt, index, Convert.ToInt64 (value));
-				}
-				else if (value is Single || value is Double || value is Decimal) {
-					SQLite3.BindDouble (stmt, index, Convert.ToDouble (value));
-				}
-				else if (value is TimeSpan) {
-					if (storeTimeSpanAsTicks) {
-						SQLite3.BindInt64 (stmt, index, ((TimeSpan)value).Ticks);
-					}
-					else {
-						SQLite3.BindText (stmt, index, ((TimeSpan)value).ToString (), -1, NegativePointer);
-					}
-				}
-				else if (value is DateTime) {
-					if (storeDateTimeAsTicks) {
-						SQLite3.BindInt64 (stmt, index, ((DateTime)value).Ticks);
-					}
-					else {
-						SQLite3.BindText (stmt, index, ((DateTime)value).ToString (dateTimeStringFormat, System.Globalization.CultureInfo.InvariantCulture), -1, NegativePointer);
-					}
-				}
-				else if (value is DateTimeOffset) {
-					SQLite3.BindInt64 (stmt, index, ((DateTimeOffset)value).UtcTicks);
-				}
-				else if (value is byte[]) {
-					SQLite3.BindBlob (stmt, index, (byte[])value, ((byte[])value).Length, NegativePointer);
-				}
-				else if (value is Guid) {
-					SQLite3.BindText (stmt, index, ((Guid)value).ToString (), 72, NegativePointer);
-				}
-				else if (value is Uri) {
-					SQLite3.BindText (stmt, index, ((Uri)value).ToString (), -1, NegativePointer);
-				}
-				else if (value is StringBuilder) {
-					SQLite3.BindText (stmt, index, ((StringBuilder)value).ToString (), -1, NegativePointer);
-				}
-				else if (value is UriBuilder) {
-					SQLite3.BindText (stmt, index, ((UriBuilder)value).ToString (), -1, NegativePointer);
-				}
-				else {
-					// Now we could possibly get an enum, retrieve cached info
-					var valueType = value.GetType ();
-					var enumInfo = EnumCache.GetInfo (valueType);
-					if (enumInfo.IsEnum) {
-						var enumIntValue = Convert.ToInt32 (value);
-						if (enumInfo.StoreAsText)
-							SQLite3.BindText (stmt, index, enumInfo.EnumValues[enumIntValue], -1, NegativePointer);
-						else
-							SQLite3.BindInt (stmt, index, enumIntValue);
-					}
-					else {
-						throw new NotSupportedException ("Cannot store type: " + Orm.GetType (value));
-					}
-				}
-			}
-		}
-
-		class Binding
-		{
-			public string Name { get; set; }
-
-			public object Value { get; set; }
-
-			public int Index { get; set; }
-		}
-
-		object ReadCol (Sqlite3Statement stmt, int index, SQLite3.ColType type, Type clrType)
-		{
-			if (type == SQLite3.ColType.Null) {
-				return null;
-			}
-			else {
-				var clrTypeInfo = clrType.GetTypeInfo ();
-				if (clrTypeInfo.IsGenericType && clrTypeInfo.GetGenericTypeDefinition () == typeof (Nullable<>)) {
-					clrType = clrTypeInfo.GenericTypeArguments[0];
-					clrTypeInfo = clrType.GetTypeInfo ();
-				}
-
-				if (clrType == typeof (String)) {
-					return SQLite3.ColumnString (stmt, index);
-				}
-				else if (clrType == typeof (Int32)) {
-					return (int)SQLite3.ColumnInt (stmt, index);
-				}
-				else if (clrType == typeof (Boolean)) {
-					return SQLite3.ColumnInt (stmt, index) == 1;
-				}
-				else if (clrType == typeof (double)) {
-					return SQLite3.ColumnDouble (stmt, index);
-				}
-				else if (clrType == typeof (float)) {
-					return (float)SQLite3.ColumnDouble (stmt, index);
-				}
-				else if (clrType == typeof (TimeSpan)) {
-					if (_conn.StoreTimeSpanAsTicks) {
-						return new TimeSpan (SQLite3.ColumnInt64 (stmt, index));
-					}
-					else {
-						var text = SQLite3.ColumnString (stmt, index);
-						TimeSpan resultTime;
-						if (!TimeSpan.TryParseExact (text, "c", System.Globalization.CultureInfo.InvariantCulture, System.Globalization.TimeSpanStyles.None, out resultTime)) {
-							resultTime = TimeSpan.Parse (text);
-						}
-						return resultTime;
-					}
-				}
-				else if (clrType == typeof (DateTime)) {
-					if (_conn.StoreDateTimeAsTicks) {
-						return new DateTime (SQLite3.ColumnInt64 (stmt, index));
-					}
-					else {
-						var text = SQLite3.ColumnString (stmt, index);
-						DateTime resultDate;
-						if (!DateTime.TryParseExact (text, _conn.DateTimeStringFormat, System.Globalization.CultureInfo.InvariantCulture, _conn.DateTimeStyle, out resultDate)) {
-							resultDate = DateTime.Parse (text);
-						}
-						return resultDate;
-					}
-				}
-				else if (clrType == typeof (DateTimeOffset)) {
-					return new DateTimeOffset (SQLite3.ColumnInt64 (stmt, index), TimeSpan.Zero);
-				}
-				else if (clrTypeInfo.IsEnum) {
-					if (type == SQLite3.ColType.Text) {
-						var value = SQLite3.ColumnString (stmt, index);
-						return Enum.Parse (clrType, value.ToString (), true);
-					}
-					else
-						return SQLite3.ColumnInt (stmt, index);
-				}
-				else if (clrType == typeof (Int64)) {
-					return SQLite3.ColumnInt64 (stmt, index);
-				}
-				else if (clrType == typeof (UInt64)) {
-					return (ulong)SQLite3.ColumnInt64 (stmt, index);
-				}
-				else if (clrType == typeof (UInt32)) {
-					return (uint)SQLite3.ColumnInt64 (stmt, index);
-				}
-				else if (clrType == typeof (decimal)) {
-					return (decimal)SQLite3.ColumnDouble (stmt, index);
-				}
-				else if (clrType == typeof (Byte)) {
-					return (byte)SQLite3.ColumnInt (stmt, index);
-				}
-				else if (clrType == typeof (UInt16)) {
-					return (ushort)SQLite3.ColumnInt (stmt, index);
-				}
-				else if (clrType == typeof (Int16)) {
-					return (short)SQLite3.ColumnInt (stmt, index);
-				}
-				else if (clrType == typeof (sbyte)) {
-					return (sbyte)SQLite3.ColumnInt (stmt, index);
-				}
-				else if (clrType == typeof (byte[])) {
-					return SQLite3.ColumnByteArray (stmt, index);
-				}
-				else if (clrType == typeof (Guid)) {
-					var text = SQLite3.ColumnString (stmt, index);
-					return new Guid (text);
-				}
-				else if (clrType == typeof (Uri)) {
-					var text = SQLite3.ColumnString (stmt, index);
-					return new Uri (text);
-				}
-				else if (clrType == typeof (StringBuilder)) {
-					var text = SQLite3.ColumnString (stmt, index);
-					return new StringBuilder (text);
-				}
-				else if (clrType == typeof (UriBuilder)) {
-					var text = SQLite3.ColumnString (stmt, index);
-					return new UriBuilder (text);
-				}
-				else {
-					throw new NotSupportedException ("Don't know how to read " + clrType);
-				}
-			}
-		}
-	}
-
-	internal class FastColumnSetter
-	{
-		/// <summary>
-		/// Creates a delegate that can be used to quickly set object members from query columns.
-		///
-		/// Note that this frontloads the slow reflection-based type checking for columns to only happen once at the beginning of a query,
-		/// and then afterwards each row of the query can invoke the delegate returned by this function to get much better performance (up to 10x speed boost, depending on query size and platform).
-		/// </summary>
-		/// <typeparam name="T">The type of the destination object that the query will read into</typeparam>
-		/// <param name="conn">The active connection.  Note that this is primarily needed in order to read preferences regarding how certain data types (such as TimeSpan / DateTime) should be encoded in the database.</param>
-		/// <param name="column">The table mapping used to map the statement column to a member of the destination object type</param>
-		/// <returns>
-		/// A delegate for fast-setting of object members from statement columns.
-		///
-		/// If no fast setter is available for the requested column (enums in particular cause headache), then this function returns null.
-		/// </returns>
-		internal static Action<object, Sqlite3Statement, int> GetFastSetter<T> (SQLiteConnection conn, TableMapping.Column column)
-		{
-			Action<object, Sqlite3Statement, int> fastSetter = null;
-
-			Type clrType = column.PropertyInfo.PropertyType;
-
-			var clrTypeInfo = clrType.GetTypeInfo ();
-			if (clrTypeInfo.IsGenericType && clrTypeInfo.GetGenericTypeDefinition () == typeof (Nullable<>)) {
-				clrType = clrTypeInfo.GenericTypeArguments[0];
-				clrTypeInfo = clrType.GetTypeInfo ();
-			}
-
-			if (clrType == typeof (String)) {
-				fastSetter = CreateTypedSetterDelegate<T, string> (column, (stmt, index) => {
-					return SQLite3.ColumnString (stmt, index);
-				});
-			}
-			else if (clrType == typeof (Int32)) {
-				fastSetter = CreateNullableTypedSetterDelegate<T, int> (column, (stmt, index)=>{
-					return SQLite3.ColumnInt (stmt, index);
-				});
-			}
-			else if (clrType == typeof (Boolean)) {
-				fastSetter = CreateNullableTypedSetterDelegate<T, bool> (column, (stmt, index) => {
-					return SQLite3.ColumnInt (stmt, index) == 1;
-				});
-			}
-			else if (clrType == typeof (double)) {
-				fastSetter = CreateNullableTypedSetterDelegate<T, double> (column, (stmt, index) => {
-					return SQLite3.ColumnDouble (stmt, index);
-				});
-			}
-			else if (clrType == typeof (float)) {
-				fastSetter = CreateNullableTypedSetterDelegate<T, float> (column, (stmt, index) => {
-					return (float) SQLite3.ColumnDouble (stmt, index);
-				});
-			}
-			else if (clrType == typeof (TimeSpan)) {
-				if (conn.StoreTimeSpanAsTicks) {
-					fastSetter = CreateNullableTypedSetterDelegate<T, TimeSpan> (column, (stmt, index) => {
-						return new TimeSpan (SQLite3.ColumnInt64 (stmt, index));
-					});
-				}
-				else {
-					fastSetter = CreateNullableTypedSetterDelegate<T, TimeSpan> (column, (stmt, index) => {
-						var text = SQLite3.ColumnString (stmt, index);
-						TimeSpan resultTime;
-						if (!TimeSpan.TryParseExact (text, "c", System.Globalization.CultureInfo.InvariantCulture, System.Globalization.TimeSpanStyles.None, out resultTime)) {
-							resultTime = TimeSpan.Parse (text);
-						}
-						return resultTime;
-					});
-				}
-			}
-			else if (clrType == typeof (DateTime)) {
-				if (conn.StoreDateTimeAsTicks) {
-					fastSetter = CreateNullableTypedSetterDelegate<T, DateTime> (column, (stmt, index) => {
-						return new DateTime (SQLite3.ColumnInt64 (stmt, index));
-					});
-				}
-				else {
-					fastSetter = CreateNullableTypedSetterDelegate<T, DateTime> (column, (stmt, index) => {
-						var text = SQLite3.ColumnString (stmt, index);
-						DateTime resultDate;
-						if (!DateTime.TryParseExact (text, conn.DateTimeStringFormat, System.Globalization.CultureInfo.InvariantCulture, conn.DateTimeStyle, out resultDate)) {
-							resultDate = DateTime.Parse (text);
-						}
-						return resultDate;
-					});
-				}
-			}
-			else if (clrType == typeof (DateTimeOffset)) {
-				fastSetter = CreateNullableTypedSetterDelegate<T, DateTimeOffset> (column, (stmt, index) => {
-					return new DateTimeOffset (SQLite3.ColumnInt64 (stmt, index), TimeSpan.Zero);
-				});
-			}
-			else if (clrTypeInfo.IsEnum) {
-				// NOTE: Not sure of a good way (if any?) to do a strongly-typed fast setter like this for enumerated types -- for now, return null and column sets will revert back to the safe (but slow) Reflection-based method of column prop.Set()
-			}
-			else if (clrType == typeof (Int64)) {
-				fastSetter = CreateNullableTypedSetterDelegate<T, Int64> (column, (stmt, index) => {
-					return SQLite3.ColumnInt64 (stmt, index);
-				});
-			}
-			else if (clrType == typeof(UInt64))
-			{
-				fastSetter = CreateNullableTypedSetterDelegate<T, UInt64>(column, (stmt, index) => {
-					return (ulong)SQLite3.ColumnInt64(stmt, index);
-				});
-			}
-			else if (clrType == typeof (UInt32)) {
-				fastSetter = CreateNullableTypedSetterDelegate<T, UInt32> (column, (stmt, index) => {
-					return (uint)SQLite3.ColumnInt64 (stmt, index);
-				});
-			}
-			else if (clrType == typeof (decimal)) {
-				fastSetter = CreateNullableTypedSetterDelegate<T, decimal> (column, (stmt, index) => {
-					return (decimal)SQLite3.ColumnDouble (stmt, index);
-				});
-			}
-			else if (clrType == typeof (Byte)) {
-				fastSetter = CreateNullableTypedSetterDelegate<T, Byte> (column, (stmt, index) => {
-					return (byte)SQLite3.ColumnInt (stmt, index);
-				});
-			}
-			else if (clrType == typeof (UInt16)) {
-				fastSetter = CreateNullableTypedSetterDelegate<T, UInt16> (column, (stmt, index) => {
-					return (ushort)SQLite3.ColumnInt (stmt, index);
-				});
-			}
-			else if (clrType == typeof (Int16)) {
-				fastSetter = CreateNullableTypedSetterDelegate<T, Int16> (column, (stmt, index) => {
-					return (short)SQLite3.ColumnInt (stmt, index);
-				});
-			}
-			else if (clrType == typeof (sbyte)) {
-				fastSetter = CreateNullableTypedSetterDelegate<T, sbyte> (column, (stmt, index) => {
-					return (sbyte)SQLite3.ColumnInt (stmt, index);
-				});
-			}
-			else if (clrType == typeof (byte[])) {
-				fastSetter = CreateTypedSetterDelegate<T, byte[]> (column, (stmt, index) => {
-					return SQLite3.ColumnByteArray (stmt, index);
-				});
-			}
-			else if (clrType == typeof (Guid)) {
-				fastSetter = CreateNullableTypedSetterDelegate<T, Guid> (column, (stmt, index) => {
-					var text = SQLite3.ColumnString (stmt, index);
-					return new Guid (text);
-				});
-			}
-			else if (clrType == typeof (Uri)) {
-				fastSetter = CreateTypedSetterDelegate<T, Uri> (column, (stmt, index) => {
-					var text = SQLite3.ColumnString (stmt, index);
-					return new Uri (text);
-				});
-			}
-			else if (clrType == typeof (StringBuilder)) {
-				fastSetter = CreateTypedSetterDelegate<T, StringBuilder> (column, (stmt, index) => {
-					var text = SQLite3.ColumnString (stmt, index);
-					return new StringBuilder (text);
-				});
-			}
-			else if (clrType == typeof (UriBuilder)) {
-				fastSetter = CreateTypedSetterDelegate<T, UriBuilder> (column, (stmt, index) => {
-					var text = SQLite3.ColumnString (stmt, index);
-					return new UriBuilder (text);
-				});
-			}
-			else {
-				// NOTE: Will fall back to the slow setter method in the event that we are unable to create a fast setter delegate for a particular column type
-			}
-			return fastSetter;
-		}
-
-		/// <summary>
-		/// This creates a strongly typed delegate that will permit fast setting of column values given a Sqlite3Statement and a column index.
-		///
-		/// Note that this is identical to CreateTypedSetterDelegate(), but has an extra check to see if it should create a nullable version of the delegate.
-		/// </summary>
-		/// <typeparam name="ObjectType">The type of the object whose member column is being set</typeparam>
-		/// <typeparam name="ColumnMemberType">The CLR type of the member in the object which corresponds to the given SQLite columnn</typeparam>
-		/// <param name="column">The column mapping that identifies the target member of the destination object</param>
-		/// <param name="getColumnValue">A lambda that can be used to retrieve the column value at query-time</param>
-		/// <returns>A strongly-typed delegate</returns>
-		private static Action<object, Sqlite3Statement, int> CreateNullableTypedSetterDelegate<ObjectType, ColumnMemberType> (TableMapping.Column column, Func<Sqlite3Statement, int, ColumnMemberType> getColumnValue) where ColumnMemberType : struct
-		{
-			var clrTypeInfo = column.PropertyInfo.PropertyType.GetTypeInfo();
-			bool isNullable = false;
-
-			if (clrTypeInfo.IsGenericType && clrTypeInfo.GetGenericTypeDefinition () == typeof (Nullable<>)) {
-				isNullable = true;
-			}
-
-			if (isNullable) {
-				var setProperty = (Action<ObjectType, ColumnMemberType?>)Delegate.CreateDelegate (
-						typeof (Action<ObjectType, ColumnMemberType?>), null,
-						column.PropertyInfo.GetSetMethod ());
-
-				return (o, stmt, i) => {
-					var colType = SQLite3.ColumnType (stmt, i);
-					if (colType != SQLite3.ColType.Null)
-						setProperty.Invoke ((ObjectType)o, getColumnValue.Invoke (stmt, i));
-				};
-			}
-
-			return CreateTypedSetterDelegate<ObjectType, ColumnMemberType> (column, getColumnValue);
-		}
-
-		/// <summary>
-		/// This creates a strongly typed delegate that will permit fast setting of column values given a Sqlite3Statement and a column index.
-		/// </summary>
-		/// <typeparam name="ObjectType">The type of the object whose member column is being set</typeparam>
-		/// <typeparam name="ColumnMemberType">The CLR type of the member in the object which corresponds to the given SQLite columnn</typeparam>
-		/// <param name="column">The column mapping that identifies the target member of the destination object</param>
-		/// <param name="getColumnValue">A lambda that can be used to retrieve the column value at query-time</param>
-		/// <returns>A strongly-typed delegate</returns>
-		private static Action<object, Sqlite3Statement, int> CreateTypedSetterDelegate<ObjectType, ColumnMemberType> (TableMapping.Column column, Func<Sqlite3Statement, int, ColumnMemberType> getColumnValue)
-		{
-			var setProperty = (Action<ObjectType, ColumnMemberType>)Delegate.CreateDelegate (
-					typeof (Action<ObjectType, ColumnMemberType>), null,
-					column.PropertyInfo.GetSetMethod ());
-
-			return (o, stmt, i) => {
-				var colType = SQLite3.ColumnType (stmt, i);
-				if (colType != SQLite3.ColType.Null)
-					setProperty.Invoke ((ObjectType)o, getColumnValue.Invoke (stmt, i));
-			};
-		}
-	}
-
-	/// <summary>
-	/// Since the insert never changed, we only need to prepare once.
-	/// </summary>
-	class PreparedSqlLiteInsertCommand : IDisposable
-	{
-		bool Initialized;
-
-		SQLiteConnection Connection;
-
-		string CommandText;
-
-		Sqlite3Statement Statement;
-		static readonly Sqlite3Statement NullStatement = default (Sqlite3Statement);
-
-		public PreparedSqlLiteInsertCommand (SQLiteConnection conn, string commandText)
-		{
-			Connection = conn;
-			CommandText = commandText;
-		}
-
-		public int ExecuteNonQuery (object[] source)
-		{
-			if (Initialized && Statement == NullStatement) {
-				throw new ObjectDisposedException (nameof (PreparedSqlLiteInsertCommand));
-			}
-
-			if (Connection.Trace) {
-				Connection.Tracer?.Invoke ("Executing: " + CommandText);
-			}
-
-			var r = SQLite3.Result.OK;
-
-			if (!Initialized) {
-				Statement = SQLite3.Prepare2 (Connection.Handle, CommandText);
-				Initialized = true;
-			}
-
-			//bind the values.
-			if (source != null) {
-				for (int i = 0; i < source.Length; i++) {
-					SQLiteCommand.BindParameter (Statement, i + 1, source[i], Connection.StoreDateTimeAsTicks, Connection.DateTimeStringFormat, Connection.StoreTimeSpanAsTicks);
-				}
-			}
-			r = SQLite3.Step (Statement);
-
-			if (r == SQLite3.Result.Done) {
-				int rowsAffected = SQLite3.Changes (Connection.Handle);
-				SQLite3.Reset (Statement);
-				return rowsAffected;
-			}
-			else if (r == SQLite3.Result.Error) {
-				string msg = SQLite3.GetErrmsg (Connection.Handle);
-				SQLite3.Reset (Statement);
-				throw SQLiteException.New (r, msg);
-			}
-			else if (r == SQLite3.Result.Constraint && SQLite3.ExtendedErrCode (Connection.Handle) == SQLite3.ExtendedResult.ConstraintNotNull) {
-				SQLite3.Reset (Statement);
-				throw NotNullConstraintViolationException.New (r, SQLite3.GetErrmsg (Connection.Handle));
-			}
-			else {
-				SQLite3.Reset (Statement);
-				throw SQLiteException.New (r, SQLite3.GetErrmsg (Connection.Handle));
-			}
-		}
-
-		public void Dispose ()
-		{
-			Dispose (true);
-			GC.SuppressFinalize (this);
-		}
-
-		void Dispose (bool disposing)
-		{
-			var s = Statement;
-			Statement = NullStatement;
-			Connection = null;
-			if (s != NullStatement) {
-				SQLite3.Finalize (s);
-			}
-		}
-
-		~PreparedSqlLiteInsertCommand ()
-		{
-			Dispose (false);
-		}
-	}
-
-	public enum CreateTableResult
-	{
-		Created,
-		Migrated,
-	}
-
-	public class CreateTablesResult
-	{
-		public Dictionary<Type, CreateTableResult> Results { get; private set; }
-
-		public CreateTablesResult ()
-		{
-			Results = new Dictionary<Type, CreateTableResult> ();
-		}
-	}
-
-	public abstract class BaseTableQuery
-	{
-		protected class Ordering
-		{
-			public string ColumnName { get; set; }
-			public bool Ascending { get; set; }
-		}
-	}
-
-	public class TableQuery<T> : BaseTableQuery, IEnumerable<T>
-	{
-		public SQLiteConnection Connection { get; private set; }
-
-		public TableMapping Table { get; private set; }
-
-		Expression _where;
-		List<Ordering> _orderBys;
-		int? _limit;
-		int? _offset;
-
-		BaseTableQuery _joinInner;
-		Expression _joinInnerKeySelector;
-		BaseTableQuery _joinOuter;
-		Expression _joinOuterKeySelector;
-		Expression _joinSelector;
-
-		Expression _selector;
-
-		TableQuery (SQLiteConnection conn, TableMapping table)
-		{
-			Connection = conn;
-			Table = table;
-		}
-
-		public TableQuery (SQLiteConnection conn)
-		{
-			Connection = conn;
-			Table = Connection.GetMapping (typeof (T));
-		}
-
-		public TableQuery<U> Clone<U> ()
-		{
-			var q = new TableQuery<U> (Connection, Table);
-			q._where = _where;
-			q._deferred = _deferred;
-			if (_orderBys != null) {
-				q._orderBys = new List<Ordering> (_orderBys);
-			}
-			q._limit = _limit;
-			q._offset = _offset;
-			q._joinInner = _joinInner;
-			q._joinInnerKeySelector = _joinInnerKeySelector;
-			q._joinOuter = _joinOuter;
-			q._joinOuterKeySelector = _joinOuterKeySelector;
-			q._joinSelector = _joinSelector;
-			q._selector = _selector;
-			return q;
-		}
-
-		/// <summary>
-		/// Filters the query based on a predicate.
-		/// </summary>
-		public TableQuery<T> Where (Expression<Func<T, bool>> predExpr)
-		{
-			if (predExpr.NodeType == ExpressionType.Lambda) {
-				var lambda = (LambdaExpression)predExpr;
-				var pred = lambda.Body;
-				var q = Clone<T> ();
-				q.AddWhere (pred);
-				return q;
-			}
-			else {
-				throw new NotSupportedException ("Must be a predicate");
-			}
-		}
-
-		/// <summary>
-		/// Delete all the rows that match this query.
-		/// </summary>
-		public int Delete ()
-		{
-			return Delete (null);
-		}
-
-		/// <summary>
-		/// Delete all the rows that match this query and the given predicate.
-		/// </summary>
-		public int Delete (Expression<Func<T, bool>> predExpr)
-		{
-			if (_limit.HasValue || _offset.HasValue)
-				throw new InvalidOperationException ("Cannot delete with limits or offsets");
-
-			if (_where == null && predExpr == null)
-				throw new InvalidOperationException ("No condition specified");
-
-			var pred = _where;
-
-			if (predExpr != null && predExpr.NodeType == ExpressionType.Lambda) {
-				var lambda = (LambdaExpression)predExpr;
-				pred = pred != null ? Expression.AndAlso (pred, lambda.Body) : lambda.Body;
-			}
-
-			var args = new List<object> ();
-			var cmdText = "delete from \"" + Table.TableName + "\"";
-			var w = CompileExpr (pred, args);
-			cmdText += " where " + w.CommandText;
-
-			var command = Connection.CreateCommand (cmdText, args.ToArray ());
-
-			int result = command.ExecuteNonQuery ();
-			return result;
-		}
-
-		/// <summary>
-		/// Yields a given number of elements from the query and then skips the remainder.
-		/// </summary>
-		public TableQuery<T> Take (int n)
-		{
-			var q = Clone<T> ();
-			q._limit = n;
-			return q;
-		}
-
-		/// <summary>
-		/// Skips a given number of elements from the query and then yields the remainder.
-		/// </summary>
-		public TableQuery<T> Skip (int n)
-		{
-			var q = Clone<T> ();
-			q._offset = n;
-			return q;
-		}
-
-		/// <summary>
-		/// Returns the element at a given index
-		/// </summary>
-		public T ElementAt (int index)
-		{
-			return Skip (index).Take (1).First ();
-		}
-
-		bool _deferred;
-		public TableQuery<T> Deferred ()
-		{
-			var q = Clone<T> ();
-			q._deferred = true;
-			return q;
-		}
-
-		/// <summary>
-		/// Order the query results according to a key.
-		/// </summary>
-		public TableQuery<T> OrderBy<U> (Expression<Func<T, U>> orderExpr)
-		{
-			return AddOrderBy<U> (orderExpr, true);
-		}
-
-		/// <summary>
-		/// Order the query results according to a key.
-		/// </summary>
-		public TableQuery<T> OrderByDescending<U> (Expression<Func<T, U>> orderExpr)
-		{
-			return AddOrderBy<U> (orderExpr, false);
-		}
-
-		/// <summary>
-		/// Order the query results according to a key.
-		/// </summary>
-		public TableQuery<T> ThenBy<U> (Expression<Func<T, U>> orderExpr)
-		{
-			return AddOrderBy<U> (orderExpr, true);
-		}
-
-		/// <summary>
-		/// Order the query results according to a key.
-		/// </summary>
-		public TableQuery<T> ThenByDescending<U> (Expression<Func<T, U>> orderExpr)
-		{
-			return AddOrderBy<U> (orderExpr, false);
-		}
-
-		TableQuery<T> AddOrderBy<U> (Expression<Func<T, U>> orderExpr, bool asc)
-		{
-			if (orderExpr.NodeType == ExpressionType.Lambda) {
-				var lambda = (LambdaExpression)orderExpr;
-
-				MemberExpression mem = null;
-
-				var unary = lambda.Body as UnaryExpression;
-				if (unary != null && unary.NodeType == ExpressionType.Convert) {
-					mem = unary.Operand as MemberExpression;
-				}
-				else {
-					mem = lambda.Body as MemberExpression;
-				}
-
-				if (mem != null && (mem.Expression.NodeType == ExpressionType.Parameter)) {
-					var q = Clone<T> ();
-					if (q._orderBys == null) {
-						q._orderBys = new List<Ordering> ();
-					}
-					q._orderBys.Add (new Ordering {
-						ColumnName = Table.FindColumnWithPropertyName (mem.Member.Name).Name,
-						Ascending = asc
-					});
-					return q;
-				}
-				else {
-					throw new NotSupportedException ("Order By does not support: " + orderExpr);
-				}
-			}
-			else {
-				throw new NotSupportedException ("Must be a predicate");
-			}
-		}
-
-		private void AddWhere (Expression pred)
-		{
-			if (_where == null) {
-				_where = pred;
-			}
-			else {
-				_where = Expression.AndAlso (_where, pred);
-			}
-		}
-
-		///// <summary>
-		///// Performs an inner join of two queries based on matching keys extracted from the elements.
-		///// </summary>
-		//public TableQuery<TResult> Join<TInner, TKey, TResult> (
-		//	TableQuery<TInner> inner,
-		//	Expression<Func<T, TKey>> outerKeySelector,
-		//	Expression<Func<TInner, TKey>> innerKeySelector,
-		//	Expression<Func<T, TInner, TResult>> resultSelector)
-		//{
-		//	var q = new TableQuery<TResult> (Connection, Connection.GetMapping (typeof (TResult))) {
-		//		_joinOuter = this,
-		//		_joinOuterKeySelector = outerKeySelector,
-		//		_joinInner = inner,
-		//		_joinInnerKeySelector = innerKeySelector,
-		//		_joinSelector = resultSelector,
-		//	};
-		//	return q;
-		//}
-
-		// Not needed until Joins are supported
-		// Keeping this commented out forces the default Linq to objects processor to run
-		//public TableQuery<TResult> Select<TResult> (Expression<Func<T, TResult>> selector)
-		//{
-		//	var q = Clone<TResult> ();
-		//	q._selector = selector;
-		//	return q;
-		//}
-
-		private SQLiteCommand GenerateCommand (string selectionList)
-		{
-			if (_joinInner != null && _joinOuter != null) {
-				throw new NotSupportedException ("Joins are not supported.");
-			}
-			else {
-				var cmdText = "select " + selectionList + " from \"" + Table.TableName + "\"";
-				var args = new List<object> ();
-				if (_where != null) {
-					var w = CompileExpr (_where, args);
-					cmdText += " where " + w.CommandText;
-				}
-				if ((_orderBys != null) && (_orderBys.Count > 0)) {
-					var t = string.Join (", ", _orderBys.Select (o => "\"" + o.ColumnName + "\"" + (o.Ascending ? "" : " desc")).ToArray ());
-					cmdText += " order by " + t;
-				}
-				if (_limit.HasValue) {
-					cmdText += " limit " + _limit.Value;
-				}
-				if (_offset.HasValue) {
-					if (!_limit.HasValue) {
-						cmdText += " limit -1 ";
-					}
-					cmdText += " offset " + _offset.Value;
-				}
-				return Connection.CreateCommand (cmdText, args.ToArray ());
-			}
-		}
-
-		class CompileResult
-		{
-			public string CommandText { get; set; }
-
-			public object Value { get; set; }
-		}
-
-		private CompileResult CompileExpr (Expression expr, List<object> queryArgs)
-		{
-			if (expr == null) {
-				throw new NotSupportedException ("Expression is NULL");
-			}
-			else if (expr is BinaryExpression) {
-				var bin = (BinaryExpression)expr;
-
-				// VB turns 'x=="foo"' into 'CompareString(x,"foo",true/false)==0', so we need to unwrap it
-				// http://blogs.msdn.com/b/vbteam/archive/2007/09/18/vb-expression-trees-string-comparisons.aspx
-				if (bin.Left.NodeType == ExpressionType.Call) {
-					var call = (MethodCallExpression)bin.Left;
-					if (call.Method.DeclaringType.FullName == "Microsoft.VisualBasic.CompilerServices.Operators"
-						&& call.Method.Name == "CompareString")
-						bin = Expression.MakeBinary (bin.NodeType, call.Arguments[0], call.Arguments[1]);
-				}
-
-
-				var leftr = CompileExpr (bin.Left, queryArgs);
-				var rightr = CompileExpr (bin.Right, queryArgs);
-
-				//If either side is a parameter and is null, then handle the other side specially (for "is null"/"is not null")
-				string text;
-				if (leftr.CommandText == "?" && leftr.Value == null)
-					text = CompileNullBinaryExpression (bin, rightr);
-				else if (rightr.CommandText == "?" && rightr.Value == null)
-					text = CompileNullBinaryExpression (bin, leftr);
-				else
-					text = "(" + leftr.CommandText + " " + GetSqlName (bin) + " " + rightr.CommandText + ")";
-				return new CompileResult { CommandText = text };
-			}
-			else if (expr.NodeType == ExpressionType.Not) {
-				var operandExpr = ((UnaryExpression)expr).Operand;
-				var opr = CompileExpr (operandExpr, queryArgs);
-				object val = opr.Value;
-				if (val is bool)
-					val = !((bool)val);
-				return new CompileResult {
-					CommandText = "NOT(" + opr.CommandText + ")",
-					Value = val
-				};
-			}
-			else if (expr.NodeType == ExpressionType.Call) {
-
-				var call = (MethodCallExpression)expr;
-				var args = new CompileResult[call.Arguments.Count];
-				var obj = call.Object != null ? CompileExpr (call.Object, queryArgs) : null;
-
-				for (var i = 0; i < args.Length; i++) {
-					args[i] = CompileExpr (call.Arguments[i], queryArgs);
-				}
-
-				var sqlCall = "";
-
-				if (call.Method.Name == "Like" && args.Length == 2) {
-					sqlCall = "(" + args[0].CommandText + " like " + args[1].CommandText + ")";
-				}
-				else if (call.Method.Name == "Contains" && args.Length == 2) {
-					sqlCall = "(" + args[1].CommandText + " in " + args[0].CommandText + ")";
-				}
-				else if (call.Method.Name == "Contains" && args.Length == 1) {
-					if (call.Object != null && call.Object.Type == typeof (string)) {
-						sqlCall = "( instr(" + obj.CommandText + "," + args[0].CommandText + ") >0 )";
-					}
-					else {
-						sqlCall = "(" + args[0].CommandText + " in " + obj.CommandText + ")";
-					}
-				}
-				else if (call.Method.Name == "StartsWith" && args.Length >= 1) {
-					var startsWithCmpOp = StringComparison.CurrentCulture;
-					if (args.Length == 2) {
-						startsWithCmpOp = (StringComparison)args[1].Value;
-					}
-					switch (startsWithCmpOp) {
-						case StringComparison.Ordinal:
-						case StringComparison.CurrentCulture:
-							sqlCall = "( substr(" + obj.CommandText + ", 1, " + args[0].Value.ToString ().Length + ") =  " + args[0].CommandText + ")";
-							break;
-						case StringComparison.OrdinalIgnoreCase:
-						case StringComparison.CurrentCultureIgnoreCase:
-							sqlCall = "(" + obj.CommandText + " like (" + args[0].CommandText + " || '%'))";
-							break;
-					}
-
-				}
-				else if (call.Method.Name == "EndsWith" && args.Length >= 1) {
-					var endsWithCmpOp = StringComparison.CurrentCulture;
-					if (args.Length == 2) {
-						endsWithCmpOp = (StringComparison)args[1].Value;
-					}
-					switch (endsWithCmpOp) {
-						case StringComparison.Ordinal:
-						case StringComparison.CurrentCulture:
-							sqlCall = "( substr(" + obj.CommandText + ", length(" + obj.CommandText + ") - " + args[0].Value.ToString ().Length + "+1, " + args[0].Value.ToString ().Length + ") =  " + args[0].CommandText + ")";
-							break;
-						case StringComparison.OrdinalIgnoreCase:
-						case StringComparison.CurrentCultureIgnoreCase:
-							sqlCall = "(" + obj.CommandText + " like ('%' || " + args[0].CommandText + "))";
-							break;
-					}
-				}
-				else if (call.Method.Name == "Equals" && args.Length == 1) {
-					sqlCall = "(" + obj.CommandText + " = (" + args[0].CommandText + "))";
-				}
-				else if (call.Method.Name == "ToLower") {
-					sqlCall = "(lower(" + obj.CommandText + "))";
-				}
-				else if (call.Method.Name == "ToUpper") {
-					sqlCall = "(upper(" + obj.CommandText + "))";
-				}
-				else if (call.Method.Name == "Replace" && args.Length == 2) {
-					sqlCall = "(replace(" + obj.CommandText + "," + args[0].CommandText + "," + args[1].CommandText + "))";
-				}
-				else if (call.Method.Name == "IsNullOrEmpty" && args.Length == 1) {
-					sqlCall = "(" + args[0].CommandText + " is null or" + args[0].CommandText + " ='' )";
-				}
-				else {
-					sqlCall = call.Method.Name.ToLower () + "(" + string.Join (",", args.Select (a => a.CommandText).ToArray ()) + ")";
-				}
-				return new CompileResult { CommandText = sqlCall };
-
-			}
-			else if (expr.NodeType == ExpressionType.Constant) {
-				var c = (ConstantExpression)expr;
-				queryArgs.Add (c.Value);
-				return new CompileResult {
-					CommandText = "?",
-					Value = c.Value
-				};
-			}
-			else if (expr.NodeType == ExpressionType.Convert) {
-				var u = (UnaryExpression)expr;
-				var ty = u.Type;
-				var valr = CompileExpr (u.Operand, queryArgs);
-				return new CompileResult {
-					CommandText = valr.CommandText,
-					Value = valr.Value != null ? ConvertTo (valr.Value, ty) : null
-				};
-			}
-			else if (expr.NodeType == ExpressionType.MemberAccess) {
-				var mem = (MemberExpression)expr;
-
-				var paramExpr = mem.Expression as ParameterExpression;
-				if (paramExpr == null) {
-					var convert = mem.Expression as UnaryExpression;
-					if (convert != null && convert.NodeType == ExpressionType.Convert) {
-						paramExpr = convert.Operand as ParameterExpression;
-					}
-				}
-
-				if (paramExpr != null) {
-					//
-					// This is a column of our table, output just the column name
-					// Need to translate it if that column name is mapped
-					//
-					var columnName = Table.FindColumnWithPropertyName (mem.Member.Name).Name;
-					return new CompileResult { CommandText = "\"" + columnName + "\"" };
-				}
-				else {
-					object obj = null;
-					if (mem.Expression != null) {
-						var r = CompileExpr (mem.Expression, queryArgs);
-						if (r.Value == null) {
-							throw new NotSupportedException ("Member access failed to compile expression");
-						}
-						if (r.CommandText == "?") {
-							queryArgs.RemoveAt (queryArgs.Count - 1);
-						}
-						obj = r.Value;
-					}
-
-					//
-					// Get the member value
-					//
-					object val = null;
-
-					if (mem.Member is PropertyInfo) {
-						var m = (PropertyInfo)mem.Member;
-						val = m.GetValue (obj, null);
-					}
-					else if (mem.Member is FieldInfo) {
-						var m = (FieldInfo)mem.Member;
-						val = m.GetValue (obj);
-					}
-					else {
-						throw new NotSupportedException ("MemberExpr: " + mem.Member.GetType ());
-					}
-
-					//
-					// Work special magic for enumerables
-					//
-					if (val != null && val is System.Collections.IEnumerable && !(val is string) && !(val is System.Collections.Generic.IEnumerable<byte>)) {
-						var sb = new System.Text.StringBuilder ();
-						sb.Append ("(");
-						var head = "";
-						foreach (var a in (System.Collections.IEnumerable)val) {
-							queryArgs.Add (a);
-							sb.Append (head);
-							sb.Append ("?");
-							head = ",";
-						}
-						sb.Append (")");
-						return new CompileResult {
-							CommandText = sb.ToString (),
-							Value = val
-						};
-					}
-					else {
-						queryArgs.Add (val);
-						return new CompileResult {
-							CommandText = "?",
-							Value = val
-						};
-					}
-				}
-			}
-			throw new NotSupportedException ("Cannot compile: " + expr.NodeType.ToString ());
-		}
-
-		static object ConvertTo (object obj, Type t)
-		{
-			Type nut = Nullable.GetUnderlyingType (t);
-
-			if (nut != null) {
-				if (obj == null)
-					return null;
-				return Convert.ChangeType (obj, nut);
-			}
-			else {
-				return Convert.ChangeType (obj, t);
-			}
-		}
-
-		/// <summary>
-		/// Compiles a BinaryExpression where one of the parameters is null.
-		/// </summary>
-		/// <param name="expression">The expression to compile</param>
-		/// <param name="parameter">The non-null parameter</param>
-		private string CompileNullBinaryExpression (BinaryExpression expression, CompileResult parameter)
-		{
-			if (expression.NodeType == ExpressionType.Equal)
-				return "(" + parameter.CommandText + " is ?)";
-			else if (expression.NodeType == ExpressionType.NotEqual)
-				return "(" + parameter.CommandText + " is not ?)";
-			else if (expression.NodeType == ExpressionType.GreaterThan
-				|| expression.NodeType == ExpressionType.GreaterThanOrEqual
-				|| expression.NodeType == ExpressionType.LessThan
-				|| expression.NodeType == ExpressionType.LessThanOrEqual)
-				return "(" + parameter.CommandText + " < ?)"; // always false
-			else
-				throw new NotSupportedException ("Cannot compile Null-BinaryExpression with type " + expression.NodeType.ToString ());
-		}
-
-		string GetSqlName (Expression expr)
-		{
-			var n = expr.NodeType;
-			if (n == ExpressionType.GreaterThan)
-				return ">";
-			else if (n == ExpressionType.GreaterThanOrEqual) {
-				return ">=";
-			}
-			else if (n == ExpressionType.LessThan) {
-				return "<";
-			}
-			else if (n == ExpressionType.LessThanOrEqual) {
-				return "<=";
-			}
-			else if (n == ExpressionType.And) {
-				return "&";
-			}
-			else if (n == ExpressionType.AndAlso) {
-				return "and";
-			}
-			else if (n == ExpressionType.Or) {
-				return "|";
-			}
-			else if (n == ExpressionType.OrElse) {
-				return "or";
-			}
-			else if (n == ExpressionType.Equal) {
-				return "=";
-			}
-			else if (n == ExpressionType.NotEqual) {
-				return "!=";
-			}
-			else {
-				throw new NotSupportedException ("Cannot get SQL for: " + n);
-			}
-		}
-
-		/// <summary>
-		/// Execute SELECT COUNT(*) on the query
-		/// </summary>
-		public int Count ()
-		{
-			return GenerateCommand ("count(*)").ExecuteScalar<int> ();
-		}
-
-		/// <summary>
-		/// Execute SELECT COUNT(*) on the query with an additional WHERE clause.
-		/// </summary>
-		public int Count (Expression<Func<T, bool>> predExpr)
-		{
-			return Where (predExpr).Count ();
-		}
-
-		public IEnumerator<T> GetEnumerator ()
-		{
-			if (!_deferred)
-				return GenerateCommand ("*").ExecuteQuery<T> ().GetEnumerator ();
-
-			return GenerateCommand ("*").ExecuteDeferredQuery<T> ().GetEnumerator ();
-		}
-
-		System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator ()
-		{
-			return GetEnumerator ();
-		}
-
-		/// <summary>
-		/// Queries the database and returns the results as a List.
-		/// </summary>
-		public List<T> ToList ()
-		{
-			return GenerateCommand ("*").ExecuteQuery<T> ();
-		}
-
-		/// <summary>
-		/// Queries the database and returns the results as an array.
-		/// </summary>
-		public T[] ToArray ()
-		{
-			return GenerateCommand ("*").ExecuteQuery<T> ().ToArray ();
-		}
-
-		/// <summary>
-		/// Returns the first element of this query.
-		/// </summary>
-		public T First ()
-		{
-			var query = Take (1);
-			return query.ToList ().First ();
-		}
-
-		/// <summary>
-		/// Returns the first element of this query, or null if no element is found.
-		/// </summary>
-		public T FirstOrDefault ()
-		{
-			var query = Take (1);
-			return query.ToList ().FirstOrDefault ();
-		}
-
-		/// <summary>
-		/// Returns the first element of this query that matches the predicate.
-		/// </summary>
-		public T First (Expression<Func<T, bool>> predExpr)
-		{
-			return Where (predExpr).First ();
-		}
-
-		/// <summary>
-		/// Returns the first element of this query that matches the predicate, or null
-		/// if no element is found.
-		/// </summary>
-		public T FirstOrDefault (Expression<Func<T, bool>> predExpr)
-		{
-			return Where (predExpr).FirstOrDefault ();
-		}
-	}
-
-	public static class SQLite3
-	{
-		public enum Result : int
-		{
-			OK = 0,
-			Error = 1,
-			Internal = 2,
-			Perm = 3,
-			Abort = 4,
-			Busy = 5,
-			Locked = 6,
-			NoMem = 7,
-			ReadOnly = 8,
-			Interrupt = 9,
-			IOError = 10,
-			Corrupt = 11,
-			NotFound = 12,
-			Full = 13,
-			CannotOpen = 14,
-			LockErr = 15,
-			Empty = 16,
-			SchemaChngd = 17,
-			TooBig = 18,
-			Constraint = 19,
-			Mismatch = 20,
-			Misuse = 21,
-			NotImplementedLFS = 22,
-			AccessDenied = 23,
-			Format = 24,
-			Range = 25,
-			NonDBFile = 26,
-			Notice = 27,
-			Warning = 28,
-			Row = 100,
-			Done = 101
-		}
-
-		public enum ExtendedResult : int
-		{
-			IOErrorRead = (Result.IOError | (1 << 8)),
-			IOErrorShortRead = (Result.IOError | (2 << 8)),
-			IOErrorWrite = (Result.IOError | (3 << 8)),
-			IOErrorFsync = (Result.IOError | (4 << 8)),
-			IOErrorDirFSync = (Result.IOError | (5 << 8)),
-			IOErrorTruncate = (Result.IOError | (6 << 8)),
-			IOErrorFStat = (Result.IOError | (7 << 8)),
-			IOErrorUnlock = (Result.IOError | (8 << 8)),
-			IOErrorRdlock = (Result.IOError | (9 << 8)),
-			IOErrorDelete = (Result.IOError | (10 << 8)),
-			IOErrorBlocked = (Result.IOError | (11 << 8)),
-			IOErrorNoMem = (Result.IOError | (12 << 8)),
-			IOErrorAccess = (Result.IOError | (13 << 8)),
-			IOErrorCheckReservedLock = (Result.IOError | (14 << 8)),
-			IOErrorLock = (Result.IOError | (15 << 8)),
-			IOErrorClose = (Result.IOError | (16 << 8)),
-			IOErrorDirClose = (Result.IOError | (17 << 8)),
-			IOErrorSHMOpen = (Result.IOError | (18 << 8)),
-			IOErrorSHMSize = (Result.IOError | (19 << 8)),
-			IOErrorSHMLock = (Result.IOError | (20 << 8)),
-			IOErrorSHMMap = (Result.IOError | (21 << 8)),
-			IOErrorSeek = (Result.IOError | (22 << 8)),
-			IOErrorDeleteNoEnt = (Result.IOError | (23 << 8)),
-			IOErrorMMap = (Result.IOError | (24 << 8)),
-			LockedSharedcache = (Result.Locked | (1 << 8)),
-			BusyRecovery = (Result.Busy | (1 << 8)),
-			CannottOpenNoTempDir = (Result.CannotOpen | (1 << 8)),
-			CannotOpenIsDir = (Result.CannotOpen | (2 << 8)),
-			CannotOpenFullPath = (Result.CannotOpen | (3 << 8)),
-			CorruptVTab = (Result.Corrupt | (1 << 8)),
-			ReadonlyRecovery = (Result.ReadOnly | (1 << 8)),
-			ReadonlyCannotLock = (Result.ReadOnly | (2 << 8)),
-			ReadonlyRollback = (Result.ReadOnly | (3 << 8)),
-			AbortRollback = (Result.Abort | (2 << 8)),
-			ConstraintCheck = (Result.Constraint | (1 << 8)),
-			ConstraintCommitHook = (Result.Constraint | (2 << 8)),
-			ConstraintForeignKey = (Result.Constraint | (3 << 8)),
-			ConstraintFunction = (Result.Constraint | (4 << 8)),
-			ConstraintNotNull = (Result.Constraint | (5 << 8)),
-			ConstraintPrimaryKey = (Result.Constraint | (6 << 8)),
-			ConstraintTrigger = (Result.Constraint | (7 << 8)),
-			ConstraintUnique = (Result.Constraint | (8 << 8)),
-			ConstraintVTab = (Result.Constraint | (9 << 8)),
-			NoticeRecoverWAL = (Result.Notice | (1 << 8)),
-			NoticeRecoverRollback = (Result.Notice | (2 << 8))
-		}
-
-
-		public enum ConfigOption : int
-		{
-			SingleThread = 1,
-			MultiThread = 2,
-			Serialized = 3
-		}
-
-		const string LibraryPath = "sqlite3";
+        }
+
+        public static int? MaxStringLength (PropertyInfo p) => MaxStringLength((MemberInfo)p);
+
+        public static bool IsMarkedNotNull (MemberInfo p)
+        {
+            return p.CustomAttributes.Any (x => x.AttributeType == typeof (NotNullAttribute));
+        }
+    }
+
+    public partial class SQLiteCommand
+    {
+        SQLiteConnection _conn;
+        private List<Binding> _bindings;
+
+        public string CommandText { get; set; }
+
+        public SQLiteCommand (SQLiteConnection conn)
+        {
+            _conn = conn;
+            _bindings = new List<Binding> ();
+            CommandText = "";
+        }
+
+        public int ExecuteNonQuery ()
+        {
+            if (_conn.Trace) {
+                _conn.Tracer?.Invoke ("Executing: " + this);
+            }
+
+            var r = SQLite3.Result.OK;
+            var stmt = Prepare ();
+            r = SQLite3.Step (stmt);
+            Finalize (stmt);
+            if (r == SQLite3.Result.Done) {
+                int rowsAffected = SQLite3.Changes (_conn.Handle);
+                return rowsAffected;
+            }
+            else if (r == SQLite3.Result.Error) {
+                string msg = SQLite3.GetErrmsg (_conn.Handle);
+                throw SQLiteException.New (r, msg);
+            }
+            else if (r == SQLite3.Result.Constraint) {
+                if (SQLite3.ExtendedErrCode (_conn.Handle) == SQLite3.ExtendedResult.ConstraintNotNull) {
+                    throw NotNullConstraintViolationException.New (r, SQLite3.GetErrmsg (_conn.Handle));
+                }
+            }
+
+            throw SQLiteException.New (r, SQLite3.GetErrmsg (_conn.Handle));
+        }
+
+        public IEnumerable<T> ExecuteDeferredQuery<T> ()
+        {
+            return ExecuteDeferredQuery<T> (_conn.GetMapping (typeof (T)));
+        }
+
+        public List<T> ExecuteQuery<T> ()
+        {
+            return ExecuteDeferredQuery<T> (_conn.GetMapping (typeof (T))).ToList ();
+        }
+
+        public List<T> ExecuteQuery<T> (TableMapping map)
+        {
+            return ExecuteDeferredQuery<T> (map).ToList ();
+        }
+
+        /// <summary>
+        /// Invoked every time an instance is loaded from the database.
+        /// </summary>
+        /// <param name='obj'>
+        /// The newly created object.
+        /// </param>
+        /// <remarks>
+        /// This can be overridden in combination with the <see cref="SQLiteConnection.NewCommand"/>
+        /// method to hook into the life-cycle of objects.
+        /// </remarks>
+        protected virtual void OnInstanceCreated (object obj)
+        {
+            // Can be overridden.
+        }
+
+        public IEnumerable<T> ExecuteDeferredQuery<T> (TableMapping map)
+        {
+            if (_conn.Trace) {
+                _conn.Tracer?.Invoke ("Executing Query: " + this);
+            }
+
+            var stmt = Prepare ();
+            try {
+                var cols = new TableMapping.Column[SQLite3.ColumnCount (stmt)];
+                var fastColumnSetters = new Action<object, Sqlite3Statement, int>[SQLite3.ColumnCount (stmt)];
+
+                if (map.Method == TableMapping.MapMethod.ByPosition)
+                {
+                    Array.Copy(map.Columns, cols, Math.Min(cols.Length, map.Columns.Length));
+                }
+                else if (map.Method == TableMapping.MapMethod.ByName) {
+                    MethodInfo getSetter = null;
+                    if (typeof(T) != map.MappedType) {
+                        getSetter = typeof(FastColumnSetter)
+                            .GetMethod (nameof(FastColumnSetter.GetFastSetter),
+                                BindingFlags.NonPublic | BindingFlags.Static).MakeGenericMethod (map.MappedType);
+                    }
+
+                    for (int i = 0; i < cols.Length; i++) {						
+                        var name = SQLite3.ColumnName16 (stmt, i);
+                        cols[i] = map.FindColumn (name);
+                        if (cols[i] != null)
+                            if (getSetter != null) {
+                                fastColumnSetters[i] = (Action<object, Sqlite3Statement, int>)getSetter.Invoke(null, new object[]{ _conn, cols[i]});
+                            }
+                            else {
+                                fastColumnSetters[i] = FastColumnSetter.GetFastSetter<T>(_conn, cols[i]);
+                            }
+                    }
+                }
+
+                while (SQLite3.Step (stmt) == SQLite3.Result.Row) {
+                    var obj = Activator.CreateInstance (map.MappedType);
+                    for (int i = 0; i < cols.Length; i++) {
+                        if (cols[i] == null)
+                            continue;
+
+                        if (fastColumnSetters[i] != null) {
+                            fastColumnSetters[i].Invoke (obj, stmt, i);
+                        }
+                        else {
+                            var colType = SQLite3.ColumnType (stmt, i);
+                            var val = ReadCol (stmt, i, colType, cols[i].ColumnType);
+                            cols[i].SetValue (obj, val);
+                        }
+                    }
+                    OnInstanceCreated (obj);
+                    yield return (T)obj;
+                }
+            }
+            finally {
+                SQLite3.Finalize (stmt);
+            }
+        }
+
+        public T ExecuteScalar<T> ()
+        {
+            if (_conn.Trace) {
+                _conn.Tracer?.Invoke ("Executing Query: " + this);
+            }
+
+            T val = default (T);
+
+            var stmt = Prepare ();
+
+            try {
+                var r = SQLite3.Step (stmt);
+                if (r == SQLite3.Result.Row) {
+                    var colType = SQLite3.ColumnType (stmt, 0);
+                    var colval = ReadCol (stmt, 0, colType, typeof (T));
+                    if (colval != null) {
+                        val = (T)colval;
+                    }
+                }
+                else if (r == SQLite3.Result.Done) {
+                }
+                else {
+                    throw SQLiteException.New (r, SQLite3.GetErrmsg (_conn.Handle));
+                }
+            }
+            finally {
+                Finalize (stmt);
+            }
+
+            return val;
+        }
+
+        public IEnumerable<T> ExecuteQueryScalars<T> ()
+        {
+            if (_conn.Trace) {
+                _conn.Tracer?.Invoke ("Executing Query: " + this);
+            }
+            var stmt = Prepare ();
+            try {
+                if (SQLite3.ColumnCount (stmt) < 1) {
+                    throw new InvalidOperationException ("QueryScalars should return at least one column");
+                }
+                while (SQLite3.Step (stmt) == SQLite3.Result.Row) {
+                    var colType = SQLite3.ColumnType (stmt, 0);
+                    var val = ReadCol (stmt, 0, colType, typeof (T));
+                    if (val == null) {
+                        yield return default (T);
+                    }
+                    else {
+                        yield return (T)val;
+                    }
+                }
+            }
+            finally {
+                Finalize (stmt);
+            }
+        }
+
+        public void Bind (string name, object val)
+        {
+            _bindings.Add (new Binding {
+                Name = name,
+                Value = val
+            });
+        }
+
+        public void Bind (object val)
+        {
+            Bind (null, val);
+        }
+
+        public override string ToString ()
+        {
+            var parts = new string[1 + _bindings.Count];
+            parts[0] = CommandText;
+            var i = 1;
+            foreach (var b in _bindings) {
+                parts[i] = string.Format ("  {0}: {1}", i - 1, b.Value);
+                i++;
+            }
+            return string.Join (Environment.NewLine, parts);
+        }
+
+        Sqlite3Statement Prepare ()
+        {
+            var stmt = SQLite3.Prepare2 (_conn.Handle, CommandText);
+            BindAll (stmt);
+            return stmt;
+        }
+
+        void Finalize (Sqlite3Statement stmt)
+        {
+            SQLite3.Finalize (stmt);
+        }
+
+        void BindAll (Sqlite3Statement stmt)
+        {
+            int nextIdx = 1;
+            foreach (var b in _bindings) {
+                if (b.Name != null) {
+                    b.Index = SQLite3.BindParameterIndex (stmt, b.Name);
+                }
+                else {
+                    b.Index = nextIdx++;
+                }
+
+                BindParameter (stmt, b.Index, b.Value, _conn.StoreDateTimeAsTicks, _conn.DateTimeStringFormat, _conn.StoreTimeSpanAsTicks);
+            }
+        }
+
+        static IntPtr NegativePointer = new IntPtr (-1);
+
+        internal static void BindParameter (Sqlite3Statement stmt, int index, object value, bool storeDateTimeAsTicks, string dateTimeStringFormat, bool storeTimeSpanAsTicks)
+        {
+            if (value == null) {
+                SQLite3.BindNull (stmt, index);
+            }
+            else {
+                if (value is Int32) {
+                    SQLite3.BindInt (stmt, index, (int)value);
+                }
+                else if (value is String) {
+                    SQLite3.BindText (stmt, index, (string)value, -1, NegativePointer);
+                }
+                else if (value is Byte || value is UInt16 || value is SByte || value is Int16) {
+                    SQLite3.BindInt (stmt, index, Convert.ToInt32 (value));
+                }
+                else if (value is Boolean) {
+                    SQLite3.BindInt (stmt, index, (bool)value ? 1 : 0);
+                }
+                else if (value is UInt32 || value is Int64 || value is UInt64) {
+                    SQLite3.BindInt64 (stmt, index, Convert.ToInt64 (value));
+                }
+                else if (value is Single || value is Double || value is Decimal) {
+                    SQLite3.BindDouble (stmt, index, Convert.ToDouble (value));
+                }
+                else if (value is TimeSpan) {
+                    if (storeTimeSpanAsTicks) {
+                        SQLite3.BindInt64 (stmt, index, ((TimeSpan)value).Ticks);
+                    }
+                    else {
+                        SQLite3.BindText (stmt, index, ((TimeSpan)value).ToString (), -1, NegativePointer);
+                    }
+                }
+                else if (value is DateTime) {
+                    if (storeDateTimeAsTicks) {
+                        SQLite3.BindInt64 (stmt, index, ((DateTime)value).Ticks);
+                    }
+                    else {
+                        SQLite3.BindText (stmt, index, ((DateTime)value).ToString (dateTimeStringFormat, System.Globalization.CultureInfo.InvariantCulture), -1, NegativePointer);
+                    }
+                }
+                else if (value is DateTimeOffset) {
+                    SQLite3.BindInt64 (stmt, index, ((DateTimeOffset)value).UtcTicks);
+                }
+                else if (value is byte[]) {
+                    SQLite3.BindBlob (stmt, index, (byte[])value, ((byte[])value).Length, NegativePointer);
+                }
+                else if (value is Guid) {
+                    SQLite3.BindText (stmt, index, ((Guid)value).ToString (), 72, NegativePointer);
+                }
+                else if (value is Uri) {
+                    SQLite3.BindText (stmt, index, ((Uri)value).ToString (), -1, NegativePointer);
+                }
+                else if (value is StringBuilder) {
+                    SQLite3.BindText (stmt, index, ((StringBuilder)value).ToString (), -1, NegativePointer);
+                }
+                else if (value is UriBuilder) {
+                    SQLite3.BindText (stmt, index, ((UriBuilder)value).ToString (), -1, NegativePointer);
+                }
+                else {
+                    // Now we could possibly get an enum, retrieve cached info
+                    var valueType = value.GetType ();
+                    var enumInfo = EnumCache.GetInfo (valueType);
+                    if (enumInfo.IsEnum) {
+                        var enumIntValue = Convert.ToInt32 (value);
+                        if (enumInfo.StoreAsText)
+                            SQLite3.BindText (stmt, index, enumInfo.EnumValues[enumIntValue], -1, NegativePointer);
+                        else
+                            SQLite3.BindInt (stmt, index, enumIntValue);
+                    }
+                    else {
+                        throw new NotSupportedException ("Cannot store type: " + Orm.GetType (value));
+                    }
+                }
+            }
+        }
+
+        class Binding
+        {
+            public string Name { get; set; }
+
+            public object Value { get; set; }
+
+            public int Index { get; set; }
+        }
+
+        object ReadCol (Sqlite3Statement stmt, int index, SQLite3.ColType type, Type clrType)
+        {
+            if (type == SQLite3.ColType.Null) {
+                return null;
+            }
+            else {
+                var clrTypeInfo = clrType.GetTypeInfo ();
+                if (clrTypeInfo.IsGenericType && clrTypeInfo.GetGenericTypeDefinition () == typeof (Nullable<>)) {
+                    clrType = clrTypeInfo.GenericTypeArguments[0];
+                    clrTypeInfo = clrType.GetTypeInfo ();
+                }
+
+                if (clrType == typeof (String)) {
+                    return SQLite3.ColumnString (stmt, index);
+                }
+                else if (clrType == typeof (Int32)) {
+                    return (int)SQLite3.ColumnInt (stmt, index);
+                }
+                else if (clrType == typeof (Boolean)) {
+                    return SQLite3.ColumnInt (stmt, index) == 1;
+                }
+                else if (clrType == typeof (double)) {
+                    return SQLite3.ColumnDouble (stmt, index);
+                }
+                else if (clrType == typeof (float)) {
+                    return (float)SQLite3.ColumnDouble (stmt, index);
+                }
+                else if (clrType == typeof (TimeSpan)) {
+                    if (_conn.StoreTimeSpanAsTicks) {
+                        return new TimeSpan (SQLite3.ColumnInt64 (stmt, index));
+                    }
+                    else {
+                        var text = SQLite3.ColumnString (stmt, index);
+                        TimeSpan resultTime;
+                        if (!TimeSpan.TryParseExact (text, "c", System.Globalization.CultureInfo.InvariantCulture, System.Globalization.TimeSpanStyles.None, out resultTime)) {
+                            resultTime = TimeSpan.Parse (text);
+                        }
+                        return resultTime;
+                    }
+                }
+                else if (clrType == typeof (DateTime)) {
+                    if (_conn.StoreDateTimeAsTicks) {
+                        return new DateTime (SQLite3.ColumnInt64 (stmt, index));
+                    }
+                    else {
+                        var text = SQLite3.ColumnString (stmt, index);
+                        DateTime resultDate;
+                        if (!DateTime.TryParseExact (text, _conn.DateTimeStringFormat, System.Globalization.CultureInfo.InvariantCulture, _conn.DateTimeStyle, out resultDate)) {
+                            resultDate = DateTime.Parse (text);
+                        }
+                        return resultDate;
+                    }
+                }
+                else if (clrType == typeof (DateTimeOffset)) {
+                    return new DateTimeOffset (SQLite3.ColumnInt64 (stmt, index), TimeSpan.Zero);
+                }
+                else if (clrTypeInfo.IsEnum) {
+                    if (type == SQLite3.ColType.Text) {
+                        var value = SQLite3.ColumnString (stmt, index);
+                        return Enum.Parse (clrType, value.ToString (), true);
+                    }
+                    else
+                        return SQLite3.ColumnInt (stmt, index);
+                }
+                else if (clrType == typeof (Int64)) {
+                    return SQLite3.ColumnInt64 (stmt, index);
+                }
+                else if (clrType == typeof (UInt64)) {
+                    return (ulong)SQLite3.ColumnInt64 (stmt, index);
+                }
+                else if (clrType == typeof (UInt32)) {
+                    return (uint)SQLite3.ColumnInt64 (stmt, index);
+                }
+                else if (clrType == typeof (decimal)) {
+                    return (decimal)SQLite3.ColumnDouble (stmt, index);
+                }
+                else if (clrType == typeof (Byte)) {
+                    return (byte)SQLite3.ColumnInt (stmt, index);
+                }
+                else if (clrType == typeof (UInt16)) {
+                    return (ushort)SQLite3.ColumnInt (stmt, index);
+                }
+                else if (clrType == typeof (Int16)) {
+                    return (short)SQLite3.ColumnInt (stmt, index);
+                }
+                else if (clrType == typeof (sbyte)) {
+                    return (sbyte)SQLite3.ColumnInt (stmt, index);
+                }
+                else if (clrType == typeof (byte[])) {
+                    return SQLite3.ColumnByteArray (stmt, index);
+                }
+                else if (clrType == typeof (Guid)) {
+                    var text = SQLite3.ColumnString (stmt, index);
+                    return new Guid (text);
+                }
+                else if (clrType == typeof (Uri)) {
+                    var text = SQLite3.ColumnString (stmt, index);
+                    return new Uri (text);
+                }
+                else if (clrType == typeof (StringBuilder)) {
+                    var text = SQLite3.ColumnString (stmt, index);
+                    return new StringBuilder (text);
+                }
+                else if (clrType == typeof (UriBuilder)) {
+                    var text = SQLite3.ColumnString (stmt, index);
+                    return new UriBuilder (text);
+                }
+                else {
+                    throw new NotSupportedException ("Don't know how to read " + clrType);
+                }
+            }
+        }
+    }
+
+    internal class FastColumnSetter
+    {
+        /// <summary>
+        /// Creates a delegate that can be used to quickly set object members from query columns.
+        ///
+        /// Note that this frontloads the slow reflection-based type checking for columns to only happen once at the beginning of a query,
+        /// and then afterwards each row of the query can invoke the delegate returned by this function to get much better performance (up to 10x speed boost, depending on query size and platform).
+        /// </summary>
+        /// <typeparam name="T">The type of the destination object that the query will read into</typeparam>
+        /// <param name="conn">The active connection.  Note that this is primarily needed in order to read preferences regarding how certain data types (such as TimeSpan / DateTime) should be encoded in the database.</param>
+        /// <param name="column">The table mapping used to map the statement column to a member of the destination object type</param>
+        /// <returns>
+        /// A delegate for fast-setting of object members from statement columns.
+        ///
+        /// If no fast setter is available for the requested column (enums in particular cause headache), then this function returns null.
+        /// </returns>
+        internal static Action<object, Sqlite3Statement, int> GetFastSetter<T> (SQLiteConnection conn, TableMapping.Column column)
+        {
+            Action<object, Sqlite3Statement, int> fastSetter = null;
+
+            Type clrType = column.PropertyInfo.PropertyType;
+
+            var clrTypeInfo = clrType.GetTypeInfo ();
+            if (clrTypeInfo.IsGenericType && clrTypeInfo.GetGenericTypeDefinition () == typeof (Nullable<>)) {
+                clrType = clrTypeInfo.GenericTypeArguments[0];
+                clrTypeInfo = clrType.GetTypeInfo ();
+            }
+
+            if (clrType == typeof (String)) {
+                fastSetter = CreateTypedSetterDelegate<T, string> (column, (stmt, index) => {
+                    return SQLite3.ColumnString (stmt, index);
+                });
+            }
+            else if (clrType == typeof (Int32)) {
+                fastSetter = CreateNullableTypedSetterDelegate<T, int> (column, (stmt, index)=>{
+                    return SQLite3.ColumnInt (stmt, index);
+                });
+            }
+            else if (clrType == typeof (Boolean)) {
+                fastSetter = CreateNullableTypedSetterDelegate<T, bool> (column, (stmt, index) => {
+                    return SQLite3.ColumnInt (stmt, index) == 1;
+                });
+            }
+            else if (clrType == typeof (double)) {
+                fastSetter = CreateNullableTypedSetterDelegate<T, double> (column, (stmt, index) => {
+                    return SQLite3.ColumnDouble (stmt, index);
+                });
+            }
+            else if (clrType == typeof (float)) {
+                fastSetter = CreateNullableTypedSetterDelegate<T, float> (column, (stmt, index) => {
+                    return (float) SQLite3.ColumnDouble (stmt, index);
+                });
+            }
+            else if (clrType == typeof (TimeSpan)) {
+                if (conn.StoreTimeSpanAsTicks) {
+                    fastSetter = CreateNullableTypedSetterDelegate<T, TimeSpan> (column, (stmt, index) => {
+                        return new TimeSpan (SQLite3.ColumnInt64 (stmt, index));
+                    });
+                }
+                else {
+                    fastSetter = CreateNullableTypedSetterDelegate<T, TimeSpan> (column, (stmt, index) => {
+                        var text = SQLite3.ColumnString (stmt, index);
+                        TimeSpan resultTime;
+                        if (!TimeSpan.TryParseExact (text, "c", System.Globalization.CultureInfo.InvariantCulture, System.Globalization.TimeSpanStyles.None, out resultTime)) {
+                            resultTime = TimeSpan.Parse (text);
+                        }
+                        return resultTime;
+                    });
+                }
+            }
+            else if (clrType == typeof (DateTime)) {
+                if (conn.StoreDateTimeAsTicks) {
+                    fastSetter = CreateNullableTypedSetterDelegate<T, DateTime> (column, (stmt, index) => {
+                        return new DateTime (SQLite3.ColumnInt64 (stmt, index));
+                    });
+                }
+                else {
+                    fastSetter = CreateNullableTypedSetterDelegate<T, DateTime> (column, (stmt, index) => {
+                        var text = SQLite3.ColumnString (stmt, index);
+                        DateTime resultDate;
+                        if (!DateTime.TryParseExact (text, conn.DateTimeStringFormat, System.Globalization.CultureInfo.InvariantCulture, conn.DateTimeStyle, out resultDate)) {
+                            resultDate = DateTime.Parse (text);
+                        }
+                        return resultDate;
+                    });
+                }
+            }
+            else if (clrType == typeof (DateTimeOffset)) {
+                fastSetter = CreateNullableTypedSetterDelegate<T, DateTimeOffset> (column, (stmt, index) => {
+                    return new DateTimeOffset (SQLite3.ColumnInt64 (stmt, index), TimeSpan.Zero);
+                });
+            }
+            else if (clrTypeInfo.IsEnum) {
+                // NOTE: Not sure of a good way (if any?) to do a strongly-typed fast setter like this for enumerated types -- for now, return null and column sets will revert back to the safe (but slow) Reflection-based method of column prop.Set()
+            }
+            else if (clrType == typeof (Int64)) {
+                fastSetter = CreateNullableTypedSetterDelegate<T, Int64> (column, (stmt, index) => {
+                    return SQLite3.ColumnInt64 (stmt, index);
+                });
+            }
+            else if (clrType == typeof(UInt64))
+            {
+                fastSetter = CreateNullableTypedSetterDelegate<T, UInt64>(column, (stmt, index) => {
+                    return (ulong)SQLite3.ColumnInt64(stmt, index);
+                });
+            }
+            else if (clrType == typeof (UInt32)) {
+                fastSetter = CreateNullableTypedSetterDelegate<T, UInt32> (column, (stmt, index) => {
+                    return (uint)SQLite3.ColumnInt64 (stmt, index);
+                });
+            }
+            else if (clrType == typeof (decimal)) {
+                fastSetter = CreateNullableTypedSetterDelegate<T, decimal> (column, (stmt, index) => {
+                    return (decimal)SQLite3.ColumnDouble (stmt, index);
+                });
+            }
+            else if (clrType == typeof (Byte)) {
+                fastSetter = CreateNullableTypedSetterDelegate<T, Byte> (column, (stmt, index) => {
+                    return (byte)SQLite3.ColumnInt (stmt, index);
+                });
+            }
+            else if (clrType == typeof (UInt16)) {
+                fastSetter = CreateNullableTypedSetterDelegate<T, UInt16> (column, (stmt, index) => {
+                    return (ushort)SQLite3.ColumnInt (stmt, index);
+                });
+            }
+            else if (clrType == typeof (Int16)) {
+                fastSetter = CreateNullableTypedSetterDelegate<T, Int16> (column, (stmt, index) => {
+                    return (short)SQLite3.ColumnInt (stmt, index);
+                });
+            }
+            else if (clrType == typeof (sbyte)) {
+                fastSetter = CreateNullableTypedSetterDelegate<T, sbyte> (column, (stmt, index) => {
+                    return (sbyte)SQLite3.ColumnInt (stmt, index);
+                });
+            }
+            else if (clrType == typeof (byte[])) {
+                fastSetter = CreateTypedSetterDelegate<T, byte[]> (column, (stmt, index) => {
+                    return SQLite3.ColumnByteArray (stmt, index);
+                });
+            }
+            else if (clrType == typeof (Guid)) {
+                fastSetter = CreateNullableTypedSetterDelegate<T, Guid> (column, (stmt, index) => {
+                    var text = SQLite3.ColumnString (stmt, index);
+                    return new Guid (text);
+                });
+            }
+            else if (clrType == typeof (Uri)) {
+                fastSetter = CreateTypedSetterDelegate<T, Uri> (column, (stmt, index) => {
+                    var text = SQLite3.ColumnString (stmt, index);
+                    return new Uri (text);
+                });
+            }
+            else if (clrType == typeof (StringBuilder)) {
+                fastSetter = CreateTypedSetterDelegate<T, StringBuilder> (column, (stmt, index) => {
+                    var text = SQLite3.ColumnString (stmt, index);
+                    return new StringBuilder (text);
+                });
+            }
+            else if (clrType == typeof (UriBuilder)) {
+                fastSetter = CreateTypedSetterDelegate<T, UriBuilder> (column, (stmt, index) => {
+                    var text = SQLite3.ColumnString (stmt, index);
+                    return new UriBuilder (text);
+                });
+            }
+            else {
+                // NOTE: Will fall back to the slow setter method in the event that we are unable to create a fast setter delegate for a particular column type
+            }
+            return fastSetter;
+        }
+
+        /// <summary>
+        /// This creates a strongly typed delegate that will permit fast setting of column values given a Sqlite3Statement and a column index.
+        ///
+        /// Note that this is identical to CreateTypedSetterDelegate(), but has an extra check to see if it should create a nullable version of the delegate.
+        /// </summary>
+        /// <typeparam name="ObjectType">The type of the object whose member column is being set</typeparam>
+        /// <typeparam name="ColumnMemberType">The CLR type of the member in the object which corresponds to the given SQLite columnn</typeparam>
+        /// <param name="column">The column mapping that identifies the target member of the destination object</param>
+        /// <param name="getColumnValue">A lambda that can be used to retrieve the column value at query-time</param>
+        /// <returns>A strongly-typed delegate</returns>
+        private static Action<object, Sqlite3Statement, int> CreateNullableTypedSetterDelegate<ObjectType, ColumnMemberType> (TableMapping.Column column, Func<Sqlite3Statement, int, ColumnMemberType> getColumnValue) where ColumnMemberType : struct
+        {
+            var clrTypeInfo = column.PropertyInfo.PropertyType.GetTypeInfo();
+            bool isNullable = false;
+
+            if (clrTypeInfo.IsGenericType && clrTypeInfo.GetGenericTypeDefinition () == typeof (Nullable<>)) {
+                isNullable = true;
+            }
+
+            if (isNullable) {
+                var setProperty = (Action<ObjectType, ColumnMemberType?>)Delegate.CreateDelegate (
+                        typeof (Action<ObjectType, ColumnMemberType?>), null,
+                        column.PropertyInfo.GetSetMethod ());
+
+                return (o, stmt, i) => {
+                    var colType = SQLite3.ColumnType (stmt, i);
+                    if (colType != SQLite3.ColType.Null)
+                        setProperty.Invoke ((ObjectType)o, getColumnValue.Invoke (stmt, i));
+                };
+            }
+
+            return CreateTypedSetterDelegate<ObjectType, ColumnMemberType> (column, getColumnValue);
+        }
+
+        /// <summary>
+        /// This creates a strongly typed delegate that will permit fast setting of column values given a Sqlite3Statement and a column index.
+        /// </summary>
+        /// <typeparam name="ObjectType">The type of the object whose member column is being set</typeparam>
+        /// <typeparam name="ColumnMemberType">The CLR type of the member in the object which corresponds to the given SQLite columnn</typeparam>
+        /// <param name="column">The column mapping that identifies the target member of the destination object</param>
+        /// <param name="getColumnValue">A lambda that can be used to retrieve the column value at query-time</param>
+        /// <returns>A strongly-typed delegate</returns>
+        private static Action<object, Sqlite3Statement, int> CreateTypedSetterDelegate<ObjectType, ColumnMemberType> (TableMapping.Column column, Func<Sqlite3Statement, int, ColumnMemberType> getColumnValue)
+        {
+            var setProperty = (Action<ObjectType, ColumnMemberType>)Delegate.CreateDelegate (
+                    typeof (Action<ObjectType, ColumnMemberType>), null,
+                    column.PropertyInfo.GetSetMethod ());
+
+            return (o, stmt, i) => {
+                var colType = SQLite3.ColumnType (stmt, i);
+                if (colType != SQLite3.ColType.Null)
+                    setProperty.Invoke ((ObjectType)o, getColumnValue.Invoke (stmt, i));
+            };
+        }
+    }
+
+    /// <summary>
+    /// Since the insert never changed, we only need to prepare once.
+    /// </summary>
+    class PreparedSqlLiteInsertCommand : IDisposable
+    {
+        bool Initialized;
+
+        SQLiteConnection Connection;
+
+        string CommandText;
+
+        Sqlite3Statement Statement;
+        static readonly Sqlite3Statement NullStatement = default (Sqlite3Statement);
+
+        public PreparedSqlLiteInsertCommand (SQLiteConnection conn, string commandText)
+        {
+            Connection = conn;
+            CommandText = commandText;
+        }
+
+        public int ExecuteNonQuery (object[] source)
+        {
+            if (Initialized && Statement == NullStatement) {
+                throw new ObjectDisposedException (nameof (PreparedSqlLiteInsertCommand));
+            }
+
+            if (Connection.Trace) {
+                Connection.Tracer?.Invoke ("Executing: " + CommandText);
+            }
+
+            var r = SQLite3.Result.OK;
+
+            if (!Initialized) {
+                Statement = SQLite3.Prepare2 (Connection.Handle, CommandText);
+                Initialized = true;
+            }
+
+            //bind the values.
+            if (source != null) {
+                for (int i = 0; i < source.Length; i++) {
+                    SQLiteCommand.BindParameter (Statement, i + 1, source[i], Connection.StoreDateTimeAsTicks, Connection.DateTimeStringFormat, Connection.StoreTimeSpanAsTicks);
+                }
+            }
+            r = SQLite3.Step (Statement);
+
+            if (r == SQLite3.Result.Done) {
+                int rowsAffected = SQLite3.Changes (Connection.Handle);
+                SQLite3.Reset (Statement);
+                return rowsAffected;
+            }
+            else if (r == SQLite3.Result.Error) {
+                string msg = SQLite3.GetErrmsg (Connection.Handle);
+                SQLite3.Reset (Statement);
+                throw SQLiteException.New (r, msg);
+            }
+            else if (r == SQLite3.Result.Constraint && SQLite3.ExtendedErrCode (Connection.Handle) == SQLite3.ExtendedResult.ConstraintNotNull) {
+                SQLite3.Reset (Statement);
+                throw NotNullConstraintViolationException.New (r, SQLite3.GetErrmsg (Connection.Handle));
+            }
+            else {
+                SQLite3.Reset (Statement);
+                throw SQLiteException.New (r, SQLite3.GetErrmsg (Connection.Handle));
+            }
+        }
+
+        public void Dispose ()
+        {
+            Dispose (true);
+            GC.SuppressFinalize (this);
+        }
+
+        void Dispose (bool disposing)
+        {
+            var s = Statement;
+            Statement = NullStatement;
+            Connection = null;
+            if (s != NullStatement) {
+                SQLite3.Finalize (s);
+            }
+        }
+
+        ~PreparedSqlLiteInsertCommand ()
+        {
+            Dispose (false);
+        }
+    }
+
+    public enum CreateTableResult
+    {
+        Created,
+        Migrated,
+    }
+
+    public class CreateTablesResult
+    {
+        public Dictionary<Type, CreateTableResult> Results { get; private set; }
+
+        public CreateTablesResult ()
+        {
+            Results = new Dictionary<Type, CreateTableResult> ();
+        }
+    }
+
+    public abstract class BaseTableQuery
+    {
+        protected class Ordering
+        {
+            public string ColumnName { get; set; }
+            public bool Ascending { get; set; }
+        }
+    }
+
+    public class TableQuery<T> : BaseTableQuery, IEnumerable<T>
+    {
+        public SQLiteConnection Connection { get; private set; }
+
+        public TableMapping Table { get; private set; }
+
+        Expression _where;
+        List<Ordering> _orderBys;
+        int? _limit;
+        int? _offset;
+
+        BaseTableQuery _joinInner;
+        Expression _joinInnerKeySelector;
+        BaseTableQuery _joinOuter;
+        Expression _joinOuterKeySelector;
+        Expression _joinSelector;
+
+        Expression _selector;
+
+        TableQuery (SQLiteConnection conn, TableMapping table)
+        {
+            Connection = conn;
+            Table = table;
+        }
+
+        public TableQuery (SQLiteConnection conn)
+        {
+            Connection = conn;
+            Table = Connection.GetMapping (typeof (T));
+        }
+
+        public TableQuery<U> Clone<U> ()
+        {
+            var q = new TableQuery<U> (Connection, Table);
+            q._where = _where;
+            q._deferred = _deferred;
+            if (_orderBys != null) {
+                q._orderBys = new List<Ordering> (_orderBys);
+            }
+            q._limit = _limit;
+            q._offset = _offset;
+            q._joinInner = _joinInner;
+            q._joinInnerKeySelector = _joinInnerKeySelector;
+            q._joinOuter = _joinOuter;
+            q._joinOuterKeySelector = _joinOuterKeySelector;
+            q._joinSelector = _joinSelector;
+            q._selector = _selector;
+            return q;
+        }
+
+        /// <summary>
+        /// Filters the query based on a predicate.
+        /// </summary>
+        public TableQuery<T> Where (Expression<Func<T, bool>> predExpr)
+        {
+            if (predExpr.NodeType == ExpressionType.Lambda) {
+                var lambda = (LambdaExpression)predExpr;
+                var pred = lambda.Body;
+                var q = Clone<T> ();
+                q.AddWhere (pred);
+                return q;
+            }
+            else {
+                throw new NotSupportedException ("Must be a predicate");
+            }
+        }
+
+        /// <summary>
+        /// Delete all the rows that match this query.
+        /// </summary>
+        public int Delete ()
+        {
+            return Delete (null);
+        }
+
+        /// <summary>
+        /// Delete all the rows that match this query and the given predicate.
+        /// </summary>
+        public int Delete (Expression<Func<T, bool>> predExpr)
+        {
+            if (_limit.HasValue || _offset.HasValue)
+                throw new InvalidOperationException ("Cannot delete with limits or offsets");
+
+            if (_where == null && predExpr == null)
+                throw new InvalidOperationException ("No condition specified");
+
+            var pred = _where;
+
+            if (predExpr != null && predExpr.NodeType == ExpressionType.Lambda) {
+                var lambda = (LambdaExpression)predExpr;
+                pred = pred != null ? Expression.AndAlso (pred, lambda.Body) : lambda.Body;
+            }
+
+            var args = new List<object> ();
+            var cmdText = "delete from \"" + Table.TableName + "\"";
+            var w = CompileExpr (pred, args);
+            cmdText += " where " + w.CommandText;
+
+            var command = Connection.CreateCommand (cmdText, args.ToArray ());
+
+            int result = command.ExecuteNonQuery ();
+            return result;
+        }
+
+        /// <summary>
+        /// Yields a given number of elements from the query and then skips the remainder.
+        /// </summary>
+        public TableQuery<T> Take (int n)
+        {
+            var q = Clone<T> ();
+            q._limit = n;
+            return q;
+        }
+
+        /// <summary>
+        /// Skips a given number of elements from the query and then yields the remainder.
+        /// </summary>
+        public TableQuery<T> Skip (int n)
+        {
+            var q = Clone<T> ();
+            q._offset = n;
+            return q;
+        }
+
+        /// <summary>
+        /// Returns the element at a given index
+        /// </summary>
+        public T ElementAt (int index)
+        {
+            return Skip (index).Take (1).First ();
+        }
+
+        bool _deferred;
+        public TableQuery<T> Deferred ()
+        {
+            var q = Clone<T> ();
+            q._deferred = true;
+            return q;
+        }
+
+        /// <summary>
+        /// Order the query results according to a key.
+        /// </summary>
+        public TableQuery<T> OrderBy<U> (Expression<Func<T, U>> orderExpr)
+        {
+            return AddOrderBy<U> (orderExpr, true);
+        }
+
+        /// <summary>
+        /// Order the query results according to a key.
+        /// </summary>
+        public TableQuery<T> OrderByDescending<U> (Expression<Func<T, U>> orderExpr)
+        {
+            return AddOrderBy<U> (orderExpr, false);
+        }
+
+        /// <summary>
+        /// Order the query results according to a key.
+        /// </summary>
+        public TableQuery<T> ThenBy<U> (Expression<Func<T, U>> orderExpr)
+        {
+            return AddOrderBy<U> (orderExpr, true);
+        }
+
+        /// <summary>
+        /// Order the query results according to a key.
+        /// </summary>
+        public TableQuery<T> ThenByDescending<U> (Expression<Func<T, U>> orderExpr)
+        {
+            return AddOrderBy<U> (orderExpr, false);
+        }
+
+        TableQuery<T> AddOrderBy<U> (Expression<Func<T, U>> orderExpr, bool asc)
+        {
+            if (orderExpr.NodeType == ExpressionType.Lambda) {
+                var lambda = (LambdaExpression)orderExpr;
+
+                MemberExpression mem = null;
+
+                var unary = lambda.Body as UnaryExpression;
+                if (unary != null && unary.NodeType == ExpressionType.Convert) {
+                    mem = unary.Operand as MemberExpression;
+                }
+                else {
+                    mem = lambda.Body as MemberExpression;
+                }
+
+                if (mem != null && (mem.Expression.NodeType == ExpressionType.Parameter)) {
+                    var q = Clone<T> ();
+                    if (q._orderBys == null) {
+                        q._orderBys = new List<Ordering> ();
+                    }
+                    q._orderBys.Add (new Ordering {
+                        ColumnName = Table.FindColumnWithPropertyName (mem.Member.Name).Name,
+                        Ascending = asc
+                    });
+                    return q;
+                }
+                else {
+                    throw new NotSupportedException ("Order By does not support: " + orderExpr);
+                }
+            }
+            else {
+                throw new NotSupportedException ("Must be a predicate");
+            }
+        }
+
+        private void AddWhere (Expression pred)
+        {
+            if (_where == null) {
+                _where = pred;
+            }
+            else {
+                _where = Expression.AndAlso (_where, pred);
+            }
+        }
+
+        ///// <summary>
+        ///// Performs an inner join of two queries based on matching keys extracted from the elements.
+        ///// </summary>
+        //public TableQuery<TResult> Join<TInner, TKey, TResult> (
+        //	TableQuery<TInner> inner,
+        //	Expression<Func<T, TKey>> outerKeySelector,
+        //	Expression<Func<TInner, TKey>> innerKeySelector,
+        //	Expression<Func<T, TInner, TResult>> resultSelector)
+        //{
+        //	var q = new TableQuery<TResult> (Connection, Connection.GetMapping (typeof (TResult))) {
+        //		_joinOuter = this,
+        //		_joinOuterKeySelector = outerKeySelector,
+        //		_joinInner = inner,
+        //		_joinInnerKeySelector = innerKeySelector,
+        //		_joinSelector = resultSelector,
+        //	};
+        //	return q;
+        //}
+
+        // Not needed until Joins are supported
+        // Keeping this commented out forces the default Linq to objects processor to run
+        //public TableQuery<TResult> Select<TResult> (Expression<Func<T, TResult>> selector)
+        //{
+        //	var q = Clone<TResult> ();
+        //	q._selector = selector;
+        //	return q;
+        //}
+
+        private SQLiteCommand GenerateCommand (string selectionList)
+        {
+            if (_joinInner != null && _joinOuter != null) {
+                throw new NotSupportedException ("Joins are not supported.");
+            }
+            else {
+                var cmdText = "select " + selectionList + " from \"" + Table.TableName + "\"";
+                var args = new List<object> ();
+                if (_where != null) {
+                    var w = CompileExpr (_where, args);
+                    cmdText += " where " + w.CommandText;
+                }
+                if ((_orderBys != null) && (_orderBys.Count > 0)) {
+                    var t = string.Join (", ", _orderBys.Select (o => "\"" + o.ColumnName + "\"" + (o.Ascending ? "" : " desc")).ToArray ());
+                    cmdText += " order by " + t;
+                }
+                if (_limit.HasValue) {
+                    cmdText += " limit " + _limit.Value;
+                }
+                if (_offset.HasValue) {
+                    if (!_limit.HasValue) {
+                        cmdText += " limit -1 ";
+                    }
+                    cmdText += " offset " + _offset.Value;
+                }
+                return Connection.CreateCommand (cmdText, args.ToArray ());
+            }
+        }
+
+        class CompileResult
+        {
+            public string CommandText { get; set; }
+
+            public object Value { get; set; }
+        }
+
+        private CompileResult CompileExpr (Expression expr, List<object> queryArgs)
+        {
+            if (expr == null) {
+                throw new NotSupportedException ("Expression is NULL");
+            }
+            else if (expr is BinaryExpression) {
+                var bin = (BinaryExpression)expr;
+
+                // VB turns 'x=="foo"' into 'CompareString(x,"foo",true/false)==0', so we need to unwrap it
+                // http://blogs.msdn.com/b/vbteam/archive/2007/09/18/vb-expression-trees-string-comparisons.aspx
+                if (bin.Left.NodeType == ExpressionType.Call) {
+                    var call = (MethodCallExpression)bin.Left;
+                    if (call.Method.DeclaringType.FullName == "Microsoft.VisualBasic.CompilerServices.Operators"
+                        && call.Method.Name == "CompareString")
+                        bin = Expression.MakeBinary (bin.NodeType, call.Arguments[0], call.Arguments[1]);
+                }
+
+
+                var leftr = CompileExpr (bin.Left, queryArgs);
+                var rightr = CompileExpr (bin.Right, queryArgs);
+
+                //If either side is a parameter and is null, then handle the other side specially (for "is null"/"is not null")
+                string text;
+                if (leftr.CommandText == "?" && leftr.Value == null)
+                    text = CompileNullBinaryExpression (bin, rightr);
+                else if (rightr.CommandText == "?" && rightr.Value == null)
+                    text = CompileNullBinaryExpression (bin, leftr);
+                else
+                    text = "(" + leftr.CommandText + " " + GetSqlName (bin) + " " + rightr.CommandText + ")";
+                return new CompileResult { CommandText = text };
+            }
+            else if (expr.NodeType == ExpressionType.Not) {
+                var operandExpr = ((UnaryExpression)expr).Operand;
+                var opr = CompileExpr (operandExpr, queryArgs);
+                object val = opr.Value;
+                if (val is bool)
+                    val = !((bool)val);
+                return new CompileResult {
+                    CommandText = "NOT(" + opr.CommandText + ")",
+                    Value = val
+                };
+            }
+            else if (expr.NodeType == ExpressionType.Call) {
+
+                var call = (MethodCallExpression)expr;
+                var args = new CompileResult[call.Arguments.Count];
+                var obj = call.Object != null ? CompileExpr (call.Object, queryArgs) : null;
+
+                for (var i = 0; i < args.Length; i++) {
+                    args[i] = CompileExpr (call.Arguments[i], queryArgs);
+                }
+
+                var sqlCall = "";
+
+                if (call.Method.Name == "Like" && args.Length == 2) {
+                    sqlCall = "(" + args[0].CommandText + " like " + args[1].CommandText + ")";
+                }
+                else if (call.Method.Name == "Contains" && args.Length == 2) {
+                    sqlCall = "(" + args[1].CommandText + " in " + args[0].CommandText + ")";
+                }
+                else if (call.Method.Name == "Contains" && args.Length == 1) {
+                    if (call.Object != null && call.Object.Type == typeof (string)) {
+                        sqlCall = "( instr(" + obj.CommandText + "," + args[0].CommandText + ") >0 )";
+                    }
+                    else {
+                        sqlCall = "(" + args[0].CommandText + " in " + obj.CommandText + ")";
+                    }
+                }
+                else if (call.Method.Name == "StartsWith" && args.Length >= 1) {
+                    var startsWithCmpOp = StringComparison.CurrentCulture;
+                    if (args.Length == 2) {
+                        startsWithCmpOp = (StringComparison)args[1].Value;
+                    }
+                    switch (startsWithCmpOp) {
+                        case StringComparison.Ordinal:
+                        case StringComparison.CurrentCulture:
+                            sqlCall = "( substr(" + obj.CommandText + ", 1, " + args[0].Value.ToString ().Length + ") =  " + args[0].CommandText + ")";
+                            break;
+                        case StringComparison.OrdinalIgnoreCase:
+                        case StringComparison.CurrentCultureIgnoreCase:
+                            sqlCall = "(" + obj.CommandText + " like (" + args[0].CommandText + " || '%'))";
+                            break;
+                    }
+
+                }
+                else if (call.Method.Name == "EndsWith" && args.Length >= 1) {
+                    var endsWithCmpOp = StringComparison.CurrentCulture;
+                    if (args.Length == 2) {
+                        endsWithCmpOp = (StringComparison)args[1].Value;
+                    }
+                    switch (endsWithCmpOp) {
+                        case StringComparison.Ordinal:
+                        case StringComparison.CurrentCulture:
+                            sqlCall = "( substr(" + obj.CommandText + ", length(" + obj.CommandText + ") - " + args[0].Value.ToString ().Length + "+1, " + args[0].Value.ToString ().Length + ") =  " + args[0].CommandText + ")";
+                            break;
+                        case StringComparison.OrdinalIgnoreCase:
+                        case StringComparison.CurrentCultureIgnoreCase:
+                            sqlCall = "(" + obj.CommandText + " like ('%' || " + args[0].CommandText + "))";
+                            break;
+                    }
+                }
+                else if (call.Method.Name == "Equals" && args.Length == 1) {
+                    sqlCall = "(" + obj.CommandText + " = (" + args[0].CommandText + "))";
+                }
+                else if (call.Method.Name == "ToLower") {
+                    sqlCall = "(lower(" + obj.CommandText + "))";
+                }
+                else if (call.Method.Name == "ToUpper") {
+                    sqlCall = "(upper(" + obj.CommandText + "))";
+                }
+                else if (call.Method.Name == "Replace" && args.Length == 2) {
+                    sqlCall = "(replace(" + obj.CommandText + "," + args[0].CommandText + "," + args[1].CommandText + "))";
+                }
+                else if (call.Method.Name == "IsNullOrEmpty" && args.Length == 1) {
+                    sqlCall = "(" + args[0].CommandText + " is null or" + args[0].CommandText + " ='' )";
+                }
+                else {
+                    sqlCall = call.Method.Name.ToLower () + "(" + string.Join (",", args.Select (a => a.CommandText).ToArray ()) + ")";
+                }
+                return new CompileResult { CommandText = sqlCall };
+
+            }
+            else if (expr.NodeType == ExpressionType.Constant) {
+                var c = (ConstantExpression)expr;
+                queryArgs.Add (c.Value);
+                return new CompileResult {
+                    CommandText = "?",
+                    Value = c.Value
+                };
+            }
+            else if (expr.NodeType == ExpressionType.Convert) {
+                var u = (UnaryExpression)expr;
+                var ty = u.Type;
+                var valr = CompileExpr (u.Operand, queryArgs);
+                return new CompileResult {
+                    CommandText = valr.CommandText,
+                    Value = valr.Value != null ? ConvertTo (valr.Value, ty) : null
+                };
+            }
+            else if (expr.NodeType == ExpressionType.MemberAccess) {
+                var mem = (MemberExpression)expr;
+
+                var paramExpr = mem.Expression as ParameterExpression;
+                if (paramExpr == null) {
+                    var convert = mem.Expression as UnaryExpression;
+                    if (convert != null && convert.NodeType == ExpressionType.Convert) {
+                        paramExpr = convert.Operand as ParameterExpression;
+                    }
+                }
+
+                if (paramExpr != null) {
+                    //
+                    // This is a column of our table, output just the column name
+                    // Need to translate it if that column name is mapped
+                    //
+                    var columnName = Table.FindColumnWithPropertyName (mem.Member.Name).Name;
+                    return new CompileResult { CommandText = "\"" + columnName + "\"" };
+                }
+                else {
+                    object obj = null;
+                    if (mem.Expression != null) {
+                        var r = CompileExpr (mem.Expression, queryArgs);
+                        if (r.Value == null) {
+                            throw new NotSupportedException ("Member access failed to compile expression");
+                        }
+                        if (r.CommandText == "?") {
+                            queryArgs.RemoveAt (queryArgs.Count - 1);
+                        }
+                        obj = r.Value;
+                    }
+
+                    //
+                    // Get the member value
+                    //
+                    object val = null;
+
+                    if (mem.Member is PropertyInfo) {
+                        var m = (PropertyInfo)mem.Member;
+                        val = m.GetValue (obj, null);
+                    }
+                    else if (mem.Member is FieldInfo) {
+                        var m = (FieldInfo)mem.Member;
+                        val = m.GetValue (obj);
+                    }
+                    else {
+                        throw new NotSupportedException ("MemberExpr: " + mem.Member.GetType ());
+                    }
+
+                    //
+                    // Work special magic for enumerables
+                    //
+                    if (val != null && val is System.Collections.IEnumerable && !(val is string) && !(val is System.Collections.Generic.IEnumerable<byte>)) {
+                        var sb = new System.Text.StringBuilder ();
+                        sb.Append ("(");
+                        var head = "";
+                        foreach (var a in (System.Collections.IEnumerable)val) {
+                            queryArgs.Add (a);
+                            sb.Append (head);
+                            sb.Append ("?");
+                            head = ",";
+                        }
+                        sb.Append (")");
+                        return new CompileResult {
+                            CommandText = sb.ToString (),
+                            Value = val
+                        };
+                    }
+                    else {
+                        queryArgs.Add (val);
+                        return new CompileResult {
+                            CommandText = "?",
+                            Value = val
+                        };
+                    }
+                }
+            }
+            throw new NotSupportedException ("Cannot compile: " + expr.NodeType.ToString ());
+        }
+
+        static object ConvertTo (object obj, Type t)
+        {
+            Type nut = Nullable.GetUnderlyingType (t);
+
+            if (nut != null) {
+                if (obj == null)
+                    return null;
+                return Convert.ChangeType (obj, nut);
+            }
+            else {
+                return Convert.ChangeType (obj, t);
+            }
+        }
+
+        /// <summary>
+        /// Compiles a BinaryExpression where one of the parameters is null.
+        /// </summary>
+        /// <param name="expression">The expression to compile</param>
+        /// <param name="parameter">The non-null parameter</param>
+        private string CompileNullBinaryExpression (BinaryExpression expression, CompileResult parameter)
+        {
+            if (expression.NodeType == ExpressionType.Equal)
+                return "(" + parameter.CommandText + " is ?)";
+            else if (expression.NodeType == ExpressionType.NotEqual)
+                return "(" + parameter.CommandText + " is not ?)";
+            else if (expression.NodeType == ExpressionType.GreaterThan
+                || expression.NodeType == ExpressionType.GreaterThanOrEqual
+                || expression.NodeType == ExpressionType.LessThan
+                || expression.NodeType == ExpressionType.LessThanOrEqual)
+                return "(" + parameter.CommandText + " < ?)"; // always false
+            else
+                throw new NotSupportedException ("Cannot compile Null-BinaryExpression with type " + expression.NodeType.ToString ());
+        }
+
+        string GetSqlName (Expression expr)
+        {
+            var n = expr.NodeType;
+            if (n == ExpressionType.GreaterThan)
+                return ">";
+            else if (n == ExpressionType.GreaterThanOrEqual) {
+                return ">=";
+            }
+            else if (n == ExpressionType.LessThan) {
+                return "<";
+            }
+            else if (n == ExpressionType.LessThanOrEqual) {
+                return "<=";
+            }
+            else if (n == ExpressionType.And) {
+                return "&";
+            }
+            else if (n == ExpressionType.AndAlso) {
+                return "and";
+            }
+            else if (n == ExpressionType.Or) {
+                return "|";
+            }
+            else if (n == ExpressionType.OrElse) {
+                return "or";
+            }
+            else if (n == ExpressionType.Equal) {
+                return "=";
+            }
+            else if (n == ExpressionType.NotEqual) {
+                return "!=";
+            }
+            else {
+                throw new NotSupportedException ("Cannot get SQL for: " + n);
+            }
+        }
+
+        /// <summary>
+        /// Execute SELECT COUNT(*) on the query
+        /// </summary>
+        public int Count ()
+        {
+            return GenerateCommand ("count(*)").ExecuteScalar<int> ();
+        }
+
+        /// <summary>
+        /// Execute SELECT COUNT(*) on the query with an additional WHERE clause.
+        /// </summary>
+        public int Count (Expression<Func<T, bool>> predExpr)
+        {
+            return Where (predExpr).Count ();
+        }
+
+        public IEnumerator<T> GetEnumerator ()
+        {
+            if (!_deferred)
+                return GenerateCommand ("*").ExecuteQuery<T> ().GetEnumerator ();
+
+            return GenerateCommand ("*").ExecuteDeferredQuery<T> ().GetEnumerator ();
+        }
+
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator ()
+        {
+            return GetEnumerator ();
+        }
+
+        /// <summary>
+        /// Queries the database and returns the results as a List.
+        /// </summary>
+        public List<T> ToList ()
+        {
+            return GenerateCommand ("*").ExecuteQuery<T> ();
+        }
+
+        /// <summary>
+        /// Queries the database and returns the results as an array.
+        /// </summary>
+        public T[] ToArray ()
+        {
+            return GenerateCommand ("*").ExecuteQuery<T> ().ToArray ();
+        }
+
+        /// <summary>
+        /// Returns the first element of this query.
+        /// </summary>
+        public T First ()
+        {
+            var query = Take (1);
+            return query.ToList ().First ();
+        }
+
+        /// <summary>
+        /// Returns the first element of this query, or null if no element is found.
+        /// </summary>
+        public T FirstOrDefault ()
+        {
+            var query = Take (1);
+            return query.ToList ().FirstOrDefault ();
+        }
+
+        /// <summary>
+        /// Returns the first element of this query that matches the predicate.
+        /// </summary>
+        public T First (Expression<Func<T, bool>> predExpr)
+        {
+            return Where (predExpr).First ();
+        }
+
+        /// <summary>
+        /// Returns the first element of this query that matches the predicate, or null
+        /// if no element is found.
+        /// </summary>
+        public T FirstOrDefault (Expression<Func<T, bool>> predExpr)
+        {
+            return Where (predExpr).FirstOrDefault ();
+        }
+    }
+
+    public static class SQLite3
+    {
+        public enum Result : int
+        {
+            OK = 0,
+            Error = 1,
+            Internal = 2,
+            Perm = 3,
+            Abort = 4,
+            Busy = 5,
+            Locked = 6,
+            NoMem = 7,
+            ReadOnly = 8,
+            Interrupt = 9,
+            IOError = 10,
+            Corrupt = 11,
+            NotFound = 12,
+            Full = 13,
+            CannotOpen = 14,
+            LockErr = 15,
+            Empty = 16,
+            SchemaChngd = 17,
+            TooBig = 18,
+            Constraint = 19,
+            Mismatch = 20,
+            Misuse = 21,
+            NotImplementedLFS = 22,
+            AccessDenied = 23,
+            Format = 24,
+            Range = 25,
+            NonDBFile = 26,
+            Notice = 27,
+            Warning = 28,
+            Row = 100,
+            Done = 101
+        }
+
+        public enum ExtendedResult : int
+        {
+            IOErrorRead = (Result.IOError | (1 << 8)),
+            IOErrorShortRead = (Result.IOError | (2 << 8)),
+            IOErrorWrite = (Result.IOError | (3 << 8)),
+            IOErrorFsync = (Result.IOError | (4 << 8)),
+            IOErrorDirFSync = (Result.IOError | (5 << 8)),
+            IOErrorTruncate = (Result.IOError | (6 << 8)),
+            IOErrorFStat = (Result.IOError | (7 << 8)),
+            IOErrorUnlock = (Result.IOError | (8 << 8)),
+            IOErrorRdlock = (Result.IOError | (9 << 8)),
+            IOErrorDelete = (Result.IOError | (10 << 8)),
+            IOErrorBlocked = (Result.IOError | (11 << 8)),
+            IOErrorNoMem = (Result.IOError | (12 << 8)),
+            IOErrorAccess = (Result.IOError | (13 << 8)),
+            IOErrorCheckReservedLock = (Result.IOError | (14 << 8)),
+            IOErrorLock = (Result.IOError | (15 << 8)),
+            IOErrorClose = (Result.IOError | (16 << 8)),
+            IOErrorDirClose = (Result.IOError | (17 << 8)),
+            IOErrorSHMOpen = (Result.IOError | (18 << 8)),
+            IOErrorSHMSize = (Result.IOError | (19 << 8)),
+            IOErrorSHMLock = (Result.IOError | (20 << 8)),
+            IOErrorSHMMap = (Result.IOError | (21 << 8)),
+            IOErrorSeek = (Result.IOError | (22 << 8)),
+            IOErrorDeleteNoEnt = (Result.IOError | (23 << 8)),
+            IOErrorMMap = (Result.IOError | (24 << 8)),
+            LockedSharedcache = (Result.Locked | (1 << 8)),
+            BusyRecovery = (Result.Busy | (1 << 8)),
+            CannottOpenNoTempDir = (Result.CannotOpen | (1 << 8)),
+            CannotOpenIsDir = (Result.CannotOpen | (2 << 8)),
+            CannotOpenFullPath = (Result.CannotOpen | (3 << 8)),
+            CorruptVTab = (Result.Corrupt | (1 << 8)),
+            ReadonlyRecovery = (Result.ReadOnly | (1 << 8)),
+            ReadonlyCannotLock = (Result.ReadOnly | (2 << 8)),
+            ReadonlyRollback = (Result.ReadOnly | (3 << 8)),
+            AbortRollback = (Result.Abort | (2 << 8)),
+            ConstraintCheck = (Result.Constraint | (1 << 8)),
+            ConstraintCommitHook = (Result.Constraint | (2 << 8)),
+            ConstraintForeignKey = (Result.Constraint | (3 << 8)),
+            ConstraintFunction = (Result.Constraint | (4 << 8)),
+            ConstraintNotNull = (Result.Constraint | (5 << 8)),
+            ConstraintPrimaryKey = (Result.Constraint | (6 << 8)),
+            ConstraintTrigger = (Result.Constraint | (7 << 8)),
+            ConstraintUnique = (Result.Constraint | (8 << 8)),
+            ConstraintVTab = (Result.Constraint | (9 << 8)),
+            NoticeRecoverWAL = (Result.Notice | (1 << 8)),
+            NoticeRecoverRollback = (Result.Notice | (2 << 8))
+        }
+
+
+        public enum ConfigOption : int
+        {
+            SingleThread = 1,
+            MultiThread = 2,
+            Serialized = 3
+        }
+
+        const string LibraryPath = "sqlite3";
 
 #if !USE_CSHARP_SQLITE && !USE_WP8_NATIVE_SQLITE && !USE_SQLITEPCL_RAW
-		[DllImport(LibraryPath, EntryPoint = "sqlite3_threadsafe", CallingConvention=CallingConvention.Cdecl)]
-		public static extern int Threadsafe ();
+        [DllImport(LibraryPath, EntryPoint = "sqlite3_threadsafe", CallingConvention=CallingConvention.Cdecl)]
+        public static extern int Threadsafe ();
 
-		[DllImport(LibraryPath, EntryPoint = "sqlite3_open", CallingConvention=CallingConvention.Cdecl)]
-		public static extern Result Open ([MarshalAs(UnmanagedType.LPStr)] string filename, out IntPtr db);
+        [DllImport(LibraryPath, EntryPoint = "sqlite3_open", CallingConvention=CallingConvention.Cdecl)]
+        public static extern Result Open ([MarshalAs(UnmanagedType.LPStr)] string filename, out IntPtr db);
 
-		[DllImport(LibraryPath, EntryPoint = "sqlite3_open_v2", CallingConvention=CallingConvention.Cdecl)]
-		public static extern Result Open ([MarshalAs(UnmanagedType.LPStr)] string filename, out IntPtr db, int flags, [MarshalAs (UnmanagedType.LPStr)] string zvfs);
+        [DllImport(LibraryPath, EntryPoint = "sqlite3_open_v2", CallingConvention=CallingConvention.Cdecl)]
+        public static extern Result Open ([MarshalAs(UnmanagedType.LPStr)] string filename, out IntPtr db, int flags, [MarshalAs (UnmanagedType.LPStr)] string zvfs);
 
-		[DllImport(LibraryPath, EntryPoint = "sqlite3_open_v2", CallingConvention = CallingConvention.Cdecl)]
-		public static extern Result Open(byte[] filename, out IntPtr db, int flags, [MarshalAs (UnmanagedType.LPStr)] string zvfs);
+        [DllImport(LibraryPath, EntryPoint = "sqlite3_open_v2", CallingConvention = CallingConvention.Cdecl)]
+        public static extern Result Open(byte[] filename, out IntPtr db, int flags, [MarshalAs (UnmanagedType.LPStr)] string zvfs);
 
-		[DllImport(LibraryPath, EntryPoint = "sqlite3_open16", CallingConvention = CallingConvention.Cdecl)]
-		public static extern Result Open16([MarshalAs(UnmanagedType.LPWStr)] string filename, out IntPtr db);
+        [DllImport(LibraryPath, EntryPoint = "sqlite3_open16", CallingConvention = CallingConvention.Cdecl)]
+        public static extern Result Open16([MarshalAs(UnmanagedType.LPWStr)] string filename, out IntPtr db);
 
-		[DllImport(LibraryPath, EntryPoint = "sqlite3_enable_load_extension", CallingConvention=CallingConvention.Cdecl)]
-		public static extern Result EnableLoadExtension (IntPtr db, int onoff);
+        [DllImport(LibraryPath, EntryPoint = "sqlite3_enable_load_extension", CallingConvention=CallingConvention.Cdecl)]
+        public static extern Result EnableLoadExtension (IntPtr db, int onoff);
 
-		[DllImport(LibraryPath, EntryPoint = "sqlite3_close", CallingConvention=CallingConvention.Cdecl)]
-		public static extern Result Close (IntPtr db);
+        [DllImport(LibraryPath, EntryPoint = "sqlite3_close", CallingConvention=CallingConvention.Cdecl)]
+        public static extern Result Close (IntPtr db);
 
-		[DllImport(LibraryPath, EntryPoint = "sqlite3_close_v2", CallingConvention = CallingConvention.Cdecl)]
-		public static extern Result Close2(IntPtr db);
+        [DllImport(LibraryPath, EntryPoint = "sqlite3_close_v2", CallingConvention = CallingConvention.Cdecl)]
+        public static extern Result Close2(IntPtr db);
 
-		[DllImport(LibraryPath, EntryPoint = "sqlite3_initialize", CallingConvention=CallingConvention.Cdecl)]
-		public static extern Result Initialize();
+        [DllImport(LibraryPath, EntryPoint = "sqlite3_initialize", CallingConvention=CallingConvention.Cdecl)]
+        public static extern Result Initialize();
 
-		[DllImport(LibraryPath, EntryPoint = "sqlite3_shutdown", CallingConvention=CallingConvention.Cdecl)]
-		public static extern Result Shutdown();
+        [DllImport(LibraryPath, EntryPoint = "sqlite3_shutdown", CallingConvention=CallingConvention.Cdecl)]
+        public static extern Result Shutdown();
 
-		[DllImport(LibraryPath, EntryPoint = "sqlite3_config", CallingConvention=CallingConvention.Cdecl)]
-		public static extern Result Config (ConfigOption option);
+        [DllImport(LibraryPath, EntryPoint = "sqlite3_config", CallingConvention=CallingConvention.Cdecl)]
+        public static extern Result Config (ConfigOption option);
 
-		[DllImport(LibraryPath, EntryPoint = "sqlite3_win32_set_directory", CallingConvention=CallingConvention.Cdecl, CharSet=CharSet.Unicode)]
-		public static extern int SetDirectory (uint directoryType, string directoryPath);
+        [DllImport(LibraryPath, EntryPoint = "sqlite3_win32_set_directory", CallingConvention=CallingConvention.Cdecl, CharSet=CharSet.Unicode)]
+        public static extern int SetDirectory (uint directoryType, string directoryPath);
 
-		[DllImport(LibraryPath, EntryPoint = "sqlite3_busy_timeout", CallingConvention=CallingConvention.Cdecl)]
-		public static extern Result BusyTimeout (IntPtr db, int milliseconds);
+        [DllImport(LibraryPath, EntryPoint = "sqlite3_busy_timeout", CallingConvention=CallingConvention.Cdecl)]
+        public static extern Result BusyTimeout (IntPtr db, int milliseconds);
 
-		[DllImport(LibraryPath, EntryPoint = "sqlite3_changes", CallingConvention=CallingConvention.Cdecl)]
-		public static extern int Changes (IntPtr db);
+        [DllImport(LibraryPath, EntryPoint = "sqlite3_changes", CallingConvention=CallingConvention.Cdecl)]
+        public static extern int Changes (IntPtr db);
 
-		[DllImport(LibraryPath, EntryPoint = "sqlite3_prepare_v2", CallingConvention=CallingConvention.Cdecl)]
-		public static extern Result Prepare2 (IntPtr db, [MarshalAs(UnmanagedType.LPStr)] string sql, int numBytes, out IntPtr stmt, IntPtr pzTail);
+        [DllImport(LibraryPath, EntryPoint = "sqlite3_prepare_v2", CallingConvention=CallingConvention.Cdecl)]
+        public static extern Result Prepare2 (IntPtr db, [MarshalAs(UnmanagedType.LPStr)] string sql, int numBytes, out IntPtr stmt, IntPtr pzTail);
 
 #if NETFX_CORE
-		[DllImport (LibraryPath, EntryPoint = "sqlite3_prepare_v2", CallingConvention = CallingConvention.Cdecl)]
-		public static extern Result Prepare2 (IntPtr db, byte[] queryBytes, int numBytes, out IntPtr stmt, IntPtr pzTail);
+        [DllImport (LibraryPath, EntryPoint = "sqlite3_prepare_v2", CallingConvention = CallingConvention.Cdecl)]
+        public static extern Result Prepare2 (IntPtr db, byte[] queryBytes, int numBytes, out IntPtr stmt, IntPtr pzTail);
 #endif
 
-		public static IntPtr Prepare2 (IntPtr db, string query)
-		{
-			IntPtr stmt;
+        public static IntPtr Prepare2 (IntPtr db, string query)
+        {
+            IntPtr stmt;
 #if NETFX_CORE
             byte[] queryBytes = System.Text.UTF8Encoding.UTF8.GetBytes (query);
             var r = Prepare2 (db, queryBytes, queryBytes.Length, out stmt, IntPtr.Zero);
 #else
             var r = Prepare2 (db, query, System.Text.UTF8Encoding.UTF8.GetByteCount (query), out stmt, IntPtr.Zero);
 #endif
-			if (r != Result.OK) {
-				throw SQLiteException.New (r, GetErrmsg (db));
-			}
-			return stmt;
-		}
+            if (r != Result.OK) {
+                throw SQLiteException.New (r, GetErrmsg (db));
+            }
+            return stmt;
+        }
 
-		[DllImport(LibraryPath, EntryPoint = "sqlite3_step", CallingConvention=CallingConvention.Cdecl)]
-		public static extern Result Step (IntPtr stmt);
+        [DllImport(LibraryPath, EntryPoint = "sqlite3_step", CallingConvention=CallingConvention.Cdecl)]
+        public static extern Result Step (IntPtr stmt);
 
-		[DllImport(LibraryPath, EntryPoint = "sqlite3_reset", CallingConvention=CallingConvention.Cdecl)]
-		public static extern Result Reset (IntPtr stmt);
+        [DllImport(LibraryPath, EntryPoint = "sqlite3_reset", CallingConvention=CallingConvention.Cdecl)]
+        public static extern Result Reset (IntPtr stmt);
 
-		[DllImport(LibraryPath, EntryPoint = "sqlite3_finalize", CallingConvention=CallingConvention.Cdecl)]
-		public static extern Result Finalize (IntPtr stmt);
+        [DllImport(LibraryPath, EntryPoint = "sqlite3_finalize", CallingConvention=CallingConvention.Cdecl)]
+        public static extern Result Finalize (IntPtr stmt);
 
-		[DllImport(LibraryPath, EntryPoint = "sqlite3_last_insert_rowid", CallingConvention=CallingConvention.Cdecl)]
-		public static extern long LastInsertRowid (IntPtr db);
+        [DllImport(LibraryPath, EntryPoint = "sqlite3_last_insert_rowid", CallingConvention=CallingConvention.Cdecl)]
+        public static extern long LastInsertRowid (IntPtr db);
 
-		[DllImport(LibraryPath, EntryPoint = "sqlite3_errmsg16", CallingConvention=CallingConvention.Cdecl)]
-		public static extern IntPtr Errmsg (IntPtr db);
+        [DllImport(LibraryPath, EntryPoint = "sqlite3_errmsg16", CallingConvention=CallingConvention.Cdecl)]
+        public static extern IntPtr Errmsg (IntPtr db);
 
-		public static string GetErrmsg (IntPtr db)
-		{
-			return Marshal.PtrToStringUni (Errmsg (db));
-		}
+        public static string GetErrmsg (IntPtr db)
+        {
+            return Marshal.PtrToStringUni (Errmsg (db));
+        }
 
-		[DllImport(LibraryPath, EntryPoint = "sqlite3_bind_parameter_index", CallingConvention=CallingConvention.Cdecl)]
-		public static extern int BindParameterIndex (IntPtr stmt, [MarshalAs(UnmanagedType.LPStr)] string name);
+        [DllImport(LibraryPath, EntryPoint = "sqlite3_bind_parameter_index", CallingConvention=CallingConvention.Cdecl)]
+        public static extern int BindParameterIndex (IntPtr stmt, [MarshalAs(UnmanagedType.LPStr)] string name);
 
-		[DllImport(LibraryPath, EntryPoint = "sqlite3_bind_null", CallingConvention=CallingConvention.Cdecl)]
-		public static extern int BindNull (IntPtr stmt, int index);
+        [DllImport(LibraryPath, EntryPoint = "sqlite3_bind_null", CallingConvention=CallingConvention.Cdecl)]
+        public static extern int BindNull (IntPtr stmt, int index);
 
-		[DllImport(LibraryPath, EntryPoint = "sqlite3_bind_int", CallingConvention=CallingConvention.Cdecl)]
-		public static extern int BindInt (IntPtr stmt, int index, int val);
+        [DllImport(LibraryPath, EntryPoint = "sqlite3_bind_int", CallingConvention=CallingConvention.Cdecl)]
+        public static extern int BindInt (IntPtr stmt, int index, int val);
 
-		[DllImport(LibraryPath, EntryPoint = "sqlite3_bind_int64", CallingConvention=CallingConvention.Cdecl)]
-		public static extern int BindInt64 (IntPtr stmt, int index, long val);
+        [DllImport(LibraryPath, EntryPoint = "sqlite3_bind_int64", CallingConvention=CallingConvention.Cdecl)]
+        public static extern int BindInt64 (IntPtr stmt, int index, long val);
 
-		[DllImport(LibraryPath, EntryPoint = "sqlite3_bind_double", CallingConvention=CallingConvention.Cdecl)]
-		public static extern int BindDouble (IntPtr stmt, int index, double val);
+        [DllImport(LibraryPath, EntryPoint = "sqlite3_bind_double", CallingConvention=CallingConvention.Cdecl)]
+        public static extern int BindDouble (IntPtr stmt, int index, double val);
 
-		[DllImport(LibraryPath, EntryPoint = "sqlite3_bind_text16", CallingConvention=CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
-		public static extern int BindText (IntPtr stmt, int index, [MarshalAs(UnmanagedType.LPWStr)] string val, int n, IntPtr free);
+        [DllImport(LibraryPath, EntryPoint = "sqlite3_bind_text16", CallingConvention=CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
+        public static extern int BindText (IntPtr stmt, int index, [MarshalAs(UnmanagedType.LPWStr)] string val, int n, IntPtr free);
 
-		[DllImport(LibraryPath, EntryPoint = "sqlite3_bind_blob", CallingConvention=CallingConvention.Cdecl)]
-		public static extern int BindBlob (IntPtr stmt, int index, byte[] val, int n, IntPtr free);
+        [DllImport(LibraryPath, EntryPoint = "sqlite3_bind_blob", CallingConvention=CallingConvention.Cdecl)]
+        public static extern int BindBlob (IntPtr stmt, int index, byte[] val, int n, IntPtr free);
 
-		[DllImport(LibraryPath, EntryPoint = "sqlite3_column_count", CallingConvention=CallingConvention.Cdecl)]
-		public static extern int ColumnCount (IntPtr stmt);
+        [DllImport(LibraryPath, EntryPoint = "sqlite3_column_count", CallingConvention=CallingConvention.Cdecl)]
+        public static extern int ColumnCount (IntPtr stmt);
 
-		[DllImport(LibraryPath, EntryPoint = "sqlite3_column_name", CallingConvention=CallingConvention.Cdecl)]
-		public static extern IntPtr ColumnName (IntPtr stmt, int index);
+        [DllImport(LibraryPath, EntryPoint = "sqlite3_column_name", CallingConvention=CallingConvention.Cdecl)]
+        public static extern IntPtr ColumnName (IntPtr stmt, int index);
 
-		[DllImport(LibraryPath, EntryPoint = "sqlite3_column_name16", CallingConvention=CallingConvention.Cdecl)]
-		static extern IntPtr ColumnName16Internal (IntPtr stmt, int index);
-		public static string ColumnName16(IntPtr stmt, int index)
-		{
-			return Marshal.PtrToStringUni(ColumnName16Internal(stmt, index));
-		}
+        [DllImport(LibraryPath, EntryPoint = "sqlite3_column_name16", CallingConvention=CallingConvention.Cdecl)]
+        static extern IntPtr ColumnName16Internal (IntPtr stmt, int index);
+        public static string ColumnName16(IntPtr stmt, int index)
+        {
+            return Marshal.PtrToStringUni(ColumnName16Internal(stmt, index));
+        }
 
-		[DllImport(LibraryPath, EntryPoint = "sqlite3_column_type", CallingConvention=CallingConvention.Cdecl)]
-		public static extern ColType ColumnType (IntPtr stmt, int index);
+        [DllImport(LibraryPath, EntryPoint = "sqlite3_column_type", CallingConvention=CallingConvention.Cdecl)]
+        public static extern ColType ColumnType (IntPtr stmt, int index);
 
-		[DllImport(LibraryPath, EntryPoint = "sqlite3_column_int", CallingConvention=CallingConvention.Cdecl)]
-		public static extern int ColumnInt (IntPtr stmt, int index);
+        [DllImport(LibraryPath, EntryPoint = "sqlite3_column_int", CallingConvention=CallingConvention.Cdecl)]
+        public static extern int ColumnInt (IntPtr stmt, int index);
 
-		[DllImport(LibraryPath, EntryPoint = "sqlite3_column_int64", CallingConvention=CallingConvention.Cdecl)]
-		public static extern long ColumnInt64 (IntPtr stmt, int index);
+        [DllImport(LibraryPath, EntryPoint = "sqlite3_column_int64", CallingConvention=CallingConvention.Cdecl)]
+        public static extern long ColumnInt64 (IntPtr stmt, int index);
 
-		[DllImport(LibraryPath, EntryPoint = "sqlite3_column_double", CallingConvention=CallingConvention.Cdecl)]
-		public static extern double ColumnDouble (IntPtr stmt, int index);
+        [DllImport(LibraryPath, EntryPoint = "sqlite3_column_double", CallingConvention=CallingConvention.Cdecl)]
+        public static extern double ColumnDouble (IntPtr stmt, int index);
 
-		[DllImport(LibraryPath, EntryPoint = "sqlite3_column_text", CallingConvention=CallingConvention.Cdecl)]
-		public static extern IntPtr ColumnText (IntPtr stmt, int index);
+        [DllImport(LibraryPath, EntryPoint = "sqlite3_column_text", CallingConvention=CallingConvention.Cdecl)]
+        public static extern IntPtr ColumnText (IntPtr stmt, int index);
 
-		[DllImport(LibraryPath, EntryPoint = "sqlite3_column_text16", CallingConvention=CallingConvention.Cdecl)]
-		public static extern IntPtr ColumnText16 (IntPtr stmt, int index);
+        [DllImport(LibraryPath, EntryPoint = "sqlite3_column_text16", CallingConvention=CallingConvention.Cdecl)]
+        public static extern IntPtr ColumnText16 (IntPtr stmt, int index);
 
-		[DllImport(LibraryPath, EntryPoint = "sqlite3_column_blob", CallingConvention=CallingConvention.Cdecl)]
-		public static extern IntPtr ColumnBlob (IntPtr stmt, int index);
+        [DllImport(LibraryPath, EntryPoint = "sqlite3_column_blob", CallingConvention=CallingConvention.Cdecl)]
+        public static extern IntPtr ColumnBlob (IntPtr stmt, int index);
 
-		[DllImport(LibraryPath, EntryPoint = "sqlite3_column_bytes", CallingConvention=CallingConvention.Cdecl)]
-		public static extern int ColumnBytes (IntPtr stmt, int index);
+        [DllImport(LibraryPath, EntryPoint = "sqlite3_column_bytes", CallingConvention=CallingConvention.Cdecl)]
+        public static extern int ColumnBytes (IntPtr stmt, int index);
 
-		public static string ColumnString (IntPtr stmt, int index)
-		{
-			return Marshal.PtrToStringUni (SQLite3.ColumnText16 (stmt, index));
-		}
+        public static string ColumnString (IntPtr stmt, int index)
+        {
+            return Marshal.PtrToStringUni (SQLite3.ColumnText16 (stmt, index));
+        }
 
-		public static byte[] ColumnByteArray (IntPtr stmt, int index)
-		{
-			int length = ColumnBytes (stmt, index);
-			var result = new byte[length];
-			if (length > 0)
-				Marshal.Copy (ColumnBlob (stmt, index), result, 0, length);
-			return result;
-		}
+        public static byte[] ColumnByteArray (IntPtr stmt, int index)
+        {
+            int length = ColumnBytes (stmt, index);
+            var result = new byte[length];
+            if (length > 0)
+                Marshal.Copy (ColumnBlob (stmt, index), result, 0, length);
+            return result;
+        }
 
-		[DllImport (LibraryPath, EntryPoint = "sqlite3_errcode", CallingConvention = CallingConvention.Cdecl)]
-		public static extern Result GetResult (Sqlite3DatabaseHandle db);
+        [DllImport (LibraryPath, EntryPoint = "sqlite3_errcode", CallingConvention = CallingConvention.Cdecl)]
+        public static extern Result GetResult (Sqlite3DatabaseHandle db);
 
-		[DllImport (LibraryPath, EntryPoint = "sqlite3_extended_errcode", CallingConvention = CallingConvention.Cdecl)]
-		public static extern ExtendedResult ExtendedErrCode (IntPtr db);
+        [DllImport (LibraryPath, EntryPoint = "sqlite3_extended_errcode", CallingConvention = CallingConvention.Cdecl)]
+        public static extern ExtendedResult ExtendedErrCode (IntPtr db);
 
-		[DllImport (LibraryPath, EntryPoint = "sqlite3_libversion_number", CallingConvention = CallingConvention.Cdecl)]
-		public static extern int LibVersionNumber ();
+        [DllImport (LibraryPath, EntryPoint = "sqlite3_libversion_number", CallingConvention = CallingConvention.Cdecl)]
+        public static extern int LibVersionNumber ();
 
-		[DllImport (LibraryPath, EntryPoint = "sqlite3_backup_init", CallingConvention = CallingConvention.Cdecl)]
-		public static extern Sqlite3BackupHandle BackupInit (Sqlite3DatabaseHandle destDb, [MarshalAs (UnmanagedType.LPStr)] string destName, Sqlite3DatabaseHandle sourceDb, [MarshalAs (UnmanagedType.LPStr)] string sourceName);
+        [DllImport (LibraryPath, EntryPoint = "sqlite3_backup_init", CallingConvention = CallingConvention.Cdecl)]
+        public static extern Sqlite3BackupHandle BackupInit (Sqlite3DatabaseHandle destDb, [MarshalAs (UnmanagedType.LPStr)] string destName, Sqlite3DatabaseHandle sourceDb, [MarshalAs (UnmanagedType.LPStr)] string sourceName);
 
-		[DllImport (LibraryPath, EntryPoint = "sqlite3_backup_step", CallingConvention = CallingConvention.Cdecl)]
-		public static extern Result BackupStep (Sqlite3BackupHandle backup, int numPages);
+        [DllImport (LibraryPath, EntryPoint = "sqlite3_backup_step", CallingConvention = CallingConvention.Cdecl)]
+        public static extern Result BackupStep (Sqlite3BackupHandle backup, int numPages);
 
-		[DllImport (LibraryPath, EntryPoint = "sqlite3_backup_finish", CallingConvention = CallingConvention.Cdecl)]
-		public static extern Result BackupFinish (Sqlite3BackupHandle backup);
+        [DllImport (LibraryPath, EntryPoint = "sqlite3_backup_finish", CallingConvention = CallingConvention.Cdecl)]
+        public static extern Result BackupFinish (Sqlite3BackupHandle backup);
 #else
-		public static Result Open (string filename, out Sqlite3DatabaseHandle db)
-		{
-			return (Result)Sqlite3.sqlite3_open (filename, out db);
-		}
+        public static Result Open (string filename, out Sqlite3DatabaseHandle db)
+        {
+            return (Result)Sqlite3.sqlite3_open (filename, out db);
+        }
 
-		public static Result Open (string filename, out Sqlite3DatabaseHandle db, int flags, string vfsName)
-		{
+        public static Result Open (string filename, out Sqlite3DatabaseHandle db, int flags, string vfsName)
+        {
 #if USE_WP8_NATIVE_SQLITE
-			return (Result)Sqlite3.sqlite3_open_v2(filename, out db, flags, vfsName ?? "");
+            return (Result)Sqlite3.sqlite3_open_v2(filename, out db, flags, vfsName ?? "");
 #else
-			return (Result)Sqlite3.sqlite3_open_v2 (filename, out db, flags, vfsName);
+            return (Result)Sqlite3.sqlite3_open_v2 (filename, out db, flags, vfsName);
 #endif
-		}
+        }
 
-		public static Result Close (Sqlite3DatabaseHandle db)
-		{
-			return (Result)Sqlite3.sqlite3_close (db);
-		}
+        public static Result Close (Sqlite3DatabaseHandle db)
+        {
+            return (Result)Sqlite3.sqlite3_close (db);
+        }
 
-		public static Result Close2 (Sqlite3DatabaseHandle db)
-		{
-			return (Result)Sqlite3.sqlite3_close_v2 (db);
-		}
+        public static Result Close2 (Sqlite3DatabaseHandle db)
+        {
+            return (Result)Sqlite3.sqlite3_close_v2 (db);
+        }
 
-		public static Result BusyTimeout (Sqlite3DatabaseHandle db, int milliseconds)
-		{
-			return (Result)Sqlite3.sqlite3_busy_timeout (db, milliseconds);
-		}
+        public static Result BusyTimeout (Sqlite3DatabaseHandle db, int milliseconds)
+        {
+            return (Result)Sqlite3.sqlite3_busy_timeout (db, milliseconds);
+        }
 
-		public static int Changes (Sqlite3DatabaseHandle db)
-		{
-			return Sqlite3.sqlite3_changes (db);
-		}
+        public static int Changes (Sqlite3DatabaseHandle db)
+        {
+            return Sqlite3.sqlite3_changes (db);
+        }
 
-		public static Sqlite3Statement Prepare2 (Sqlite3DatabaseHandle db, string query)
-		{
-			Sqlite3Statement stmt = default (Sqlite3Statement);
+        public static Sqlite3Statement Prepare2 (Sqlite3DatabaseHandle db, string query)
+        {
+            Sqlite3Statement stmt = default (Sqlite3Statement);
 #if USE_WP8_NATIVE_SQLITE || USE_SQLITEPCL_RAW
-			var r = Sqlite3.sqlite3_prepare_v2 (db, query, out stmt);
+            var r = Sqlite3.sqlite3_prepare_v2 (db, query, out stmt);
 #else
-			stmt = new Sqlite3Statement();
-			var r = Sqlite3.sqlite3_prepare_v2(db, query, -1, ref stmt, 0);
+            stmt = new Sqlite3Statement();
+            var r = Sqlite3.sqlite3_prepare_v2(db, query, -1, ref stmt, 0);
 #endif
-			if (r != 0) {
-				throw SQLiteException.New ((Result)r, GetErrmsg (db));
-			}
-			return stmt;
-		}
+            if (r != 0) {
+                throw SQLiteException.New ((Result)r, GetErrmsg (db));
+            }
+            return stmt;
+        }
 
-		public static Result Step (Sqlite3Statement stmt)
-		{
-			return (Result)Sqlite3.sqlite3_step (stmt);
-		}
+        public static Result Step (Sqlite3Statement stmt)
+        {
+            return (Result)Sqlite3.sqlite3_step (stmt);
+        }
 
-		public static Result Reset (Sqlite3Statement stmt)
-		{
-			return (Result)Sqlite3.sqlite3_reset (stmt);
-		}
+        public static Result Reset (Sqlite3Statement stmt)
+        {
+            return (Result)Sqlite3.sqlite3_reset (stmt);
+        }
 
-		public static Result Finalize (Sqlite3Statement stmt)
-		{
-			return (Result)Sqlite3.sqlite3_finalize (stmt);
-		}
+        public static Result Finalize (Sqlite3Statement stmt)
+        {
+            return (Result)Sqlite3.sqlite3_finalize (stmt);
+        }
 
-		public static long LastInsertRowid (Sqlite3DatabaseHandle db)
-		{
-			return Sqlite3.sqlite3_last_insert_rowid (db);
-		}
+        public static long LastInsertRowid (Sqlite3DatabaseHandle db)
+        {
+            return Sqlite3.sqlite3_last_insert_rowid (db);
+        }
 
-		public static string GetErrmsg (Sqlite3DatabaseHandle db)
-		{
-			return Sqlite3.sqlite3_errmsg (db).utf8_to_string ();
-		}
+        public static string GetErrmsg (Sqlite3DatabaseHandle db)
+        {
+            return Sqlite3.sqlite3_errmsg (db).utf8_to_string ();
+        }
 
-		public static int BindParameterIndex (Sqlite3Statement stmt, string name)
-		{
-			return Sqlite3.sqlite3_bind_parameter_index (stmt, name);
-		}
+        public static int BindParameterIndex (Sqlite3Statement stmt, string name)
+        {
+            return Sqlite3.sqlite3_bind_parameter_index (stmt, name);
+        }
 
-		public static int BindNull (Sqlite3Statement stmt, int index)
-		{
-			return Sqlite3.sqlite3_bind_null (stmt, index);
-		}
+        public static int BindNull (Sqlite3Statement stmt, int index)
+        {
+            return Sqlite3.sqlite3_bind_null (stmt, index);
+        }
 
-		public static int BindInt (Sqlite3Statement stmt, int index, int val)
-		{
-			return Sqlite3.sqlite3_bind_int (stmt, index, val);
-		}
+        public static int BindInt (Sqlite3Statement stmt, int index, int val)
+        {
+            return Sqlite3.sqlite3_bind_int (stmt, index, val);
+        }
 
-		public static int BindInt64 (Sqlite3Statement stmt, int index, long val)
-		{
-			return Sqlite3.sqlite3_bind_int64 (stmt, index, val);
-		}
+        public static int BindInt64 (Sqlite3Statement stmt, int index, long val)
+        {
+            return Sqlite3.sqlite3_bind_int64 (stmt, index, val);
+        }
 
-		public static int BindDouble (Sqlite3Statement stmt, int index, double val)
-		{
-			return Sqlite3.sqlite3_bind_double (stmt, index, val);
-		}
+        public static int BindDouble (Sqlite3Statement stmt, int index, double val)
+        {
+            return Sqlite3.sqlite3_bind_double (stmt, index, val);
+        }
 
-		public static int BindText (Sqlite3Statement stmt, int index, string val, int n, IntPtr free)
-		{
+        public static int BindText (Sqlite3Statement stmt, int index, string val, int n, IntPtr free)
+        {
 #if USE_WP8_NATIVE_SQLITE
-			return Sqlite3.sqlite3_bind_text(stmt, index, val, n);
+            return Sqlite3.sqlite3_bind_text(stmt, index, val, n);
 #elif USE_SQLITEPCL_RAW
-			return Sqlite3.sqlite3_bind_text (stmt, index, val);
+            return Sqlite3.sqlite3_bind_text (stmt, index, val);
 #else
-			return Sqlite3.sqlite3_bind_text(stmt, index, val, n, null);
+            return Sqlite3.sqlite3_bind_text(stmt, index, val, n, null);
 #endif
-		}
+        }
 
-		public static int BindBlob (Sqlite3Statement stmt, int index, byte[] val, int n, IntPtr free)
-		{
+        public static int BindBlob (Sqlite3Statement stmt, int index, byte[] val, int n, IntPtr free)
+        {
 #if USE_WP8_NATIVE_SQLITE
-			return Sqlite3.sqlite3_bind_blob(stmt, index, val, n);
+            return Sqlite3.sqlite3_bind_blob(stmt, index, val, n);
 #elif USE_SQLITEPCL_RAW
-			return Sqlite3.sqlite3_bind_blob (stmt, index, val);
+            return Sqlite3.sqlite3_bind_blob (stmt, index, val);
 #else
-			return Sqlite3.sqlite3_bind_blob(stmt, index, val, n, null);
+            return Sqlite3.sqlite3_bind_blob(stmt, index, val, n, null);
 #endif
-		}
+        }
 
-		public static int ColumnCount (Sqlite3Statement stmt)
-		{
-			return Sqlite3.sqlite3_column_count (stmt);
-		}
+        public static int ColumnCount (Sqlite3Statement stmt)
+        {
+            return Sqlite3.sqlite3_column_count (stmt);
+        }
 
-		public static string ColumnName (Sqlite3Statement stmt, int index)
-		{
-			return Sqlite3.sqlite3_column_name (stmt, index).utf8_to_string ();
-		}
+        public static string ColumnName (Sqlite3Statement stmt, int index)
+        {
+            return Sqlite3.sqlite3_column_name (stmt, index).utf8_to_string ();
+        }
 
-		public static string ColumnName16 (Sqlite3Statement stmt, int index)
-		{
-			return Sqlite3.sqlite3_column_name (stmt, index).utf8_to_string ();
-		}
+        public static string ColumnName16 (Sqlite3Statement stmt, int index)
+        {
+            return Sqlite3.sqlite3_column_name (stmt, index).utf8_to_string ();
+        }
 
-		public static ColType ColumnType (Sqlite3Statement stmt, int index)
-		{
-			return (ColType)Sqlite3.sqlite3_column_type (stmt, index);
-		}
+        public static ColType ColumnType (Sqlite3Statement stmt, int index)
+        {
+            return (ColType)Sqlite3.sqlite3_column_type (stmt, index);
+        }
 
-		public static int ColumnInt (Sqlite3Statement stmt, int index)
-		{
-			return Sqlite3.sqlite3_column_int (stmt, index);
-		}
+        public static int ColumnInt (Sqlite3Statement stmt, int index)
+        {
+            return Sqlite3.sqlite3_column_int (stmt, index);
+        }
 
-		public static long ColumnInt64 (Sqlite3Statement stmt, int index)
-		{
-			return Sqlite3.sqlite3_column_int64 (stmt, index);
-		}
+        public static long ColumnInt64 (Sqlite3Statement stmt, int index)
+        {
+            return Sqlite3.sqlite3_column_int64 (stmt, index);
+        }
 
-		public static double ColumnDouble (Sqlite3Statement stmt, int index)
-		{
-			return Sqlite3.sqlite3_column_double (stmt, index);
-		}
+        public static double ColumnDouble (Sqlite3Statement stmt, int index)
+        {
+            return Sqlite3.sqlite3_column_double (stmt, index);
+        }
 
-		public static string ColumnText (Sqlite3Statement stmt, int index)
-		{
-			return Sqlite3.sqlite3_column_text (stmt, index).utf8_to_string ();
-		}
+        public static string ColumnText (Sqlite3Statement stmt, int index)
+        {
+            return Sqlite3.sqlite3_column_text (stmt, index).utf8_to_string ();
+        }
 
-		public static string ColumnText16 (Sqlite3Statement stmt, int index)
-		{
-			return Sqlite3.sqlite3_column_text (stmt, index).utf8_to_string ();
-		}
+        public static string ColumnText16 (Sqlite3Statement stmt, int index)
+        {
+            return Sqlite3.sqlite3_column_text (stmt, index).utf8_to_string ();
+        }
 
-		public static byte[] ColumnBlob (Sqlite3Statement stmt, int index)
-		{
-			return Sqlite3.sqlite3_column_blob (stmt, index).ToArray ();
-		}
+        public static byte[] ColumnBlob (Sqlite3Statement stmt, int index)
+        {
+            return Sqlite3.sqlite3_column_blob (stmt, index).ToArray ();
+        }
 
-		public static int ColumnBytes (Sqlite3Statement stmt, int index)
-		{
-			return Sqlite3.sqlite3_column_bytes (stmt, index);
-		}
+        public static int ColumnBytes (Sqlite3Statement stmt, int index)
+        {
+            return Sqlite3.sqlite3_column_bytes (stmt, index);
+        }
 
-		public static string ColumnString (Sqlite3Statement stmt, int index)
-		{
-			return Sqlite3.sqlite3_column_text (stmt, index).utf8_to_string ();
-		}
+        public static string ColumnString (Sqlite3Statement stmt, int index)
+        {
+            return Sqlite3.sqlite3_column_text (stmt, index).utf8_to_string ();
+        }
 
-		public static byte[] ColumnByteArray (Sqlite3Statement stmt, int index)
-		{
-			int length = ColumnBytes (stmt, index);
-			if (length > 0) {
-				return ColumnBlob (stmt, index);
-			}
-			return new byte[0];
-		}
+        public static byte[] ColumnByteArray (Sqlite3Statement stmt, int index)
+        {
+            int length = ColumnBytes (stmt, index);
+            if (length > 0) {
+                return ColumnBlob (stmt, index);
+            }
+            return new byte[0];
+        }
 
-		public static Result EnableLoadExtension (Sqlite3DatabaseHandle db, int onoff)
-		{
-			return (Result)Sqlite3.sqlite3_enable_load_extension (db, onoff);
-		}
+        public static Result EnableLoadExtension (Sqlite3DatabaseHandle db, int onoff)
+        {
+            return (Result)Sqlite3.sqlite3_enable_load_extension (db, onoff);
+        }
 
-		public static int LibVersionNumber ()
-		{
-			return Sqlite3.sqlite3_libversion_number ();
-		}
+        public static int LibVersionNumber ()
+        {
+            return Sqlite3.sqlite3_libversion_number ();
+        }
 
-		public static Result GetResult (Sqlite3DatabaseHandle db)
-		{
-			return (Result)Sqlite3.sqlite3_errcode (db);
-		}
+        public static Result GetResult (Sqlite3DatabaseHandle db)
+        {
+            return (Result)Sqlite3.sqlite3_errcode (db);
+        }
 
-		public static ExtendedResult ExtendedErrCode (Sqlite3DatabaseHandle db)
-		{
-			return (ExtendedResult)Sqlite3.sqlite3_extended_errcode (db);
-		}
+        public static ExtendedResult ExtendedErrCode (Sqlite3DatabaseHandle db)
+        {
+            return (ExtendedResult)Sqlite3.sqlite3_extended_errcode (db);
+        }
 
-		public static Sqlite3BackupHandle BackupInit (Sqlite3DatabaseHandle destDb, string destName, Sqlite3DatabaseHandle sourceDb, string sourceName)
-		{
-			return Sqlite3.sqlite3_backup_init (destDb, destName, sourceDb, sourceName);
-		}
+        public static Sqlite3BackupHandle BackupInit (Sqlite3DatabaseHandle destDb, string destName, Sqlite3DatabaseHandle sourceDb, string sourceName)
+        {
+            return Sqlite3.sqlite3_backup_init (destDb, destName, sourceDb, sourceName);
+        }
 
-		public static Result BackupStep (Sqlite3BackupHandle backup, int numPages)
-		{
-			return (Result)Sqlite3.sqlite3_backup_step (backup, numPages);
-		}
+        public static Result BackupStep (Sqlite3BackupHandle backup, int numPages)
+        {
+            return (Result)Sqlite3.sqlite3_backup_step (backup, numPages);
+        }
 
-		public static Result BackupFinish (Sqlite3BackupHandle backup)
-		{
-			return (Result)Sqlite3.sqlite3_backup_finish (backup);
-		}
+        public static Result BackupFinish (Sqlite3BackupHandle backup)
+        {
+            return (Result)Sqlite3.sqlite3_backup_finish (backup);
+        }
 #endif
 
-		public enum ColType : int
-		{
-			Integer = 1,
-			Float = 2,
-			Text = 3,
-			Blob = 4,
-			Null = 5
-		}
-	}
+        public enum ColType : int
+        {
+            Integer = 1,
+            Float = 2,
+            Text = 3,
+            Blob = 4,
+            Null = 5
+        }
+    }
 }

--- a/src/SQLite.cs
+++ b/src/SQLite.cs
@@ -3566,8 +3566,9 @@ namespace SQLite
 						else {
 							getSetter = FastColumnSetter.GetFastSetterMethodInfoUnsafe (map.MappedType);
 						}
-#endif
+#else
 						getSetter = FastColumnSetter.GetFastSetterMethodInfoUnsafe (map.MappedType);
+#endif
 					}
 
 					for (int i = 0; i < cols.Length; i++) {						

--- a/src/SQLite.cs
+++ b/src/SQLite.cs
@@ -2915,7 +2915,10 @@ namespace SQLite
 
     public class TableMapping
     {
-        public Type MappedType { get; private set; }
+#if NET8_0_OR_GREATER
+		[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+#endif
+		public Type MappedType { get; private set; }
 
         public string TableName { get; private set; }
 

--- a/src/SQLite.cs
+++ b/src/SQLite.cs
@@ -282,7 +282,7 @@ namespace SQLite
 			where T3 : new()
 			where T4 : new()
 			where T5 : new();
-#if NET
+#if NET8_0_OR_GREATER
 		[RequiresUnreferencedCode ("This method requires 'DynamicallyAccessedMemberTypes.All' on each input 'Type' instance.")]
 #endif
 		CreateTablesResult CreateTables (CreateFlags createFlags = CreateFlags.None, params Type[] types);
@@ -1091,7 +1091,7 @@ namespace SQLite
 		/// <returns>
 		/// Whether the table was created or migrated for each type.
 		/// </returns>
-#if NET
+#if NET8_0_OR_GREATER
 		[RequiresUnreferencedCode("This method requires 'DynamicallyAccessedMemberTypes.All' on each input 'Type' instance.")]
 #endif
 		public CreateTablesResult CreateTables (CreateFlags createFlags = CreateFlags.None, params Type[] types)

--- a/src/SQLite.cs
+++ b/src/SQLite.cs
@@ -954,7 +954,7 @@ namespace SQLite
 		/// Whether the table was created or migrated for each type.
 		/// </returns>
 #if NET8_0_OR_GREATER
-		[UnconditionalSuppressMessage ("Trimming", "IL2026", Justification = "This method preserves metata for all type arguments.")]
+		[UnconditionalSuppressMessage ("Trimming", "IL2026", Justification = "This method preserves metadata for all type arguments.")]
 #endif
 		public CreateTablesResult CreateTables<
 #if NET8_0_OR_GREATER
@@ -981,7 +981,7 @@ namespace SQLite
 		/// Whether the table was created or migrated for each type.
 		/// </returns>
 #if NET8_0_OR_GREATER
-		[UnconditionalSuppressMessage ("Trimming", "IL2026", Justification = "This method preserves metata for all type arguments.")]
+		[UnconditionalSuppressMessage ("Trimming", "IL2026", Justification = "This method preserves metadata for all type arguments.")]
 #endif
 		public CreateTablesResult CreateTables<
 #if NET8_0_OR_GREATER
@@ -1013,7 +1013,7 @@ namespace SQLite
 		/// Whether the table was created or migrated for each type.
 		/// </returns>
 #if NET8_0_OR_GREATER
-		[UnconditionalSuppressMessage ("Trimming", "IL2026", Justification = "This method preserves metata for all type arguments.")]
+		[UnconditionalSuppressMessage ("Trimming", "IL2026", Justification = "This method preserves metadata for all type arguments.")]
 #endif
 		public CreateTablesResult CreateTables<
 #if NET8_0_OR_GREATER
@@ -1050,7 +1050,7 @@ namespace SQLite
 		/// Whether the table was created or migrated for each type.
 		/// </returns>
 #if NET8_0_OR_GREATER
-		[UnconditionalSuppressMessage ("Trimming", "IL2026", Justification = "This method preserves metata for all type arguments.")]
+		[UnconditionalSuppressMessage ("Trimming", "IL2026", Justification = "This method preserves metadata for all type arguments.")]
 #endif
 		public CreateTablesResult CreateTables<
 #if NET8_0_OR_GREATER

--- a/src/SQLite.cs
+++ b/src/SQLite.cs
@@ -1880,7 +1880,7 @@ namespace SQLite
 				if (Int32.TryParse (savepoint.Substring (firstLen + 1), out depth)) {
 					// TODO: Mild race here, but inescapable without locking almost everywhere.
 					if (0 <= depth && depth < _transactionDepth) {
-#if NETFX_CORE || USE_SQLITEPCL_RAW || NETCORE
+#if NETFX_CORE || USE_SQLITEPCL_RAW || NETCORE || NET8_0_OR_GREATER
 						Volatile.Write (ref _transactionDepth, depth);
 #elif SILVERLIGHT
 						_transactionDepth = depth;

--- a/src/SQLite.cs
+++ b/src/SQLite.cs
@@ -3553,11 +3553,18 @@ namespace SQLite
 					MethodInfo getSetter = null;
 					if (typeof(T) != map.MappedType) {
 #if NET8_0_OR_GREATER
+						// The runtime feature switch must be on a separate 'if' branch on its own,
+						// or the analyzer might not be able to correctly follow the program flow.
 						if (!RuntimeFeature.IsDynamicCodeSupported) {
 							if (map.MappedType.IsValueType) {
-								throw new NotSupportedException (
-									$"Executing a query with a value type mapped type is not supported in AOT environments (The mapped type is '{map.MappedType}').");
+								getSetter = null;
 							}
+							else {
+								getSetter = FastColumnSetter.GetFastSetterMethodInfoUnsafe (map.MappedType);
+							}
+						}
+						else {
+							getSetter = FastColumnSetter.GetFastSetterMethodInfoUnsafe (map.MappedType);
 						}
 #endif
 						getSetter = FastColumnSetter.GetFastSetterMethodInfoUnsafe (map.MappedType);

--- a/src/SQLiteAsync.cs
+++ b/src/SQLiteAsync.cs
@@ -141,7 +141,7 @@ namespace SQLite
 			where T3 : new()
 			where T4 : new()
 			where T5 : new();
-#if NET
+#if NET8_0_OR_GREATER
 		[RequiresUnreferencedCode ("This method requires 'DynamicallyAccessedMemberTypes.All' on each input 'Type' instance.")]
 #endif
 		Task<CreateTablesResult> CreateTablesAsync (CreateFlags createFlags = CreateFlags.None, params Type[] types);
@@ -712,7 +712,7 @@ namespace SQLite
 		/// <returns>
 		/// Whether the table was created or migrated for each type.
 		/// </returns>
-#if NET
+#if NET8_0_OR_GREATER
 		[RequiresUnreferencedCode ("This method requires 'DynamicallyAccessedMemberTypes.All' on each input 'Type' instance.")]
 #endif
 		public Task<CreateTablesResult> CreateTablesAsync (CreateFlags createFlags = CreateFlags.None, params Type[] types)

--- a/src/SQLiteAsync.cs
+++ b/src/SQLiteAsync.cs
@@ -23,6 +23,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Threading;
@@ -50,74 +51,247 @@ namespace SQLite
 		Task<int> CreateIndexAsync (string indexName, string tableName, string columnName, bool unique = false);
 		Task<int> CreateIndexAsync (string tableName, string[] columnNames, bool unique = false);
 		Task<int> CreateIndexAsync (string indexName, string tableName, string[] columnNames, bool unique = false);
-		Task<int> CreateIndexAsync<T> (Expression<Func<T, object>> property, bool unique = false);
-		Task<CreateTableResult> CreateTableAsync<T> (CreateFlags createFlags = CreateFlags.None) where T : new();
-		Task<CreateTableResult> CreateTableAsync (Type ty, CreateFlags createFlags = CreateFlags.None);
-		Task<CreateTablesResult> CreateTablesAsync<T, T2> (CreateFlags createFlags = CreateFlags.None)
+		Task<int> CreateIndexAsync<
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+#endif
+			T> (Expression<Func<T, object>> property, bool unique = false);
+		Task<CreateTableResult> CreateTableAsync<
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+#endif
+			T> (CreateFlags createFlags = CreateFlags.None) where T : new();
+		Task<CreateTableResult> CreateTableAsync (
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+#endif
+			Type ty,
+			CreateFlags createFlags = CreateFlags.None);
+		Task<CreateTablesResult> CreateTablesAsync<
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+#endif
+			T,
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+#endif
+			T2> (CreateFlags createFlags = CreateFlags.None)
 			where T : new()
 			where T2 : new();
-		Task<CreateTablesResult> CreateTablesAsync<T, T2, T3> (CreateFlags createFlags = CreateFlags.None)
+		Task<CreateTablesResult> CreateTablesAsync<
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+#endif
+			T,
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+#endif
+			T2,
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+#endif
+			T3> (CreateFlags createFlags = CreateFlags.None)
 			where T : new()
 			where T2 : new()
 			where T3 : new();
-		Task<CreateTablesResult> CreateTablesAsync<T, T2, T3, T4> (CreateFlags createFlags = CreateFlags.None)
+		Task<CreateTablesResult> CreateTablesAsync<
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+#endif
+			T,
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+#endif
+			T2,
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+#endif
+			T3,
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+#endif
+			T4> (CreateFlags createFlags = CreateFlags.None)
 			where T : new()
 			where T2 : new()
 			where T3 : new()
 			where T4 : new();
-		Task<CreateTablesResult> CreateTablesAsync<T, T2, T3, T4, T5> (CreateFlags createFlags = CreateFlags.None)
+		Task<CreateTablesResult> CreateTablesAsync<
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+#endif
+			T,
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+#endif
+			T2,
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+#endif
+			T3,
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+#endif
+			T4,
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+#endif
+			T5> (CreateFlags createFlags = CreateFlags.None)
 			where T : new()
 			where T2 : new()
 			where T3 : new()
 			where T4 : new()
 			where T5 : new();
+#if NET
+		[RequiresUnreferencedCode ("This method requires 'DynamicallyAccessedMemberTypes.All' on each input 'Type' instance.")]
+#endif
 		Task<CreateTablesResult> CreateTablesAsync (CreateFlags createFlags = CreateFlags.None, params Type[] types);
-		Task<IEnumerable<T>> DeferredQueryAsync<T> (string query, params object[] args) where T : new();
+		Task<IEnumerable<T>> DeferredQueryAsync<
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+#endif
+			T> (string query, params object[] args) where T : new();
 		Task<IEnumerable<object>> DeferredQueryAsync (TableMapping map, string query, params object[] args);
-		Task<int> DeleteAllAsync<T> ();
+		Task<int> DeleteAllAsync<
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+#endif
+			T> ();
 		Task<int> DeleteAllAsync (TableMapping map);
+#if NET8_0_OR_GREATER
+		[RequiresUnreferencedCode ("This method requires ''DynamicallyAccessedMemberTypes.All' on the runtime type of 'objectToDelete'.")]
+#endif
 		Task<int> DeleteAsync (object objectToDelete);
-		Task<int> DeleteAsync<T> (object primaryKey);
+		Task<int> DeleteAsync<
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+#endif
+			T> (object primaryKey);
 		Task<int> DeleteAsync (object primaryKey, TableMapping map);
-		Task<int> DropTableAsync<T> () where T : new();
+		Task<int> DropTableAsync<
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+#endif
+			T> () where T : new();
 		Task<int> DropTableAsync (TableMapping map);
 		Task EnableLoadExtensionAsync (bool enabled);
 		Task EnableWriteAheadLoggingAsync ();
 		Task<int> ExecuteAsync (string query, params object[] args);
 		Task<T> ExecuteScalarAsync<T> (string query, params object[] args);
-		Task<T> FindAsync<T> (object pk) where T : new();
+		Task<T> FindAsync<
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+#endif
+			T> (object pk) where T : new();
 		Task<object> FindAsync (object pk, TableMapping map);
-		Task<T> FindAsync<T> (Expression<Func<T, bool>> predicate) where T : new();
-		Task<T> FindWithQueryAsync<T> (string query, params object[] args) where T : new();
+		Task<T> FindAsync<
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+#endif
+			T> (Expression<Func<T, bool>> predicate) where T : new();
+		Task<T> FindWithQueryAsync<
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+#endif
+			T> (string query, params object[] args) where T : new();
 		Task<object> FindWithQueryAsync (TableMapping map, string query, params object[] args);
-		Task<T> GetAsync<T> (object pk) where T : new();
+		Task<T> GetAsync<
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+#endif
+			T> (object pk) where T : new();
 		Task<object> GetAsync (object pk, TableMapping map);
-		Task<T> GetAsync<T> (Expression<Func<T, bool>> predicate) where T : new();
+		Task<T> GetAsync<
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+#endif
+			T> (Expression<Func<T, bool>> predicate) where T : new();
 		TimeSpan GetBusyTimeout ();
 		SQLiteConnectionWithLock GetConnection ();
-		Task<TableMapping> GetMappingAsync (Type type, CreateFlags createFlags = CreateFlags.None);
-		Task<TableMapping> GetMappingAsync<T> (CreateFlags createFlags = CreateFlags.None) where T : new();
+		Task<TableMapping> GetMappingAsync (
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+#endif
+			Type type,
+			CreateFlags createFlags = CreateFlags.None);
+		Task<TableMapping> GetMappingAsync<
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+#endif
+			T> (CreateFlags createFlags = CreateFlags.None) where T : new();
 		Task<List<SQLiteConnection.ColumnInfo>> GetTableInfoAsync (string tableName);
+#if NET8_0_OR_GREATER
+		[RequiresUnreferencedCode ("This method requires ''DynamicallyAccessedMemberTypes.All' on the runtime type of all objects in 'objects'.")]
+#endif
 		Task<int> InsertAllAsync (IEnumerable objects, bool runInTransaction = true);
+#if NET8_0_OR_GREATER
+		[RequiresUnreferencedCode ("This method requires ''DynamicallyAccessedMemberTypes.All' on the runtime type of all objects in 'objects'.")]
+#endif
 		Task<int> InsertAllAsync (IEnumerable objects, string extra, bool runInTransaction = true);
+#if NET8_0_OR_GREATER
+		[RequiresUnreferencedCode ("This method requires ''DynamicallyAccessedMemberTypes.All' on the runtime type of all objects in 'objects'.")]
+#endif
 		Task<int> InsertAllAsync (IEnumerable objects, Type objType, bool runInTransaction = true);
+#if NET8_0_OR_GREATER
+		[RequiresUnreferencedCode ("This method requires ''DynamicallyAccessedMemberTypes.All' on the runtime type of 'obj'.")]
+#endif
 		Task<int> InsertAsync (object obj);
-		Task<int> InsertAsync (object obj, Type objType);
+		Task<int> InsertAsync (
+			object obj,
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+#endif
+			Type objType);
+#if NET8_0_OR_GREATER
+		[RequiresUnreferencedCode ("This method requires ''DynamicallyAccessedMemberTypes.All' on the runtime type of 'obj'.")]
+#endif
 		Task<int> InsertAsync (object obj, string extra);
-		Task<int> InsertAsync (object obj, string extra, Type objType);
+		Task<int> InsertAsync (
+			object obj,
+			string extra,
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+#endif
+			Type objType);
+#if NET8_0_OR_GREATER
+		[RequiresUnreferencedCode ("This method requires ''DynamicallyAccessedMemberTypes.All' on the runtime type of 'obj'.")]
+#endif
 		Task<int> InsertOrReplaceAsync (object obj);
-		Task<int> InsertOrReplaceAsync (object obj, Type objType);
-		Task<List<T>> QueryAsync<T> (string query, params object[] args) where T : new();
+		Task<int> InsertOrReplaceAsync (
+			object obj,
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+#endif
+			Type objType);
+		Task<List<T>> QueryAsync<
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+#endif
+			T> (string query, params object[] args) where T : new();
 		Task<List<object>> QueryAsync (TableMapping map, string query, params object[] args);
 		Task<List<T>> QueryScalarsAsync<T> (string query, params object[] args);
 		Task ReKeyAsync (string key);
 		Task ReKeyAsync (byte[] key);
 		Task RunInTransactionAsync (Action<SQLiteConnection> action);
 		Task SetBusyTimeoutAsync (TimeSpan value);
-		AsyncTableQuery<T> Table<T> () where T : new();
+		AsyncTableQuery<T> Table<
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+#endif
+			T> () where T : new();
+#if NET8_0_OR_GREATER
+		[RequiresUnreferencedCode ("This method requires ''DynamicallyAccessedMemberTypes.All' on the runtime type of all objects in 'objects'.")]
+#endif
 		Task<int> UpdateAllAsync (IEnumerable objects, bool runInTransaction = true);
+#if NET8_0_OR_GREATER
+		[RequiresUnreferencedCode ("This method requires ''DynamicallyAccessedMemberTypes.All' on the runtime type of 'obj'.")]
+#endif
 		Task<int> UpdateAsync (object obj);
-		Task<int> UpdateAsync (object obj, Type objType);
+		Task<int> UpdateAsync (
+			object obj,
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+#endif
+			Type objType);
 	}
 
 	/// <summary>
@@ -360,7 +534,11 @@ namespace SQLite
 		/// <returns>
 		/// Whether the table was created or migrated.
 		/// </returns>
-		public Task<CreateTableResult> CreateTableAsync<T> (CreateFlags createFlags = CreateFlags.None)
+		public Task<CreateTableResult> CreateTableAsync<
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+#endif
+			T> (CreateFlags createFlags = CreateFlags.None)
 			where T : new()
 		{
 			return WriteAsync (conn => conn.CreateTable<T> (createFlags));
@@ -377,7 +555,12 @@ namespace SQLite
 		/// <returns>
 		/// Whether the table was created or migrated.
 		/// </returns>
-		public Task<CreateTableResult> CreateTableAsync (Type ty, CreateFlags createFlags = CreateFlags.None)
+		public Task<CreateTableResult> CreateTableAsync (
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+#endif
+			Type ty,
+			CreateFlags createFlags = CreateFlags.None)
 		{
 			return WriteAsync (conn => conn.CreateTable (ty, createFlags));
 		}
@@ -391,7 +574,18 @@ namespace SQLite
 		/// <returns>
 		/// Whether the table was created or migrated for each type.
 		/// </returns>
-		public Task<CreateTablesResult> CreateTablesAsync<T, T2> (CreateFlags createFlags = CreateFlags.None)
+#if NET8_0_OR_GREATER
+		[UnconditionalSuppressMessage ("Trimming", "IL2026", Justification = "This method preserves metata for all type arguments.")]
+#endif
+		public Task<CreateTablesResult> CreateTablesAsync<
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+#endif
+			T,
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+#endif
+			T2> (CreateFlags createFlags = CreateFlags.None)
 			where T : new()
 			where T2 : new()
 		{
@@ -407,7 +601,22 @@ namespace SQLite
 		/// <returns>
 		/// Whether the table was created or migrated for each type.
 		/// </returns>
-		public Task<CreateTablesResult> CreateTablesAsync<T, T2, T3> (CreateFlags createFlags = CreateFlags.None)
+#if NET8_0_OR_GREATER
+		[UnconditionalSuppressMessage ("Trimming", "IL2026", Justification = "This method preserves metata for all type arguments.")]
+#endif
+		public Task<CreateTablesResult> CreateTablesAsync<
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+#endif
+			T,
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+#endif
+			T2,
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+#endif
+			T3> (CreateFlags createFlags = CreateFlags.None)
 			where T : new()
 			where T2 : new()
 			where T3 : new()
@@ -424,7 +633,26 @@ namespace SQLite
 		/// <returns>
 		/// Whether the table was created or migrated for each type.
 		/// </returns>
-		public Task<CreateTablesResult> CreateTablesAsync<T, T2, T3, T4> (CreateFlags createFlags = CreateFlags.None)
+#if NET8_0_OR_GREATER
+		[UnconditionalSuppressMessage ("Trimming", "IL2026", Justification = "This method preserves metata for all type arguments.")]
+#endif
+		public Task<CreateTablesResult> CreateTablesAsync<
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+#endif
+			T,
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+#endif
+			T2,
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+#endif
+			T3,
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+#endif
+			T4> (CreateFlags createFlags = CreateFlags.None)
 			where T : new()
 			where T2 : new()
 			where T3 : new()
@@ -442,7 +670,30 @@ namespace SQLite
 		/// <returns>
 		/// Whether the table was created or migrated for each type.
 		/// </returns>
-		public Task<CreateTablesResult> CreateTablesAsync<T, T2, T3, T4, T5> (CreateFlags createFlags = CreateFlags.None)
+#if NET8_0_OR_GREATER
+		[UnconditionalSuppressMessage ("Trimming", "IL2026", Justification = "This method preserves metata for all type arguments.")]
+#endif
+		public Task<CreateTablesResult> CreateTablesAsync<
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+#endif
+			T,
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+#endif
+			T2,
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+#endif
+			T3,
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+#endif
+			T4,
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+#endif
+			T5> (CreateFlags createFlags = CreateFlags.None)
 			where T : new()
 			where T2 : new()
 			where T3 : new()
@@ -461,6 +712,9 @@ namespace SQLite
 		/// <returns>
 		/// Whether the table was created or migrated for each type.
 		/// </returns>
+#if NET
+		[RequiresUnreferencedCode ("This method requires 'DynamicallyAccessedMemberTypes.All' on each input 'Type' instance.")]
+#endif
 		public Task<CreateTablesResult> CreateTablesAsync (CreateFlags createFlags = CreateFlags.None, params Type[] types)
 		{
 			return WriteAsync (conn => conn.CreateTables (createFlags, types));
@@ -469,7 +723,11 @@ namespace SQLite
 		/// <summary>
 		/// Executes a "drop table" on the database.  This is non-recoverable.
 		/// </summary>
-		public Task<int> DropTableAsync<T> ()
+		public Task<int> DropTableAsync<
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+#endif
+			T> ()
 			where T : new()
 		{
 			return WriteAsync (conn => conn.DropTable<T> ());
@@ -544,7 +802,11 @@ namespace SQLite
 		/// <param name="property">Property to index</param>
 		/// <param name="unique">Whether the index should be unique</param>
 		/// <returns>Zero on success.</returns>
-		public Task<int> CreateIndexAsync<T> (Expression<Func<T, object>> property, bool unique = false)
+		public Task<int> CreateIndexAsync<
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+#endif
+			T> (Expression<Func<T, object>> property, bool unique = false)
 		{
 			return WriteAsync (conn => conn.CreateIndex (property, unique));
 		}
@@ -559,6 +821,9 @@ namespace SQLite
 		/// <returns>
 		/// The number of rows added to the table.
 		/// </returns>
+#if NET8_0_OR_GREATER
+		[RequiresUnreferencedCode ("This method requires ''DynamicallyAccessedMemberTypes.All' on the runtime type of 'obj'.")]
+#endif
 		public Task<int> InsertAsync (object obj)
 		{
 			return WriteAsync (conn => conn.Insert (obj));
@@ -578,7 +843,12 @@ namespace SQLite
 		/// <returns>
 		/// The number of rows added to the table.
 		/// </returns>
-		public Task<int> InsertAsync (object obj, Type objType)
+		public Task<int> InsertAsync (
+			object obj,
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+#endif
+			Type objType)
 		{
 			return WriteAsync (conn => conn.Insert (obj, objType));
 		}
@@ -597,6 +867,9 @@ namespace SQLite
 		/// <returns>
 		/// The number of rows added to the table.
 		/// </returns>
+#if NET8_0_OR_GREATER
+		[RequiresUnreferencedCode ("This method requires ''DynamicallyAccessedMemberTypes.All' on the runtime type of 'obj'.")]
+#endif
 		public Task<int> InsertAsync (object obj, string extra)
 		{
 			return WriteAsync (conn => conn.Insert (obj, extra));
@@ -619,7 +892,13 @@ namespace SQLite
 		/// <returns>
 		/// The number of rows added to the table.
 		/// </returns>
-		public Task<int> InsertAsync (object obj, string extra, Type objType)
+		public Task<int> InsertAsync (
+			object obj,
+			string extra,
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+#endif
+			Type objType)
 		{
 			return WriteAsync (conn => conn.Insert (obj, extra, objType));
 		}
@@ -638,6 +917,9 @@ namespace SQLite
 		/// <returns>
 		/// The number of rows modified.
 		/// </returns>
+#if NET8_0_OR_GREATER
+		[RequiresUnreferencedCode ("This method requires ''DynamicallyAccessedMemberTypes.All' on the runtime type of 'obj'.")]
+#endif
 		public Task<int> InsertOrReplaceAsync (object obj)
 		{
 			return WriteAsync (conn => conn.InsertOrReplace (obj));
@@ -660,7 +942,12 @@ namespace SQLite
 		/// <returns>
 		/// The number of rows modified.
 		/// </returns>
-		public Task<int> InsertOrReplaceAsync (object obj, Type objType)
+		public Task<int> InsertOrReplaceAsync (
+			object obj,
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+#endif
+			Type objType)
 		{
 			return WriteAsync (conn => conn.InsertOrReplace (obj, objType));
 		}
@@ -676,6 +963,9 @@ namespace SQLite
 		/// <returns>
 		/// The number of rows updated.
 		/// </returns>
+#if NET8_0_OR_GREATER
+		[RequiresUnreferencedCode ("This method requires ''DynamicallyAccessedMemberTypes.All' on the runtime type of 'obj'.")]
+#endif
 		public Task<int> UpdateAsync (object obj)
 		{
 			return WriteAsync (conn => conn.Update (obj));
@@ -695,7 +985,12 @@ namespace SQLite
 		/// <returns>
 		/// The number of rows updated.
 		/// </returns>
-		public Task<int> UpdateAsync (object obj, Type objType)
+		public Task<int> UpdateAsync (
+			object obj,
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+#endif
+			Type objType)
 		{
 			return WriteAsync (conn => conn.Update (obj, objType));
 		}
@@ -712,6 +1007,9 @@ namespace SQLite
 		/// <returns>
 		/// The number of rows modified.
 		/// </returns>
+#if NET8_0_OR_GREATER
+		[RequiresUnreferencedCode ("This method requires ''DynamicallyAccessedMemberTypes.All' on the runtime type of all objects in 'objects'.")]
+#endif
 		public Task<int> UpdateAllAsync (IEnumerable objects, bool runInTransaction = true)
 		{
 			return WriteAsync (conn => conn.UpdateAll (objects, runInTransaction));
@@ -726,6 +1024,9 @@ namespace SQLite
 		/// <returns>
 		/// The number of rows deleted.
 		/// </returns>
+#if NET8_0_OR_GREATER
+		[RequiresUnreferencedCode ("This method requires ''DynamicallyAccessedMemberTypes.All' on the runtime type of 'objectToDelete'.")]
+#endif
 		public Task<int> DeleteAsync (object objectToDelete)
 		{
 			return WriteAsync (conn => conn.Delete (objectToDelete));
@@ -743,7 +1044,11 @@ namespace SQLite
 		/// <typeparam name='T'>
 		/// The type of object.
 		/// </typeparam>
-		public Task<int> DeleteAsync<T> (object primaryKey)
+		public Task<int> DeleteAsync<
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+#endif
+			T> (object primaryKey)
 		{
 			return WriteAsync (conn => conn.Delete<T> (primaryKey));
 		}
@@ -776,7 +1081,11 @@ namespace SQLite
 		/// <typeparam name='T'>
 		/// The type of objects to delete.
 		/// </typeparam>
-		public Task<int> DeleteAllAsync<T> ()
+		public Task<int> DeleteAllAsync<
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+#endif
+			T> ()
 		{
 			return WriteAsync (conn => conn.DeleteAll<T> ());
 		}
@@ -822,7 +1131,11 @@ namespace SQLite
 		/// The object with the given primary key. Throws a not found exception
 		/// if the object is not found.
 		/// </returns>
-		public Task<T> GetAsync<T> (object pk)
+		public Task<T> GetAsync<
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+#endif
+			T> (object pk)
 			where T : new()
 		{
 			return ReadAsync (conn => conn.Get<T> (pk));
@@ -859,7 +1172,11 @@ namespace SQLite
 		/// The object that matches the given predicate. Throws a not found exception
 		/// if the object is not found.
 		/// </returns>
-		public Task<T> GetAsync<T> (Expression<Func<T, bool>> predicate)
+		public Task<T> GetAsync<
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+# endif
+			T> (Expression<Func<T, bool>> predicate)
 			where T : new()
 		{
 			return ReadAsync (conn => conn.Get<T> (predicate));
@@ -877,7 +1194,11 @@ namespace SQLite
 		/// The object with the given primary key or null
 		/// if the object is not found.
 		/// </returns>
-		public Task<T> FindAsync<T> (object pk)
+		public Task<T> FindAsync<
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+#endif
+			T> (object pk)
 			where T : new()
 		{
 			return ReadAsync (conn => conn.Find<T> (pk));
@@ -914,7 +1235,11 @@ namespace SQLite
 		/// The object that matches the given predicate or null
 		/// if the object is not found.
 		/// </returns>
-		public Task<T> FindAsync<T> (Expression<Func<T, bool>> predicate)
+		public Task<T> FindAsync<
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+#endif
+			T> (Expression<Func<T, bool>> predicate)
 			where T : new()
 		{
 			return ReadAsync (conn => conn.Find<T> (predicate));
@@ -934,7 +1259,11 @@ namespace SQLite
 		/// The object that matches the given predicate or null
 		/// if the object is not found.
 		/// </returns>
-		public Task<T> FindWithQueryAsync<T> (string query, params object[] args)
+		public Task<T> FindWithQueryAsync<
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+#endif
+			T> (string query, params object[] args)
 			where T : new()
 		{
 			return ReadAsync (conn => conn.FindWithQuery<T> (query, args));
@@ -975,7 +1304,12 @@ namespace SQLite
 		/// The mapping represents the schema of the columns of the database and contains 
 		/// methods to set and get properties of objects.
 		/// </returns>
-		public Task<TableMapping> GetMappingAsync (Type type, CreateFlags createFlags = CreateFlags.None)
+		public Task<TableMapping> GetMappingAsync (
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+#endif
+			Type type,
+			CreateFlags createFlags = CreateFlags.None)
 		{
 			return ReadAsync (conn => conn.GetMapping (type, createFlags));
 		}
@@ -990,7 +1324,11 @@ namespace SQLite
 		/// The mapping represents the schema of the columns of the database and contains 
 		/// methods to set and get properties of objects.
 		/// </returns>
-		public Task<TableMapping> GetMappingAsync<T> (CreateFlags createFlags = CreateFlags.None)
+		public Task<TableMapping> GetMappingAsync<
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+#endif
+			T> (CreateFlags createFlags = CreateFlags.None)
 			where T : new()
 		{
 			return ReadAsync (conn => conn.GetMapping<T> (createFlags));
@@ -1039,6 +1377,9 @@ namespace SQLite
 		/// <returns>
 		/// The number of rows added to the table.
 		/// </returns>
+#if NET8_0_OR_GREATER
+		[RequiresUnreferencedCode ("This method requires ''DynamicallyAccessedMemberTypes.All' on the runtime type of all objects in 'objects'.")]
+#endif
 		public Task<int> InsertAllAsync (IEnumerable objects, bool runInTransaction = true)
 		{
 			return WriteAsync (conn => conn.InsertAll (objects, runInTransaction));
@@ -1059,6 +1400,9 @@ namespace SQLite
 		/// <returns>
 		/// The number of rows added to the table.
 		/// </returns>
+#if NET8_0_OR_GREATER
+		[RequiresUnreferencedCode ("This method requires ''DynamicallyAccessedMemberTypes.All' on the runtime type of all objects in 'objects'.")]
+#endif
 		public Task<int> InsertAllAsync (IEnumerable objects, string extra, bool runInTransaction = true)
 		{
 			return WriteAsync (conn => conn.InsertAll (objects, extra, runInTransaction));
@@ -1079,6 +1423,9 @@ namespace SQLite
 		/// <returns>
 		/// The number of rows added to the table.
 		/// </returns>
+#if NET8_0_OR_GREATER
+		[RequiresUnreferencedCode ("This method requires ''DynamicallyAccessedMemberTypes.All' on the runtime type of all objects in 'objects'.")]
+#endif
 		public Task<int> InsertAllAsync (IEnumerable objects, Type objType, bool runInTransaction = true)
 		{
 			return WriteAsync (conn => conn.InsertAll (objects, objType, runInTransaction));
@@ -1117,7 +1464,11 @@ namespace SQLite
 		/// A queryable object that is able to translate Where, OrderBy, and Take
 		/// queries into native SQL.
 		/// </returns>
-		public AsyncTableQuery<T> Table<T> ()
+		public AsyncTableQuery<T> Table<
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+#endif
+			T> ()
 			where T : new()
 		{
 			//
@@ -1167,7 +1518,11 @@ namespace SQLite
 		/// <returns>
 		/// A list with one result for each row returned by the query.
 		/// </returns>
-		public Task<List<T>> QueryAsync<T> (string query, params object[] args)
+		public Task<List<T>> QueryAsync<
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+#endif
+			T> (string query, params object[] args)
 			where T : new()
 		{
 			return ReadAsync (conn => conn.Query<T> (query, args));
@@ -1234,7 +1589,11 @@ namespace SQLite
 		/// The enumerator will call sqlite3_step on each call to MoveNext, so the database
 		/// connection must remain open for the lifetime of the enumerator.
 		/// </returns>
-		public Task<IEnumerable<T>> DeferredQueryAsync<T> (string query, params object[] args)
+		public Task<IEnumerable<T>> DeferredQueryAsync<
+#if NET8_0_OR_GREATER
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+#endif
+			T> (string query, params object[] args)
 			where T : new()
 		{
 			return ReadAsync (conn => (IEnumerable<T>)conn.DeferredQuery<T> (query, args).ToList ());
@@ -1295,7 +1654,11 @@ namespace SQLite
 	/// <summary>
 	/// Query to an asynchronous database connection.
 	/// </summary>
-	public class AsyncTableQuery<T>
+	public class AsyncTableQuery<
+#if NET8_0_OR_GREATER
+		[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+#endif
+	T>
 		where T : new()
 	{
 		TableQuery<T> _innerQuery;

--- a/src/SQLiteAsync.cs
+++ b/src/SQLiteAsync.cs
@@ -575,7 +575,7 @@ namespace SQLite
 		/// Whether the table was created or migrated for each type.
 		/// </returns>
 #if NET8_0_OR_GREATER
-		[UnconditionalSuppressMessage ("Trimming", "IL2026", Justification = "This method preserves metata for all type arguments.")]
+		[UnconditionalSuppressMessage ("Trimming", "IL2026", Justification = "This method preserves metadata for all type arguments.")]
 #endif
 		public Task<CreateTablesResult> CreateTablesAsync<
 #if NET8_0_OR_GREATER
@@ -602,7 +602,7 @@ namespace SQLite
 		/// Whether the table was created or migrated for each type.
 		/// </returns>
 #if NET8_0_OR_GREATER
-		[UnconditionalSuppressMessage ("Trimming", "IL2026", Justification = "This method preserves metata for all type arguments.")]
+		[UnconditionalSuppressMessage ("Trimming", "IL2026", Justification = "This method preserves metadata for all type arguments.")]
 #endif
 		public Task<CreateTablesResult> CreateTablesAsync<
 #if NET8_0_OR_GREATER
@@ -634,7 +634,7 @@ namespace SQLite
 		/// Whether the table was created or migrated for each type.
 		/// </returns>
 #if NET8_0_OR_GREATER
-		[UnconditionalSuppressMessage ("Trimming", "IL2026", Justification = "This method preserves metata for all type arguments.")]
+		[UnconditionalSuppressMessage ("Trimming", "IL2026", Justification = "This method preserves metadata for all type arguments.")]
 #endif
 		public Task<CreateTablesResult> CreateTablesAsync<
 #if NET8_0_OR_GREATER
@@ -671,7 +671,7 @@ namespace SQLite
 		/// Whether the table was created or migrated for each type.
 		/// </returns>
 #if NET8_0_OR_GREATER
-		[UnconditionalSuppressMessage ("Trimming", "IL2026", Justification = "This method preserves metata for all type arguments.")]
+		[UnconditionalSuppressMessage ("Trimming", "IL2026", Justification = "This method preserves metadata for all type arguments.")]
 #endif
 		public Task<CreateTablesResult> CreateTablesAsync<
 #if NET8_0_OR_GREATER


### PR DESCRIPTION
### Closes #1218

This PR adds all trimming and AOT annotations to the code to make the codebase trim/AOT-safe. There's no functional changes introduced in this PR, other than removing the fast column accessor for all value types on NAOT, as that would otherwise throw (and generally just be unsupported code due to the AOT warning we'd have to suppress otherwise). It should still work, just take the slower reflection-based fallback path in that case. In order to allow all annotations to correctly flow to consumers, all projects have also been switched to multi-targeting, with the .NET 8 TFM being added as well.