### PR TITLE
Added support for loading extensions (e.g. mod_spatialite)

### DIFF
--- a/src/SQLite.cs
+++ b/src/SQLite.cs
@@ -706,6 +706,28 @@ namespace SQLite
 				throw SQLiteException.New (r, msg);
 			}
 		}
+		
+		/// <summary>
+		/// Load extension.
+		/// </summary>
+		public void LoadExtension (string filename)
+		{
+			SQLite3.Result r = SQLite3.LoadExtension (Handle, filename, null, out var msg);
+			if (r != SQLite3.Result.OK) {
+				throw SQLiteException.New (r, msg);
+			}
+		}
+
+		/// <summary>
+		/// Load extension.
+		/// </summary>
+		public void LoadExtension (string filename, string customInitFunctionName)
+		{
+			SQLite3.Result r = SQLite3.LoadExtension (Handle, filename, customInitFunctionName, out var msg);
+			if (r != SQLite3.Result.OK) {
+				throw SQLiteException.New (r, msg);
+			}
+		}
 
 #if !USE_SQLITEPCL_RAW
 		static byte[] GetNullTerminatedUtf8 (string s)
@@ -5050,6 +5072,9 @@ namespace SQLite
 		[DllImport(LibraryPath, EntryPoint = "sqlite3_enable_load_extension", CallingConvention=CallingConvention.Cdecl)]
 		public static extern Result EnableLoadExtension (IntPtr db, int onoff);
 
+		[DllImport (LibraryPath, EntryPoint = "sqlite3_load_extension", CallingConvention = CallingConvention.Cdecl)]
+		public static extern Result LoadExtension (IntPtr db, [MarshalAs (UnmanagedType.LPStr)] string filename, [MarshalAs (UnmanagedType.LPStr)] string initFunctionName, [MarshalAs(UnmanagedType.LPStr)] out string errorMsg);
+
 		[DllImport(LibraryPath, EntryPoint = "sqlite3_close", CallingConvention=CallingConvention.Cdecl)]
 		public static extern Result Close (IntPtr db);
 
@@ -5400,6 +5425,16 @@ namespace SQLite
 		public static Result EnableLoadExtension (Sqlite3DatabaseHandle db, int onoff)
 		{
 			return (Result)Sqlite3.sqlite3_enable_load_extension (db, onoff);
+		}
+		
+		public static Result LoadExtension (Sqlite3DatabaseHandle db, string fileName, string initFunctionName, out string errorMessage)
+		{
+			var result = (Result)Sqlite3.sqlite3_load_extension (db, SQLitePCL.utf8z.FromString (fileName),
+				SQLitePCL.utf8z.FromString (initFunctionName), out SQLitePCL.utf8z pzErrMsg);
+
+			errorMessage = pzErrMsg.utf8_to_string ();
+
+			return result;
 		}
 
 		public static int LibVersionNumber ()

--- a/tests/SQLite.Tests/SQLite.Tests.csproj
+++ b/tests/SQLite.Tests/SQLite.Tests.csproj
@@ -12,7 +12,16 @@
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.16.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+    <PackageReference Include="SourceGear.sqlite3" Version="3.50.3" />
+    <PackageReference Include="SQLitePCLRaw.config.e_sqlite3" Version="3.0.1" />
   </ItemGroup>
+
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DefineConstants>USE_SQLITEPCL_RAW;RELEASE</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DefineConstants>USE_SQLITEPCL_RAW;DEBUG</DefineConstants>
+  </PropertyGroup>
 
   <ItemGroup>
     <Compile Include="..\..\src\SQLite.cs">


### PR DESCRIPTION
@ericsink no need to merge this.
You are welcome to just "copy and enhance the code"

But since you are already at migrating to *raw 3.x.x, could you please, please be so kind and also support extension loading?

E.g. we need spatialite to run geospatial queries in our SQLite database
<img width="1163" height="781" alt="image" src="https://github.com/user-attachments/assets/9027d78d-3a0f-41e6-87f6-18c458e19d4a" />
