### PR TITLE
Replace <LicenseFile> with <LicenseExpression>

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,7 +7,7 @@
         <PackageProjectUrl>https://github.com/praeclarum/sqlite-net</PackageProjectUrl>
         <RepositoryUrl>https://github.com/praeclarum/sqlite-net.git</RepositoryUrl>
         <PackageTags>sqlite-net;sqlite;database;orm</PackageTags>
-        <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
+        <PackageLicenseExpression>MIT</PackageLicenseExpression>
 
         <Company>Krueger Systems, Inc.</Company>
 


### PR DESCRIPTION
Nuget effectively allows only one of the two, but using the expression had two advantages:

1. It is a tad easier to extract by tooling, because you need not query the github API for a possibly outdated license file.
2. It is recommended practice by Microsoft for standard licenses https://learn.microsoft.com/en-us/nuget/reference/nuspec#license




This is far from the most urgent improvement.  I just thought before I add a line in our internal tooling, I might in parallel spend a miniscule amount of time giving something back.