### PR TITLE
Fix support for struct in query results by disabling fast column setters

### DIFF
--- a/src/SQLite.cs
+++ b/src/SQLite.cs
@@ -3143,10 +3143,11 @@ namespace SQLite
 								BindingFlags.NonPublic | BindingFlags.Static).MakeGenericMethod (map.MappedType);
 					}
 
+					var canUseFastColumnSetter = !typeof(T).IsValueType;
 					for (int i = 0; i < cols.Length; i++) {						
 						var name = SQLite3.ColumnName16 (stmt, i);
 						cols[i] = map.FindColumn (name);
-						if (cols[i] != null)
+						if (canUseFastColumnSetter && cols[i] != null)
 							if (getSetter != null) {
 								fastColumnSetters[i] = (Action<object, Sqlite3Statement, int>)getSetter.Invoke(null, new object[]{ _conn, cols[i]});
 							}


### PR DESCRIPTION
Using struct types as query return raises `ArgumentException` on `FastColumnSetter` code because property setter delegates for structs should use `ref ObjectType` for its first parameter (#1075). This PR disables the usage of fast column setters for value types, fixing support for queries with struct returns.