### PR TITLE
#82 - Added support for dynamic query result types (dictionary<string,object>)

### DIFF
--- a/src/SQLite.cs
+++ b/src/SQLite.cs
@@ -1411,7 +1411,7 @@ namespace SQLite
 			var cmd = CreateCommand (query, args);
 			return cmd.ExecuteQuery<T> ();
 		}
-
+		
 		/// <summary>
 		/// Creates a SQLiteCommand given the command text (SQL) with arguments. Place a '?'
 		/// in the command text for each of the arguments and then executes that command.
@@ -1458,6 +1458,49 @@ namespace SQLite
 		{
 			var cmd = CreateCommand (query, args);
 			return cmd.ExecuteDeferredQuery<T> ();
+		}
+
+
+		/// <summary>
+		/// Creates a SQLiteCommand given the command text (SQL) with arguments. Place a '?'
+		/// in the command text for each of the arguments and then executes that command.
+		/// It returns each row of the result a dictionary
+		/// </summary>
+		/// <param name="query">
+		/// The fully escaped SQL.
+		/// </param>
+		/// <param name="args">
+		/// Arguments to substitute for the occurences of '?' in the query.
+		/// </param>
+		/// <returns>
+		/// An enumerable with one result for each row returned by the query as dictionary
+		/// </returns>
+		public List<Dictionary<string, object>> Query(string query, params object[] args)
+		{
+			var cmd = CreateCommand(query, args);
+			return cmd.ExecuteDeferredQuery().ToList();
+		}
+
+
+		/// <summary>
+		/// Creates a SQLiteCommand given the command text (SQL) with arguments. Place a '?'
+		/// in the command text for each of the arguments and then executes that command.
+		/// It returns each row of the result a dictionary
+		/// </summary>
+		/// <param name="query">
+		/// The fully escaped SQL.
+		/// </param>
+		/// <param name="args">
+		/// Arguments to substitute for the occurences of '?' in the query.
+		/// </param>
+		/// <returns>
+		/// An enumerable with one result for each row returned by the query as dictionary
+		/// </returns>
+		public IEnumerable<Dictionary<string, object>> ExecuteDeferredQuery(string query, params object[] args)
+		{
+			var cmd = CreateCommand(query, args);
+			return cmd.ExecuteDeferredQuery();
+
 		}
 
 		/// <summary>
@@ -3606,6 +3649,61 @@ namespace SQLite
 			}
 			finally {
 				SQLite3.Finalize (stmt);
+			}
+		}
+
+		public IEnumerable<Dictionary<string, object>> ExecuteDeferredQuery()
+		{
+			if (_conn.Trace)
+			{
+				Debug.WriteLine("Executing Query: " + this);
+			}
+
+			var stmt = Prepare();
+			try
+			{
+				var cols = new string[SQLite3.ColumnCount(stmt)];
+
+				for (int i = 0; i < cols.Length; i++)
+				{
+					var name = SQLite3.ColumnName16(stmt, i);
+					cols[i] = name;
+				}
+
+				while (SQLite3.Step(stmt) == SQLite3.Result.Row)
+				{
+					var obj = new Dictionary<string, object>();
+					for (int i = 0; i < cols.Length; i++)
+					{
+						var colType = SQLite3.ColumnType(stmt, i);
+
+						Type targetType;
+						switch (colType)
+						{
+							case SQLite3.ColType.Text:
+								targetType = typeof(string);
+								break;
+							case SQLite3.ColType.Integer:
+								targetType = typeof(int);
+								break;
+							case SQLite3.ColType.Float:
+								targetType = typeof(double);
+								break;
+							default:
+								targetType = typeof(object);
+								break;
+						}
+
+						var val = ReadCol(stmt, i, colType, targetType);
+						obj.Add(cols[i], val);
+					}
+					OnInstanceCreated(obj);
+					yield return obj;
+				}
+			}
+			finally
+			{
+				SQLite3.Finalize(stmt);
 			}
 		}
 

--- a/tests/SQLite.Tests/QueryTest.cs
+++ b/tests/SQLite.Tests/QueryTest.cs
@@ -50,6 +50,24 @@ namespace SQLite.Tests
 			Assert.AreEqual (_records[0].Walue, r[0].Walue);
 		}
 
+
+		[Test]
+		public void QueryGenericObjectAsDictionary ()
+		{
+			var path = Path.GetTempFileName ();
+			var db = new SQLiteConnection (path, true);
+
+			db.Execute ("create table G(Value integer not null)");
+			db.Execute ("insert into G(Value) values (?)", 42);
+			db.Execute ("insert into G(Value) values (?)", 43);
+			db.Execute ("insert into G(Value) values (?)", 44);
+			var r = db.Query ("select * from G where value > ?", 42);
+
+			Assert.AreEqual (2, r.Count);
+			Assert.AreEqual (43, r[0]["Value"]);
+			Assert.AreEqual (44, r[1]["Value"]);
+		}
+
 		#region Issue #1007
 
 		[Test]


### PR DESCRIPTION
Allows to run dynamically created queries at runtime and just get the results as a `Dictionary<string,object>`

We've been using this for years now, so I hope it finally makes its way into the codebase 😅