### PR TITLE
Add FullTextTable class attribute &  FullTextIndexed property attribute for easy FTS indexing

### DIFF
--- a/src/SQLite.cs
+++ b/src/SQLite.cs
@@ -836,10 +836,6 @@ namespace SQLite
 			var count = 0;
 
 			if (map.FullTextTableName != null && map.FullTextColumns.Length > 0) {
-				// Drop full text index before content table
-				var queryFullText = string.Format ("DROP TABLE IF EXISTS \"{0}\"", map.FullTextTableName);
-				count += Execute (queryFullText);
-
 				// Drop full text index triggers
 				var queryFullTextTriggerBeforeUpdate = string.Format ("DROP TRIGGER IF EXISTS \"{0}_t_bu\"", map.FullTextTableName);
 				count += Execute (queryFullTextTriggerBeforeUpdate);
@@ -852,6 +848,10 @@ namespace SQLite
 
 				var queryFullTextTriggerAfterInsert = string.Format ("DROP TRIGGER IF EXISTS \"{0}_t_ai\"", map.FullTextTableName);
 				count += Execute (queryFullTextTriggerAfterInsert);
+
+				// Drop full text index before content table
+				var queryFullText = string.Format("DROP TABLE IF EXISTS \"{0}\"", map.FullTextTableName);
+				count += Execute(queryFullText);
 			}
 
 			var query = string.Format ("drop table if exists \"{0}\"", map.TableName);
@@ -970,7 +970,42 @@ namespace SQLite
 					throw new Exception ("Must have at least one full text index column to specify a full text index for the table");
 				}
 
+				// Check if the columns have changed since it was created
 				var fullTextColsNames = map.FullTextColumns.Select (c => c.Name);
+				var existingFtsColumns = GetTableInfo (map.FullTextTableName);
+				
+				bool needsRecreate = false;
+				if (existingFtsColumns.Count > 0) {
+					// FTS4 table exists - check if columns match
+					// Note: FTS4 tables have hidden columns (docid, plus internal columns), so we filter those out
+					var actualColumns = existingFtsColumns
+						.Where (c => !c.Name.StartsWith ("c") || c.Name.Length > 2) // Filter out internal FTS columns like c0, c1, etc.
+						.Where (c => c.Name != "docid") // Filter out docid
+						.Select (c => c.Name)
+						.OrderBy (n => n)
+						.ToList ();
+					
+					var expectedColumns = fullTextColsNames.OrderBy (n => n).ToList ();
+					
+					// Check if column lists match
+					if (actualColumns.Count != expectedColumns.Count || 
+					    !actualColumns.SequenceEqual (expectedColumns)) {
+						needsRecreate = true;
+					}
+				}
+				
+				if (needsRecreate) {
+					// Drop triggers
+					Execute ("DROP TRIGGER IF EXISTS \"" + map.FullTextTableName + "_t_bu\"");
+					Execute ("DROP TRIGGER IF EXISTS \"" + map.FullTextTableName + "_t_bd\"");
+					Execute ("DROP TRIGGER IF EXISTS \"" + map.FullTextTableName + "_t_au\"");
+					Execute ("DROP TRIGGER IF EXISTS \"" + map.FullTextTableName + "_t_ai\"");
+
+					// Drop and recreate the FTS table and triggers since columns changed
+					var dropFullText = "DROP TABLE IF EXISTS \"" + map.FullTextTableName + "\"";
+					Execute (dropFullText);					
+				}
+
 				// Only support FTS4 because content= options to link an FTS table to external tables is not supported in FTS3
 				var queryFullText = "CREATE VIRTUAL TABLE IF NOT EXISTS \"" + map.FullTextTableName + "\" USING fts4(content=\"" + map.TableName + "\", ";
 				queryFullText += string.Join (",\n", fullTextColsNames.ToArray ());
@@ -978,6 +1013,13 @@ namespace SQLite
 				queryFullText += ")";
 
 				Execute (queryFullText);
+
+				if (needsRecreate)
+				{
+					// Now actually rebuild the full text index data
+					var queryRebuild = "INSERT INTO \"" + map.FullTextTableName + "\"(\"" + map.FullTextTableName + "\") VALUES('rebuild');";
+					Execute(queryRebuild);
+				}
 
 				// Create triggers to keep full text index in sync with content table
 				var deleteOldSql = "DELETE FROM \"" + map.FullTextTableName + "\" WHERE docid=old." + map.PK.Name + ";";

--- a/src/SQLite.cs
+++ b/src/SQLite.cs
@@ -833,8 +833,31 @@ namespace SQLite
 		/// </param>
 		public int DropTable (TableMapping map)
 		{
+			var count = 0;
+
+			if (map.FullTextTableName != null && map.FullTextColumns.Length > 0) {
+				// Drop full text index before content table
+				var queryFullText = string.Format ("DROP TABLE IF EXISTS \"{0}\"", map.FullTextTableName);
+				count += Execute (queryFullText);
+
+				// Drop full text index triggers
+				var queryFullTextTriggerBeforeUpdate = string.Format ("DROP TRIGGER IF EXISTS \"{0}_t_bu\"", map.FullTextTableName);
+				count += Execute (queryFullTextTriggerBeforeUpdate);
+
+				var queryFullTextTriggerBeforeDelete = string.Format ("DROP TRIGGER IF EXISTS \"{0}_t_bd\"", map.FullTextTableName);
+				count += Execute (queryFullTextTriggerBeforeDelete);
+
+				var queryFullTextTriggerAfterUpdate = string.Format ("DROP TRIGGER IF EXISTS \"{0}_t_au\"", map.FullTextTableName);
+				count += Execute (queryFullTextTriggerAfterUpdate);
+
+				var queryFullTextTriggerAfterInsert = string.Format ("DROP TRIGGER IF EXISTS \"{0}_t_ai\"", map.FullTextTableName);
+				count += Execute (queryFullTextTriggerAfterInsert);
+			}
+
 			var query = string.Format ("drop table if exists \"{0}\"", map.TableName);
-			return Execute (query);
+			count += Execute (query);
+
+			return count;
 		}
 
 		/// <summary>
@@ -939,6 +962,39 @@ namespace SQLite
 				var index = indexes[indexName];
 				var columns = index.Columns.OrderBy (i => i.Order).Select (i => i.ColumnName).ToArray ();
 				CreateIndex (indexName, index.TableName, columns, index.Unique);
+			}
+
+			// Create full text indexes
+			if (map.FullTextTableName != null) {
+				if (map.FullTextColumns.Length == 0) {
+					throw new Exception ("Must have at least one full text index column to specify a full text index for the table");
+				}
+
+				var fullTextColsNames = map.FullTextColumns.Select (c => c.Name);
+				// Only support FTS4 because content= options to link an FTS table to external tables is not supported in FTS3
+				var queryFullText = "CREATE VIRTUAL TABLE IF NOT EXISTS \"" + map.FullTextTableName + "\" USING fts4(content=\"" + map.TableName + "\", ";
+				queryFullText += string.Join (",\n", fullTextColsNames.ToArray ());
+				queryFullText += ", tokenize=" + map.FullTextTableTokenizer;
+				queryFullText += ")";
+
+				Execute (queryFullText);
+
+				// Create triggers to keep full text index in sync with content table
+				var deleteOldSql = "DELETE FROM \"" + map.FullTextTableName + "\" WHERE docid=old." + map.PK.Name + ";";
+				var insertNewSql = "INSERT INTO \"" + map.FullTextTableName + "\"(docid, " + string.Join (", ", fullTextColsNames);
+				insertNewSql += ") VALUES (new." + map.PK.Name + ", new." + string.Join (", new.", fullTextColsNames) + ");";
+
+				var beforeUpdateSql = "CREATE TRIGGER IF NOT EXISTS \"" + map.FullTextTableName + "_t_bu\" BEFORE UPDATE ON \"" + map.TableName + "\" BEGIN\n" + deleteOldSql + "\nEND;";
+				Execute (beforeUpdateSql);
+
+				var beforeDeleteSql = "CREATE TRIGGER IF NOT EXISTS \"" + map.FullTextTableName + "_t_bd\" BEFORE DELETE ON \"" + map.TableName + "\" BEGIN\n" + deleteOldSql + "\nEND;";
+				Execute (beforeDeleteSql);
+
+				var afterUpdateSql = "CREATE TRIGGER IF NOT EXISTS \"" + map.FullTextTableName + "_t_au\" AFTER UPDATE ON \"" + map.TableName + "\" BEGIN\n" + insertNewSql + "\nEND;";
+				Execute (afterUpdateSql);
+
+				var afterInsertSql = "CREATE TRIGGER IF NOT EXISTS \"" + map.FullTextTableName + "_t_ai\" AFTER INSERT ON \"" + map.TableName + "\" BEGIN\n" + insertNewSql + "\nEND;";
+				Execute (afterInsertSql);
 			}
 
 			return result;
@@ -2917,6 +2973,45 @@ namespace SQLite
 	{
 	}
 
+	public enum FullTextSearchModule
+	{
+		FullTextSearch3 = 0,
+		FullTextSearch4 = 1
+	}
+
+	/// <summary>
+	/// Attribute to specify a full-text search table created from a subset of the 
+	/// table columns. Name is the name of the FTS table, and Tokenizer is the tokenizer
+	/// to use, which can be one of the built-in tokenizers: "simple", "porter", "unicode61", or (possibly) "icu".
+	/// </summary>
+	[AttributeUsage (AttributeTargets.Class)]
+	public class FullTextTableAttribute : Attribute
+	{
+		public string Name { get; set; }
+		public string Tokenizer { get; set; }
+		public FullTextSearchModule Module { get; set; } = FullTextSearchModule.FullTextSearch4;
+
+		public FullTextTableAttribute ()
+		{
+		}
+
+		public FullTextTableAttribute (string name)
+		{
+			Name = name;
+		}
+
+		public FullTextTableAttribute (string name, string tokenizer)
+		{
+			Name = name;
+			Tokenizer = tokenizer;
+		}
+	}
+
+	[AttributeUsage (AttributeTargets.Property)]
+	public class FullTextIndexedAttribute : Attribute
+	{
+	}
+
 	public class TableMapping
 	{
 #if NET8_0_OR_GREATER
@@ -2934,6 +3029,10 @@ namespace SQLite
 
 		public string GetByPrimaryKeySql { get; private set; }
 
+		public string FullTextTableName { get; private set; }
+
+		public string FullTextTableTokenizer { get; private set; }
+
 		public CreateFlags CreateFlags { get; private set; }
 
 		internal MapMethod Method { get; private set; } = MapMethod.ByName;
@@ -2941,6 +3040,7 @@ namespace SQLite
 		readonly Column _autoPk;
 		readonly Column[] _insertColumns;
 		readonly Column[] _insertOrReplaceColumns;
+		Column[] _fullTextColumns;
 
 		public TableMapping (
 #if NET8_0_OR_GREATER
@@ -2968,6 +3068,23 @@ namespace SQLite
 
 			TableName = (tableAttr != null && !string.IsNullOrEmpty (tableAttr.Name)) ? tableAttr.Name : MappedType.Name;
 			WithoutRowId = tableAttr != null ? tableAttr.WithoutRowId : false;
+
+#if ENABLE_IL2CPP
+			var fullTextTableAttr = typeInfo.GetCustomAttribute<FullTextTableAttribute> ();
+#elif NET8_0_OR_GREATER
+			var fullTextTableAttr = type.GetCustomAttributes<FullTextTableAttribute> ().FirstOrDefault ();
+#else
+			var fullTextTableAttr =
+				typeInfo.CustomAttributes
+						.Where (x => x.AttributeType == typeof (FullTextTableAttribute))
+						.Select (x => (FullTextTableAttribute)Orm.InflateAttribute (x))
+						.FirstOrDefault ();
+#endif
+
+			if (fullTextTableAttr != null) {
+				FullTextTableName = fullTextTableAttr.Name != null ? fullTextTableAttr.Name : MappedType.Name + "_FT";
+				FullTextTableTokenizer = fullTextTableAttr.Tokenizer != null ? fullTextTableAttr.Tokenizer : "unicode61"; // The default "simple" tokenizer only supports ASCII so default to "unicode61" instead
+			}
 
 			var members = GetPublicMembers(type);
 			var cols = new List<Column>(members.Count);
@@ -3075,6 +3192,15 @@ namespace SQLite
 			}
 		}
 
+		public Column[] FullTextColumns {
+			get {
+				if (_fullTextColumns == null) {
+					_fullTextColumns = Columns.Where (c => c.IsInFullTextIndex).ToArray ();
+				}
+				return _fullTextColumns;
+			}
+		}
+
 		public Column FindColumnWithPropertyName (string propertyName)
 		{
 			var exact = Columns.FirstOrDefault (c => c.PropertyName == propertyName);
@@ -3110,6 +3236,8 @@ namespace SQLite
 			public bool IsPK { get; private set; }
 
 			public IEnumerable<IndexedAttribute> Indices { get; set; }
+
+			public bool IsInFullTextIndex { get; private set; }
 
 			public bool IsNullable { get; private set; }
 
@@ -3151,6 +3279,7 @@ namespace SQLite
 					) {
 					Indices = new IndexedAttribute[] { new IndexedAttribute () };
 				}
+				IsInFullTextIndex = Orm.IsInFullTextIndex (member);
 				IsNullable = !(IsPK || Orm.IsMarkedNotNull (member));
 				MaxStringLength = Orm.MaxStringLength (member);
 
@@ -3453,6 +3582,11 @@ namespace SQLite
 		public static bool IsMarkedNotNull (MemberInfo p)
 		{
 			return p.CustomAttributes.Any (x => x.AttributeType == typeof (NotNullAttribute));
+		}
+
+		public static bool IsInFullTextIndex (MemberInfo p)
+		{
+			return p.CustomAttributes.Any (x => x.AttributeType == typeof (FullTextIndexedAttribute));
 		}
 	}
 

--- a/tests/SQLite.Tests/FullTextSearchTests.cs
+++ b/tests/SQLite.Tests/FullTextSearchTests.cs
@@ -1,0 +1,530 @@
+using System;
+using System.Linq;
+
+#if NETFX_CORE
+using Microsoft.VisualStudio.TestPlatform.UnitTestFramework;
+using SetUp = Microsoft.VisualStudio.TestPlatform.UnitTestFramework.TestInitializeAttribute;
+using TestFixture = Microsoft.VisualStudio.TestPlatform.UnitTestFramework.TestClassAttribute;
+using Test = Microsoft.VisualStudio.TestPlatform.UnitTestFramework.TestMethodAttribute;
+#else
+using NUnit.Framework;
+#endif
+
+namespace SQLite.Tests
+{
+	[TestFixture]
+	public class FullTextSearchTests
+	{
+		[FullTextTable]
+		public class Article
+		{
+			[PrimaryKey, AutoIncrement]
+			public int Id { get; set; }
+
+			[FullTextIndexed]
+			public string Title { get; set; }
+
+			[FullTextIndexed]
+			public string Content { get; set; }
+
+			public string Author { get; set; }
+
+			public DateTime PublishDate { get; set; }
+		}
+
+		// Test model with custom table name and custom tokenizer
+		[FullTextTable("Document_fts", "porter")]
+		public class Document
+		{
+			[PrimaryKey, AutoIncrement]
+			public int Id { get; set; }
+
+			[FullTextIndexed]
+			public string Title { get; set; }
+
+			[FullTextIndexed]
+			public string Body { get; set; }
+
+			public string Category { get; set; }
+		}
+
+		// Test model for Japanese text
+		[FullTextTable("JapaneseText_FT", "unicode61")]
+		public class JapaneseText
+		{
+			[PrimaryKey, AutoIncrement]
+			public int Id { get; set; }
+
+			[FullTextIndexed]
+			public string Text { get; set; }
+
+			public string Notes { get; set; }
+		}
+
+		// Simple model with default settings
+		[FullTextTable]
+		public class Note
+		{
+			[PrimaryKey, AutoIncrement]
+			public int Id { get; set; }
+
+			[FullTextIndexed]
+			public string Content { get; set; }
+		}
+
+		[Test]
+		public void CreateTableWithFTS4_Article()
+		{
+			var db = new TestDb();
+			db.CreateTable<Article>();
+
+			var mapping = db.GetMapping<Article>();
+			Assert.NotNull(mapping);
+			Assert.AreEqual("Article_FT", mapping.FullTextTableName);
+		}
+
+		[Test]
+		public void CreateTableWithFTS4_Document()
+		{
+			var db = new TestDb();
+			db.CreateTable<Document>();
+
+			var mapping = db.GetMapping<Document>();
+			Assert.NotNull(mapping);
+			Assert.AreEqual("Document_fts", mapping.FullTextTableName);
+		}
+
+		[Test]
+		public void InsertAndRetrieveFullTextRecord()
+		{
+			var db = new TestDb();
+			db.CreateTable<Article>();
+
+			var article = new Article
+			{
+				Title = "Introduction to SQLite",
+				Content = "SQLite is a lightweight database engine.",
+				Author = "John Doe",
+				PublishDate = DateTime.Now
+			};
+
+			db.Insert(article);
+			Assert.AreNotEqual(0, article.Id);
+
+			var retrieved = db.Get<Article>(article.Id);
+			Assert.AreEqual(article.Title, retrieved.Title);
+			Assert.AreEqual(article.Content, retrieved.Content);
+			Assert.AreEqual(article.Author, retrieved.Author);
+		}
+
+		[Test]
+		public void UpdateFullTextRecord()
+		{
+			var db = new TestDb();
+			db.CreateTable<Article>();
+
+			var article = new Article
+			{
+				Title = "Original Title",
+				Content = "Original content here.",
+				Author = "Jane Smith"
+			};
+
+			db.Insert(article);
+			var originalId = article.Id;
+
+			article.Title = "Updated Title";
+			article.Content = "Updated content with new information.";
+			db.Update(article);
+
+			var updated = db.Get<Article>(originalId);
+			Assert.AreEqual("Updated Title", updated.Title);
+			Assert.AreEqual("Updated content with new information.", updated.Content);
+		}
+
+		[Test]
+		public void DeleteFullTextRecord()
+		{
+			var db = new TestDb();
+			db.CreateTable<Article>();
+
+			var article = new Article
+			{
+				Title = "Article to Delete",
+				Content = "This will be deleted.",
+				Author = "Test Author"
+			};
+
+			db.Insert(article);
+			var articleId = article.Id;
+
+			db.Delete(article);
+
+			var result = db.Table<Article>().Where(a => a.Id == articleId).FirstOrDefault();
+			Assert.IsNull(result);
+		}
+
+		[Test]
+		public void MatchQueryWithKeywordInMiddle()
+		{
+			var db = new TestDb();
+			db.CreateTable<Article>();
+
+			db.Insert(new Article { Title = "Introduction to Programming", Content = "Learn the basics of programming.", Author = "Alice" });
+			db.Insert(new Article { Title = "Advanced Programming Techniques", Content = "Master advanced concepts.", Author = "Bob" });
+			db.Insert(new Article { Title = "Database Design", Content = "Understanding database principles.", Author = "Charlie" });
+
+			// Search for "programming" which appears in the middle of titles
+			var query = "SELECT * FROM Article WHERE Id IN (SELECT docid FROM Article_FT WHERE Article_FT MATCH 'programming')";
+			var results = db.Query<Article>(query).ToList();
+
+			Assert.AreEqual(2, results.Count);
+			Assert.IsTrue(results.Any(a => a.Title.Contains("Programming")));
+		}
+
+		[Test]
+		public void MatchQueryWithPhraseSearch()
+		{
+			var db = new TestDb();
+			db.CreateTable<Article>();
+
+			db.Insert(new Article { Title = "Quick Start Guide", Content = "This is a quick start guide for beginners.", Author = "Alice" });
+			db.Insert(new Article { Title = "Getting Started", Content = "Start your journey with this quick tutorial.", Author = "Bob" });
+			db.Insert(new Article { Title = "Advanced Topics", Content = "For experienced users only.", Author = "Charlie" });
+
+			// Phrase search with quotes
+			var query = "SELECT * FROM Article WHERE Id IN (SELECT docid FROM Article_FT WHERE Article_FT MATCH '\"quick start\"')";
+			var results = db.Query<Article>(query).ToList();
+
+			Assert.AreEqual(1, results.Count);
+			Assert.AreEqual("Quick Start Guide", results[0].Title);
+		}
+
+		[Test]
+		public void MatchOnlySearchesIndexedColumns()
+		{
+			var db = new TestDb();
+			db.CreateTable<Article>();
+
+			db.Insert(new Article { Title = "Article about databases", Content = "SQLite is great.", Author = "DatabaseExpert" });
+			db.Insert(new Article { Title = "Another article", Content = "More content here.", Author = "TechWriter" });
+
+			// Search for "DatabaseExpert" which is in the Author column (NOT indexed)
+			var query = "SELECT * FROM Article WHERE Id IN (SELECT docid FROM Article_FT WHERE Article_FT MATCH 'DatabaseExpert')";
+			var results = db.Query<Article>(query).ToList();
+
+			// Should return 0 results because Author is not indexed
+			Assert.AreEqual(0, results.Count);
+
+			// Now search for "databases" which is in Title (indexed)
+			query = "SELECT * FROM Article WHERE Id IN (SELECT docid FROM Article_FT WHERE Article_FT MATCH 'databases')";
+			results = db.Query<Article>(query).ToList();
+
+			Assert.AreEqual(1, results.Count);
+			Assert.AreEqual("Article about databases", results[0].Title);
+		}
+
+		[Test]
+		public void SearchNonIndexedColumnReturnsClearResults()
+		{
+			var db = new TestDb();
+			db.CreateTable<Article>();
+
+			db.Insert(new Article { Title = "Tech Article", Content = "Technology content.", Author = "UniqueAuthorName" });
+
+			// Search in Title/Content (indexed) - should work
+			var query = "SELECT * FROM Article WHERE Id IN (SELECT docid FROM Article_FT WHERE Article_FT MATCH 'Technology')";
+			var results = db.Query<Article>(query).ToList();
+			Assert.AreEqual(1, results.Count);
+
+			// Search for Author value (not indexed) - should not find it
+			query = "SELECT * FROM Article WHERE Id IN (SELECT docid FROM Article_FT WHERE Article_FT MATCH 'UniqueAuthorName')";
+			results = db.Query<Article>(query).ToList();
+			Assert.AreEqual(0, results.Count);
+		}
+
+		[Test]
+		public void JapaneseTextSearch()
+		{
+			var db = new TestDb();
+			db.CreateTable<JapaneseText>();
+
+			// Japanese text with spaces between words (because there isn't a built-in CJK tokenizer) - the "unicode61" tokenizer
+			// treats spaces as word boundaries, so we add spaces between Japanese words
+			// Using Unicode escape sequences to ensure proper encoding
+			db.Insert(new JapaneseText { Text = "\u3053\u308c \u306f \u30c6\u30b9\u30c8 \u3067\u3059", Notes = "Test note" }); // これ は テスト です
+			db.Insert(new JapaneseText { Text = "\u30c7\u30fc\u30bf\u30d9\u30fc\u30b9 \u691c\u7d22 \u6a5f\u80fd", Notes = "Search feature" }); // データベース 検索 機能
+			db.Insert(new JapaneseText { Text = "\u5225 \u306e \u30b5\u30f3\u30d7\u30eb \u30c6\u30ad\u30b9\u30c8", Notes = "Another sample" }); // 別 の サンプル テキスト
+
+			// Verify data was inserted and Text values are correct
+            var allRecords = db.Table<JapaneseText>().OrderBy(x => x.Id).ToList();
+            Assert.AreEqual(3, allRecords.Count, "Should have inserted 3 records");
+            
+            // Verify the text was stored correctly
+            Assert.AreEqual("\u3053\u308c \u306f \u30c6\u30b9\u30c8 \u3067\u3059", allRecords[0].Text, "First record Text should match"); // これ は テスト です
+            Assert.AreEqual("\u30c7\u30fc\u30bf\u30d9\u30fc\u30b9 \u691c\u7d22 \u6a5f\u80fd", allRecords[1].Text, "Second record Text should match"); // データベース 検索 機能
+            Assert.AreEqual("\u5225 \u306e \u30b5\u30f3\u30d7\u30eb \u30c6\u30ad\u30b9\u30c8", allRecords[2].Text, "Third record Text should match"); // 別 の サンプル テキスト
+			string searchTerm = "\u30c6\u30b9\u30c8";  // テスト
+			var query = $"SELECT * FROM JapaneseText WHERE Id IN (SELECT docid FROM JapaneseText_FT WHERE JapaneseText_FT MATCH ?)";
+			var results = db.Query<JapaneseText>(query, searchTerm).ToList();
+
+			// If FTS search doesn't work with Japanese, at least verify we can use regular SQL
+			if (results.Count == 0)
+			{
+				// Fall back to LIKE query to demonstrate the data is there - use parameterized query
+				var likeResults = db.Query<JapaneseText>("SELECT * FROM JapaneseText WHERE Text LIKE ?", $"%{searchTerm}%").ToList();
+				Assert.AreEqual(1, likeResults.Count, "Should find the record with LIKE query");
+				
+				// Mark test as inconclusive rather than failed, as this is a known SQLite FTS limitation with CJK
+				Assert.Inconclusive("FTS with Japanese characters requires special CJK tokenizers not available in standard SQLite. Data is present but not FTS-searchable.");
+			}
+
+			Assert.AreEqual(1, results.Count, "Should find the record containing '\u30c6\u30b9\u30c8'"); // テスト
+			Assert.IsTrue(results.Any(t => t.Text.Contains("\u30c6\u30b9\u30c8"))); // テスト
+
+			// Search for another word - 検索 (search)
+			var searchTerm2 = "\u691c\u7d22"; // 検索
+			query = "SELECT * FROM JapaneseText WHERE Id IN (SELECT docid FROM JapaneseText_FT WHERE JapaneseText_FT MATCH ?)";
+			results = db.Query<JapaneseText>(query, searchTerm2).ToList();
+
+			// If FTS doesn't work, fall back to validate data exists
+			if (results.Count == 0)
+			{
+				var likeResults2 = db.Query<JapaneseText>("SELECT * FROM JapaneseText WHERE Text LIKE ?", $"%{searchTerm2}%").ToList();
+				Assert.AreEqual(1, likeResults2.Count, "Should find the record with LIKE query for second term");
+				Assert.Inconclusive("FTS with Japanese characters requires special CJK tokenizers not available in standard SQLite. Data is present but not FTS-searchable.");
+			}
+
+			Assert.AreEqual(1, results.Count);
+			Assert.IsTrue(results[0].Text.Contains("\u691c\u7d22"));
+		}
+
+		[Test]
+		public void PorterStemmerTokenizer()
+		{
+			var db = new TestDb();
+			db.CreateTable<Document>();
+
+			// Insert documents with words that have common stems
+			db.Insert(new Document { Title = "Running Guide", Body = "Tips for runners who love running.", Category = "Sports" });
+			db.Insert(new Document { Title = "Walking Guide", Body = "Information about walking.", Category = "Sports" });
+			db.Insert(new Document { Title = "Programming Basics", Body = "Learn to program effectively.", Category = "Tech" });
+
+			// Search for "run" - should match "running" and "runners" due to Porter stemmer
+			var query = "SELECT * FROM Document WHERE Id IN (SELECT docid FROM Document_fts WHERE Document_fts MATCH 'run')";
+			var results = db.Query<Document>(query).ToList();
+
+			Assert.AreEqual(1, results.Count);
+			Assert.AreEqual("Running Guide", results[0].Title);
+
+			// Search for "program" - should match "programming" due to stemming
+			query = "SELECT * FROM Document WHERE Id IN (SELECT docid FROM Document_fts WHERE Document_fts MATCH 'program')";
+			results = db.Query<Document>(query).ToList();
+
+			Assert.AreEqual(1, results.Count);
+			Assert.IsTrue(results[0].Body.Contains("program"));
+		}
+
+		[Test]
+		public void PorterStemmerMatchesRelatedForms()
+		{
+			var db = new TestDb();
+			db.CreateTable<Document>();
+
+			db.Insert(new Document { Title = "Writing Tutorial", Body = "Learn about writing and writers.", Category = "Education" });
+			db.Insert(new Document { Title = "Reading Guide", Body = "Tips for readers.", Category = "Education" });
+
+			// Search for "write" - should match "writing" and "writers"
+			var query = "SELECT * FROM Document WHERE Id IN (SELECT docid FROM Document_fts WHERE Document_fts MATCH 'write')";
+			var results = db.Query<Document>(query).ToList();
+
+			Assert.AreEqual(1, results.Count);
+			Assert.AreEqual("Writing Tutorial", results[0].Title);
+		}
+
+		[Test]
+		public void FTS4ModuleWorks()
+		{
+			var db = new TestDb();
+			db.CreateTable<Document>();
+
+			db.Insert(new Document { Title = "FTS4 Features", Body = "Testing FTS4 capabilities.", Category = "Tech" });
+
+			var query = "SELECT * FROM Document WHERE Id IN (SELECT docid FROM Document_fts WHERE Document_fts MATCH 'FTS4')";
+			var results = db.Query<Document>(query).ToList();
+
+			Assert.AreEqual(1, results.Count);
+			Assert.AreEqual("FTS4 Features", results[0].Title);
+		}
+
+		[Test]
+		public void MultipleMatchesAcrossColumns()
+		{
+			var db = new TestDb();
+			db.CreateTable<Article>();
+
+			db.Insert(new Article { Title = "SQLite Overview", Content = "SQLite is a powerful database.", Author = "DB Expert" });
+			db.Insert(new Article { Title = "Database Comparison", Content = "Comparing SQLite with other databases.", Author = "Tech Writer" });
+			db.Insert(new Article { Title = "Getting Started", Content = "How to install and use various tools.", Author = "Newbie Guide" });
+
+			// Search across both indexed columns
+			var query = "SELECT * FROM Article WHERE Id IN (SELECT docid FROM Article_FT WHERE Article_FT MATCH 'SQLite')";
+			var results = db.Query<Article>(query).ToList();
+
+			Assert.AreEqual(2, results.Count);
+			Assert.IsTrue(results.Any(a => a.Title == "SQLite Overview"));
+			Assert.IsTrue(results.Any(a => a.Title == "Database Comparison"));
+		}
+
+		[Test]
+		public void DropTableDropsFTSTable()
+		{
+			var db = new TestDb();
+			db.CreateTable<Article>();
+
+			db.Insert(new Article { Title = "Test Article", Content = "Some content.", Author = "Author" });
+
+			// Verify FTS table exists by querying it
+			var query = "SELECT count(*) FROM Article_FT";
+			var count = db.ExecuteScalar<int>(query);
+			Assert.AreEqual(1, count);
+
+			// Drop the table
+			db.DropTable<Article>();
+
+			// Verify FTS table is also dropped
+			Assert.Throws<SQLiteException>(() => db.ExecuteScalar<int>("SELECT count(*) FROM Article_FT"));
+		}
+
+		[Test]
+		public void DefaultSettingsUseFTS4()
+		{
+			var db = new TestDb();
+			db.CreateTable<Note>();
+
+			var mapping = db.GetMapping<Note>();
+			Assert.NotNull(mapping);
+			Assert.AreEqual("Note_FT", mapping.FullTextTableName);
+
+			db.Insert(new Note { Content = "This is a simple note." });
+
+			var query = "SELECT * FROM Note WHERE Id IN (SELECT docid FROM Note_FT WHERE Note_FT MATCH 'simple')";
+			var results = db.Query<Note>(query).ToList();
+
+			Assert.AreEqual(1, results.Count);
+			Assert.AreEqual("This is a simple note.", results[0].Content);
+		}
+
+		[Test]
+		public void CaseInsensitiveSearch()
+		{
+			var db = new TestDb();
+			db.CreateTable<Article>();
+
+			db.Insert(new Article { Title = "UPPERCASE TITLE", Content = "lowercase content", Author = "MixedCase Author" });
+
+			// Search with lowercase
+			var query = "SELECT * FROM Article WHERE Id IN (SELECT docid FROM Article_FT WHERE Article_FT MATCH 'uppercase')";
+			var results = db.Query<Article>(query).ToList();
+
+			Assert.AreEqual(1, results.Count);
+
+			// Search with different case
+			query = "SELECT * FROM Article WHERE Id IN (SELECT docid FROM Article_FT WHERE Article_FT MATCH 'LOWERCASE')";
+			results = db.Query<Article>(query).ToList();
+
+			Assert.AreEqual(1, results.Count);
+		}
+
+		[Test]
+		public void BooleanSearchOperators()
+		{
+			var db = new TestDb();
+			db.CreateTable<Article>();
+
+			db.Insert(new Article { Title = "Python Programming", Content = "Learn Python basics.", Author = "Alice" });
+			db.Insert(new Article { Title = "Java Programming", Content = "Learn Java fundamentals.", Author = "Bob" });
+			db.Insert(new Article { Title = "Web Development", Content = "HTML, CSS, and JavaScript.", Author = "Charlie" });
+
+			// OR operator
+			var query = "SELECT * FROM Article WHERE Id IN (SELECT docid FROM Article_FT WHERE Article_FT MATCH 'Python OR Java')";
+			var results = db.Query<Article>(query).ToList();
+
+			Assert.AreEqual(2, results.Count);
+
+			// AND operator
+			query = "SELECT * FROM Article WHERE Id IN (SELECT docid FROM Article_FT WHERE Article_FT MATCH 'Programming Java')";
+			results = db.Query<Article>(query).ToList();
+
+			Assert.AreEqual(1, results.Count);
+			Assert.AreEqual("Java Programming", results[0].Title);
+		}
+
+		[Test]
+		public void EmptySearchReturnsNoResults()
+		{
+			var db = new TestDb();
+			db.CreateTable<Article>();
+
+			db.Insert(new Article { Title = "Sample Article", Content = "Some content here.", Author = "Author" });
+
+			var query = "SELECT * FROM Article WHERE Id IN (SELECT docid FROM Article_FT WHERE Article_FT MATCH 'nonexistentword')";
+			var results = db.Query<Article>(query).ToList();
+
+			Assert.AreEqual(0, results.Count);
+		}
+
+		[Test]
+		public void UpdateTriggersUpdateFTSIndex()
+		{
+			var db = new TestDb();
+			db.CreateTable<Article>();
+
+			var article = new Article { Title = "Original", Content = "Original content.", Author = "Author" };
+			db.Insert(article);
+
+			// Verify original content is searchable
+			var query = "SELECT * FROM Article WHERE Id IN (SELECT docid FROM Article_FT WHERE Article_FT MATCH 'Original')";
+			var results = db.Query<Article>(query).ToList();
+			Assert.AreEqual(1, results.Count);
+
+			// Update the article
+			article.Title = "Modified";
+			article.Content = "Modified content.";
+			db.Update(article);
+
+			// Old content should not be found
+			query = "SELECT * FROM Article WHERE Id IN (SELECT docid FROM Article_FT WHERE Article_FT MATCH 'Original')";
+			results = db.Query<Article>(query).ToList();
+			Assert.AreEqual(0, results.Count);
+
+			// New content should be found
+			query = "SELECT * FROM Article WHERE Id IN (SELECT docid FROM Article_FT WHERE Article_FT MATCH 'Modified')";
+			results = db.Query<Article>(query).ToList();
+			Assert.AreEqual(1, results.Count);
+		}
+
+		[Test]
+		public void DeleteRemovesFromFTSIndex()
+		{
+			var db = new TestDb();
+			db.CreateTable<Article>();
+
+			var article = new Article { Title = "To Be Deleted", Content = "This will be removed.", Author = "Author" };
+			db.Insert(article);
+
+			// Verify content is searchable
+			var query = "SELECT * FROM Article WHERE Id IN (SELECT docid FROM Article_FT WHERE Article_FT MATCH 'Deleted')";
+			var results = db.Query<Article>(query).ToList();
+			Assert.AreEqual(1, results.Count);
+
+			// Delete the article
+			db.Delete(article);
+
+			// Should not be found anymore
+			query = "SELECT * FROM Article WHERE Id IN (SELECT docid FROM Article_FT WHERE Article_FT MATCH 'Deleted')";
+			results = db.Query<Article>(query).ToList();
+			Assert.AreEqual(0, results.Count);
+		}
+	}
+}


### PR DESCRIPTION
Add FullTextTable class attribute &  FullTextIndexed property attribute for easy FTS indexing

Add simple attribute support for full text indexing of a subset of columns in table as well as support to change the default tokenizer behavior [for the table. Porting a change that I did in a copy of SQLite.cs for a UWP Japanese dictionary app ~9 years ago that I'm now trying to port to MAUI. Updated to include detecting FTS column changes and rebuilding the index when the column list changes. Added a bunch of unit tests to cover the functionality and confirmed the existing tests are all passing on Win11. 

Note that this PR does NOT port custom tokenizer support that I also had added in order to use a Japanese word breaker, but I can work around that with pre-breaking using a .NET Japanese language model library as long as I can at least use the "unicode61" tokenizer instead of the default "simple" one that clobbers most Unicode characters.

Example usage:

		**[FullTextTable]**
		public class Article
		{
			[PrimaryKey, AutoIncrement]
			public int Id { get; set; }

			**[FullTextIndexed]**
			public string Title { get; set; }

			**[FullTextIndexed]**
			public string Content { get; set; }
			public string Author { get; set; }
			public DateTime PublishDate { get; set; }
		}

		**[FullTextTable("JapaneseText_FT", "unicode61")]**
		public class JapaneseText
		{
			[PrimaryKey, AutoIncrement]
			public int Id { get; set; }

			**[FullTextIndexed]**
			public string Text { get; set; }

			public string Notes { get; set; }
		}
		
		var query = "SELECT * FROM Article WHERE Id IN (SELECT docid FROM Article_FT WHERE Article_FT MATCH 'programming')";
		var results = db.Query<Article>(query);
