### PR TITLE
Change _mappings to instance variable from static

### DIFF
--- a/src/SQLite.cs
+++ b/src/SQLite.cs
@@ -446,7 +446,7 @@ namespace SQLite
 	{
 		private bool _open;
 		private TimeSpan _busyTimeout;
-		readonly static Dictionary<string, TableMapping> _mappings = new Dictionary<string, TableMapping> ();
+		readonly Dictionary<string, TableMapping> _mappings = new Dictionary<string, TableMapping> ();
 		private System.Diagnostics.Stopwatch _sw;
 		private long _elapsedMilliseconds = 0;
 


### PR DESCRIPTION
Fixed an issue where a static _mapping dictionary caused table mappings to be shared across different SQLiteConnection instances and database paths. Converted _mapping to an instance member so mappings remain isolated per connection.